### PR TITLE
fix: handle EEXIST when skill dir is a real directory + clean stale clones

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -80,6 +80,11 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     }
   }
 
+  // Clean up stale clone from a previous failed install
+  if (existsSync(installPath)) {
+    Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
+  }
+
   const cloneResult = Bun.spawnSync(["git", "clone", repoUrl, installPath], {
     stdout: "pipe",
     stderr: "pipe",

--- a/src/lib/symlinks.ts
+++ b/src/lib/symlinks.ts
@@ -1,4 +1,4 @@
-import { symlink, unlink, readlink, lstat, mkdir, writeFile, chmod } from "fs/promises";
+import { symlink, unlink, readlink, lstat, mkdir, writeFile, chmod, rename } from "fs/promises";
 import { join, dirname, basename } from "path";
 import type { PaiManifest } from "../types.js";
 
@@ -15,6 +15,12 @@ export async function createSymlink(
   try {
     const stat = await lstat(linkPath);
     if (stat.isSymbolicLink()) {
+      await unlink(linkPath);
+    } else if (stat.isDirectory()) {
+      // Back up existing directory (e.g., manually-installed skill being replaced by pai-pkg)
+      const backupPath = linkPath + ".pre-pai-pkg";
+      await rename(linkPath, backupPath);
+    } else if (stat.isFile()) {
       await unlink(linkPath);
     }
   } catch (err: any) {


### PR DESCRIPTION
## Summary

- Fix `createSymlink()` to handle existing real directories (not just symlinks) at the target path
- Clean up stale clones in `repos/` before cloning, so failed installs don't block retries

## Context

Found during beta testing (`pai-pkg install https://github.com/jcfischer/pii-pseudonymizer`). When a PAI skill is already installed as a real directory (the common case for all existing PAI users), `pai-pkg install` fails with EEXIST. See #1 for the full bug report.

## Changes

**`src/lib/symlinks.ts`** — `createSymlink()` now checks for `isDirectory()` and `isFile()` in addition to `isSymbolicLink()`. Existing directories are backed up to `.pre-pai-pkg` rather than deleted, so users can recover if needed.

**`src/commands/install.ts`** — Added stale clone cleanup before `git clone`. If `installPath` already exists (from a prior failed install), it's removed before cloning.

## Test plan

- [x] All 169 existing tests pass (527 assertions)
- [ ] Manual: `pai-pkg install` on a repo where `~/.claude/skills/{name}` is a real directory
- [ ] Manual: `pai-pkg install` after a previous failed install left a stale clone

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)