### PR TITLE
feat: default configRoot to ~/.config/arc

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,7 +302,7 @@ arc attest <skill>              # Positive attestation
 arc destate <skill>             # Negative attestation
 ```
 
-### Sources Configuration (~/.config/pai/sources.yaml)
+### Sources Configuration (~/.config/arc/sources.yaml)
 
 ```yaml
 registries:
@@ -363,7 +363,7 @@ arc install extract-wisdom
   4. Review: display capabilities, prompt user
   5. Place: copy to ~/.claude/skills/ExtractWisdom/
   6. Wire: bun install in Tools/, update skill-index.json
-  7. Record: write to ~/.config/pai/packages.db
+  7. Record: write to ~/.config/arc/packages.db
 ```
 
 ---

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,10 +50,10 @@ arc install git@github.com:mellanon/pai-skill-doc.git
 ```
 
 arc will:
-1. Clone the repo to `~/.config/pai/pkg/repos/`
+1. Clone the repo to `~/.config/arc/pkg/repos/`
 2. Show you what capabilities the skill requests
 3. Create a symlink in `~/.claude/skills/`
-4. Record the install in `~/.config/pai/packages.db`
+4. Record the install in `~/.config/arc/packages.db`
 
 ## Manage Installed Skills
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ No npm. No Docker. Just git clone, symlinks, and a manifest.
 arc supports multiple registry sources, like apt's sources.list:
 
 ```yaml
-# ~/.config/pai/sources.yaml (auto-created on first run)
+# ~/.config/arc/sources.yaml (auto-created on first run)
 sources:
   - name: pai-collab
     url: https://raw.githubusercontent.com/mellanon/pai-collab/main/skills/REGISTRY.yaml

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -248,7 +248,7 @@ This is why Layer 2 (tool-call enforcement) is non-negotiable. Review is necessa
 | Asset | Value | Location |
 |-------|-------|----------|
 | User's filesystem | High (source code, credentials, personal data) | Local machine |
-| API keys and secrets | Critical (~/.config/pai/secrets/) | Local machine |
+| API keys and secrets | Critical (~/.config/arc/secrets/) | Local machine |
 | Conversation context | High (may contain sensitive business data) | Agent memory |
 | Agent tool access | Critical (shell, filesystem, network) | Runtime |
 | Registry integrity | High (trust anchor for all installs) | Git repository |

--- a/SECURITY-ARCHITECTURE.md
+++ b/SECURITY-ARCHITECTURE.md
@@ -144,7 +144,7 @@ base:
       - "~/.ssh/"
       - "~/.gnupg/"
       - "~/.aws/credentials"
-      - "~/.config/pai/secrets/"
+      - "~/.config/arc/secrets/"
     readOnly:
       - "/etc/"
       - "/usr/"
@@ -370,7 +370,7 @@ SecurityValidator already logs every security event to `MEMORY/SECURITY/`. But t
 A new observability layer that analyzes PATTERNS across security events within a session:
 
 ```yaml
-# ~/.config/pai/security/anomaly-rules.yaml
+# ~/.config/arc/security/anomaly-rules.yaml
 
 rules:
   # Detect read-then-exfiltrate pattern
@@ -378,7 +378,7 @@ rules:
     description: "Reading sensitive files followed by network access"
     trigger:
       sequence:
-        - event: {tool: "Read", path_matches: "~/.config/pai/secrets/*"}
+        - event: {tool: "Read", path_matches: "~/.config/arc/secrets/*"}
         - event: {tool: "Bash", command_matches: "curl|wget|nc|fetch|python3|node"}
       within_minutes: 5
     action: block
