### PR TITLE
fix: resolve ${VAR} brace syntax in hook command paths

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -108,7 +108,8 @@ export function resolveHooksFromManifest(
 }
 
 /**
- * Replace $PKG_DIR and $<NAME>_DIR in hook commands with the actual install path.
+ * Replace $PKG_DIR / ${PKG_DIR} and $<NAME>_DIR / ${<NAME>_DIR}
+ * in hook commands with the actual install path.
  */
 function resolveCommandPaths(
   hooks: InlineHook[],
@@ -116,12 +117,12 @@ function resolveCommandPaths(
   packageName: string,
 ): InlineHook[] {
   const nameUpper = packageName.toUpperCase().replace(/-/g, "_");
-  const namePattern = new RegExp(`\\$${nameUpper}_DIR`, "g");
+  const namePattern = new RegExp(`\\$\\{?${nameUpper}_DIR\\}?`, "g");
 
   return hooks.map((hook) => ({
     ...hook,
     command: hook.command
-      .replace(/\$PKG_DIR/g, installPath)
+      .replace(/\$\{?PKG_DIR\}?/g, installPath)
       .replace(namePattern, installPath),
   }));
 }

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -335,6 +335,26 @@ describe("resolveHooksFromManifest", () => {
     ]);
   });
 
+  test("resolves ${PKG_DIR} brace syntax to install path", () => {
+    const inline = [
+      { event: "PostToolUse", command: "bun ${PKG_DIR}/src/hooks/hook.ts" },
+    ];
+    const result = resolveHooksFromManifest(inline, "/opt/packages/mypkg", "MyPkg");
+    expect(result).toEqual([
+      { event: "PostToolUse", command: "bun /opt/packages/mypkg/src/hooks/hook.ts" },
+    ]);
+  });
+
+  test("resolves ${NAME_DIR} brace syntax to install path", () => {
+    const inline = [
+      { event: "SessionStart", command: "bun ${MINER_DIR}/src/hooks/MinerEventLogger.hook.ts" },
+    ];
+    const result = resolveHooksFromManifest(inline, "/home/user/.config/arc/pkg/repos/miner", "Miner");
+    expect(result).toEqual([
+      { event: "SessionStart", command: "bun /home/user/.config/arc/pkg/repos/miner/src/hooks/MinerEventLogger.hook.ts" },
+    ]);
+  });
+
   test("loads and flattens config-file JSON format", async () => {
     // Create a temporary hooks JSON file
     const hooksJson = {


### PR DESCRIPTION
## Summary
- Hook path resolution only matched `$PKG_DIR` / `$NAME_DIR` but not `${PKG_DIR}` / `${NAME_DIR}`
- Since manifests use the brace syntax, hooks were written with unresolved env vars, breaking every session
- Updated regex patterns in `resolveCommandPaths` to accept both forms

## Test plan
- [x] Added tests for `${PKG_DIR}` brace syntax resolution
- [x] Added tests for `${NAME_DIR}` brace syntax resolution
- [x] All 231 existing tests pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)