@@ -607,7 +607,7 @@ The pai-collab spoke repos (pai-secret-scanning, pai-content-filter, skill-enfor
 # These aren't regular skills — they're enforcement components
 
 arc install --system pai-secret-scanning
-# → Installs gitleaks rules to ~/.config/pai/security/
+# → Installs gitleaks rules to ~/.config/arc/security/
 # → Registers pre-commit hook
 
 arc install --system pai-content-filter
@@ -624,7 +624,7 @@ The `--system` flag distinguishes infrastructure packages from regular skills. S
 - Are verified against a separate trust chain (the hive's allowed-signers)
 - Update independently from regular skills via signed atomic operations (write tmp, validate, rename)
 - Provide patterns/rules consumed by the SecurityValidator rather than SKILL.md instructions
-- Install to a protected path (`~/.config/pai/system-skills/`) separate from user skills
+- Install to a protected path (`~/.config/arc/system-skills/`) separate from user skills
 - Have integrity verified at SessionStart + periodically (every 30 minutes for long sessions)
 
 ### 6.2.1 System Package Manifest Schema

--- a/SKILL-LIFECYCLE.md
+++ b/SKILL-LIFECYCLE.md
@@ -16,7 +16,7 @@ PAI's skill ecosystem has grown organically into a set of disconnected systems:
 |--------|-------------|----------------|
 | PAI releases (v4.0.3) | Built-in skills (18 upstream) | Release tree (`~/.claude/skills/`) |
 | Custom skill repos | 7 standalone skills (`pai-skill-*`) | `~/Developer/pai-skill-*/` |
-| Three-tier persistence | Secrets, config, runtime state | `~/.config/pai/`, `pai-personal-data/` |
+| Three-tier persistence | Secrets, config, runtime state | `~/.config/arc/`, `pai-personal-data/` |
 | SecurityValidator | Tool-call firewall (YAML policies) | `~/.claude/hooks/` |
 | pai-content-filter | Prompt injection detection | `jcfischer/pai-content-filter` (spoke repo) |
 | pai-secret-scanning | Outbound secret detection | `jcfischer/pai-secret-scanning` (spoke repo) |
@@ -156,7 +156,7 @@ Skills that have configuration or state use the three-tier architecture. Nothing
 
 ```
 Tier 1: Secrets (API tokens)
-  ~/.config/pai/secrets/{skill-name}.env
+  ~/.config/arc/secrets/{skill-name}.env
   → Never in git. Survives all upgrades.
 
 Tier 2: Instance config (URLs, project keys, usernames)
@@ -164,7 +164,7 @@ Tier 2: Instance config (URLs, project keys, usernames)
   → In private git. Survives all upgrades.
 
 Tier 3: Runtime state (cache, rate limits, last-run)
-  ~/.config/pai/skills/{skill-name}/
+  ~/.config/arc/skills/{skill-name}/
   → Not in git. Survives PAI upgrades. Disposable.
 ```
 
@@ -175,7 +175,7 @@ Symlinks bridge these into the skill's working directory:
   → pai-personal-data/profiles/jira/work.env         (Tier 2)
 
 ~/.claude/secrets/jira-work.env
-  → ~/.config/pai/secrets/jira-work.env               (Tier 1)
+  → ~/.config/arc/secrets/jira-work.env               (Tier 1)
 ```
 
 ---
@@ -196,7 +196,7 @@ ln -sfn ~/Developer/pai-skill-jira/skill ~/.claude/skills/_JIRA
 ln -sfn ~/Developer/pai-skill-jira ~/.claude/bin/jira
 
 # Set up persistence (Tier 1 + 2)
-# Copy secrets to ~/.config/pai/secrets/jira-work.env
+# Copy secrets to ~/.config/arc/secrets/jira-work.env
 # Link profiles from pai-personal-data
 ```
 
@@ -207,7 +207,7 @@ arc install extract-wisdom
 
 # What happens internally:
 # 1. RESOLVE: extract-wisdom → git repo URL from curated list
-# 2. FETCH: git clone to ~/.config/pai/pkg/staging/extract-wisdom/
+# 2. FETCH: git clone to ~/.config/arc/pkg/staging/extract-wisdom/
 # 3. VERIFY: check signatures (SkillSeal / Sigstore / git commit hash)
 # 4. REVIEW: display capabilities from pai-manifest.yaml
 #    ┌─────────────────────────────────────────────┐
@@ -222,7 +222,7 @@ arc install extract-wisdom
 # 5. POLICY: merge capabilities into patterns.yaml skill section
 # 6. PLACE: symlink ~/.claude/skills/ExtractWisdom → staging dir
 # 7. WIRE: bun install in src/, create bin symlink if CLI
-# 8. RECORD: write to ~/.config/pai/packages.db
+# 8. RECORD: write to ~/.config/arc/packages.db
 ```
 
 ### 4.3 System Packages (Future, via arc --system)
@@ -323,7 +323,7 @@ The migration doc (v3.0 → v4.0) identified these pain points:
 | Pain Point | Root Cause | Solution |
 |-----------|-----------|---------|
 | Custom skills lost on upgrade | Flat files in release tree | Standalone repos + symlinks |
-| Secrets stranded in old version | Flat files in `~/.claude/secrets/` | Tier 1: `~/.config/pai/secrets/` |
+| Secrets stranded in old version | Flat files in `~/.claude/secrets/` | Tier 1: `~/.config/arc/secrets/` |
 | Config lost on `cp -r` | Symlinks dereferenced by copy | Three-tier persistence + `cp -a` |
 | Manual symlink recreation | No upgrade automation | `arc upgrade-core` command |
 | 20-line shell script per upgrade | Each upgrade is bespoke | Scripted: symlinks computed from installed packages |
@@ -337,12 +337,12 @@ arc upgrade-core v4.1.0
 # That single command:
 # a) Checks out new release directory
 # b) Creates persistent symlinks:
-#    .env → ~/.config/pai/.env
+#    .env → ~/.config/arc/.env
 #    CLAUDE.md → pai-personal-data/CLAUDE.md
-#    MEMORY → ~/.config/pai/MEMORY
+#    MEMORY → ~/.config/arc/MEMORY
 #    profiles → pai-personal-data/profiles
-#    secrets → ~/.config/pai/secrets
-#    PAI/USER → ~/.config/pai/CORE_USER
+#    secrets → ~/.config/arc/secrets
+#    PAI/USER → ~/.config/arc/CORE_USER
 #
 # c) Re-symlinks all installed skills:
 #    For each entry in packages.db:
@@ -567,7 +567,7 @@ Network required only for:
 | Component | Exists? | Where | Gap |
 |-----------|---------|-------|-----|
 | Standalone skill repos | ✅ 7 custom skills | `~/Developer/pai-skill-*/` | Need `pai-manifest.yaml` added to each |
-| Three-tier persistence | ✅ Designed + implemented | `~/.config/pai/`, `pai-personal-data/` | Working for custom skills |
+| Three-tier persistence | ✅ Designed + implemented | `~/.config/arc/`, `pai-personal-data/` | Working for custom skills |
 | SecurityValidator hook | ✅ Shipping | `~/.claude/hooks/SecurityValidator.hook.ts` | Needs skill-scoped policy extension |
 | patterns.yaml | ✅ Shipping | `PAI/USER/PAISECURITYSYSTEM/patterns.yaml` | Needs v2.0 schema with `skills:` section |
 | Security event logging | ✅ Shipping | `MEMORY/SECURITY/` | Needs cross-event analysis |
@@ -580,7 +580,7 @@ Network required only for:
 | **arc CLI** | ✅ Built | `the-metafactory/arc` | 10 commands, 64 tests, 202 assertions |
 | **Curated skill list** | ❌ Not built | — | Needed for discovery |
 | **SessionAudit hook** | ❌ Not built | — | Needed for drip-feed detection |
-| **packages.db** | ✅ Built | `~/.config/pai/packages.db` | SQLite via bun:sqlite, WAL mode |
+| **packages.db** | ✅ Built | `~/.config/arc/packages.db` | SQLite via bun:sqlite, WAL mode |
 | **pai-manifest.yaml in skills** | ✅ Added | All 7 `pai-skill-*/` repos | Capability declarations for all custom skills |
 
 ---

--- a/src/commands/upgrade-core.ts
+++ b/src/commands/upgrade-core.ts
@@ -17,7 +17,7 @@ export interface UpgradeConfig {
   branch: string;
   /** Personal data repo (e.g. ~/Developer/pai-personal-data/) */
   personalDataDir: string;
-  /** Config root (e.g. ~/.config/pai/) */
+  /** Config root (e.g. ~/.config/arc/) */
   configRoot: string;
   /** Home directory */
   homeDir: string;

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -9,7 +9,11 @@ import type { PaiPaths } from "../types.js";
 export function createPaths(overrides?: Partial<PaiPaths>): PaiPaths {
   const home = homedir();
   const claudeRoot = overrides?.claudeRoot ?? join(home, ".claude");
-  const configRoot = overrides?.configRoot ?? join(home, ".config", "pai");
+  const configRoot =
+    overrides?.configRoot ??
+    (process.env.ARC_CONFIG_ROOT
+      ? process.env.ARC_CONFIG_ROOT.replace(/^~/, home)
+      : join(home, ".config", "arc"));
 
   return {
     claudeRoot,

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,15 +232,15 @@ export interface PaiPaths {
   promptsDir: string;
   /** Bin directory (~/.claude/bin/) */
   binDir: string;
-  /** Package repos (~/.config/pai/pkg/repos/) */
+  /** Package repos (~/.config/arc/pkg/repos/) */
   reposDir: string;
-  /** Database path (~/.config/pai/packages.db) */
+  /** Database path (~/.config/arc/packages.db) */
   dbPath: string;
-  /** Config root (~/.config/pai/) */
+  /** Config root (~/.config/arc/) */
   configRoot: string;
-  /** Secrets directory (~/.config/pai/secrets/) */
+  /** Secrets directory (~/.config/arc/secrets/) */
   secretsDir: string;
-  /** Runtime state (~/.config/pai/skills/) */
+  /** Runtime state (~/.config/arc/skills/) */
   runtimeDir: string;
   /** PATH-accessible shim directory (~/bin/) */
   shimDir: string;
@@ -248,8 +248,8 @@ export interface PaiPaths {
   catalogPath: string;
   /** Registry file path (repo-root/registry.yaml) */
   registryPath: string;
-  /** Sources config path (~/.config/pai/sources.yaml) */
+  /** Sources config path (~/.config/arc/sources.yaml) */
   sourcesPath: string;
-  /** Remote registry cache directory (~/.config/pai/pkg/cache/) */
+  /** Remote registry cache directory (~/.config/arc/pkg/cache/) */
   cachePath: string;
 }

--- a/test/commands/upgrade-core.test.ts
+++ b/test/commands/upgrade-core.test.ts
@@ -22,7 +22,7 @@ interface MockPaiEnv {
   newRelease: string;
   /** Path to ~/.claude symlink */
   claudeSymlink: string;
-  /** Path to config root (~/.config/pai/) */
+  /** Path to config root (~/.config/arc/) */
   configRoot: string;
   /** Path to personal data repo */
   personalDataDir: string;
@@ -35,7 +35,7 @@ interface MockPaiEnv {
  * Layout:
  *   root/
  *     .claude → old release (symlink)
- *     .config/pai/               (config root)
+ *     .config/arc/               (config root)
  *       .env
  *       MEMORY/
  *       secrets/

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -455,7 +455,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     // Verify test paths don't point to real directories
     expect(env.paths.claudeRoot).not.toContain(Bun.env.HOME + "/.claude");
     expect(env.paths.configRoot).not.toContain(
-      Bun.env.HOME + "/.config/pai"
+      Bun.env.HOME + "/.config/arc"
     );
     expect(env.paths.claudeRoot).toContain("arc-test-");
   });

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -11,8 +11,8 @@ describe("createPaths", () => {
     expect(paths.claudeRoot).toBe(join(home, ".claude"));
     expect(paths.skillsDir).toBe(join(home, ".claude", "skills"));
     expect(paths.binDir).toBe(join(home, ".claude", "bin"));
-    expect(paths.configRoot).toBe(join(home, ".config", "pai"));
-    expect(paths.dbPath).toBe(join(home, ".config", "pai", "packages.db"));
+    expect(paths.configRoot).toBe(join(home, ".config", "arc"));
+    expect(paths.dbPath).toBe(join(home, ".config", "arc", "packages.db"));
   });
 
   test("accepts overrides for test isolation", () => {
@@ -25,6 +25,31 @@ describe("createPaths", () => {
     expect(paths.skillsDir).toBe("/tmp/test/.claude/skills");
     expect(paths.configRoot).toBe("/tmp/test/.config/pai");
     expect(paths.dbPath).toBe("/tmp/test/.config/pai/packages.db");
+  });
+
+  test("ARC_CONFIG_ROOT env var overrides default configRoot", () => {
+    const original = process.env.ARC_CONFIG_ROOT;
+    try {
+      process.env.ARC_CONFIG_ROOT = "/custom/arc-config";
+      const paths = createPaths();
+      expect(paths.configRoot).toBe("/custom/arc-config");
+      expect(paths.dbPath).toBe("/custom/arc-config/packages.db");
+    } finally {
+      if (original === undefined) delete process.env.ARC_CONFIG_ROOT;
+      else process.env.ARC_CONFIG_ROOT = original;
+    }
+  });
+
+  test("explicit override takes precedence over ARC_CONFIG_ROOT env var", () => {
+    const original = process.env.ARC_CONFIG_ROOT;
+    try {
+      process.env.ARC_CONFIG_ROOT = "/env/override";
+      const paths = createPaths({ configRoot: "/explicit/override" });
+      expect(paths.configRoot).toBe("/explicit/override");
+    } finally {
+      if (original === undefined) delete process.env.ARC_CONFIG_ROOT;
+      else process.env.ARC_CONFIG_ROOT = original;
+    }
   });
 
   test("specific overrides take precedence over derived paths", () => {


### PR DESCRIPTION
## Summary
- Changes default `configRoot` from `~/.config/pai/` to `~/.config/arc/` so standalone installs don't leak PAI naming
- Adds `ARC_CONFIG_ROOT` env var override for PAI (or any custom setup) to point elsewhere
- Override precedence: explicit param > `ARC_CONFIG_ROOT` env var > default `~/.config/arc/`
- Updates all docs, type comments, and tests to match

## Context
Discussed in Discord — Jens-Christian's direction: "~/.config/arc and leave PAI out of the equation."

Reverses the deliberate decision in 466ce7f which hardcoded `~/.config/pai`. That made sense when arc was part of PAI, but now that arc is standalone, a fresh install shouldn't create PAI directories.

## Files changed (12)
- `src/lib/paths.ts` — core change + env var support
- `src/types.ts` — updated interface comments
- `src/commands/upgrade-core.ts` — updated comment
- `test/unit/paths.test.ts` — updated defaults + 2 new env var tests
- `test/e2e/lifecycle.test.ts` — updated guard assertion
- `test/commands/upgrade-core.test.ts` — updated comment
- 6 doc files — all `~/.config/pai` → `~/.config/arc`

## Test plan
- [x] All 208 tests pass (`bun test`)
- [x] New tests verify `ARC_CONFIG_ROOT` env var override
- [x] New test verifies explicit override beats env var
- [ ] Verify `arc list` works on fresh install (no pre-existing dirs)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)