### PR TITLE
fix: show actions in their own section in arc list

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -54,15 +54,18 @@ export function formatList(result: ListResult): string {
     return "No packages installed.";
   }
 
-  const skills = result.skills.filter((s) => !["tool", "pipeline"].includes(s.artifact_type));
+  const skills = result.skills.filter((s) => !["tool", "pipeline", "action"].includes(s.artifact_type));
   const tools = result.skills.filter((s) => s.artifact_type === "tool");
+  const actions = result.skills.filter((s) => s.artifact_type === "action");
   const pipelines = result.skills.filter((s) => s.artifact_type === "pipeline");
   const lines: string[] = [];
   let sectionCount = 0;
 
-  if (skills.length > 0) {
-    lines.push(`Installed skills (${skills.length}):`, "");
-    for (const s of skills) {
+  const formatSection = (items: InstalledSkill[], label: string) => {
+    if (!items.length) return;
+    if (sectionCount > 0) lines.push("");
+    lines.push(`Installed ${label} (${items.length}):`, "");
+    for (const s of items) {
       const statusBadge = s.status === "active" ? "✅" : "⏸️";
       const tierBadge = s.tier === "official" ? " (official)" : s.tier === "community" ? " (community)" : "";
       const customBadge = s.customization_path ? " *" : "";
@@ -70,28 +73,12 @@ export function formatList(result: ListResult): string {
       lines.push(`  ${statusBadge} ${s.name} v${s.version} [${s.status}]${tierBadge}${customBadge}${libraryBadge}`);
     }
     sectionCount++;
-  }
+  };
 
-  if (tools.length > 0) {
-    if (sectionCount > 0) lines.push("");
-    lines.push(`Installed tools (${tools.length}):`, "");
-    for (const t of tools) {
-      const statusBadge = t.status === "active" ? "✅" : "⏸️";
-      const tierBadge = t.tier === "official" ? " (official)" : t.tier === "community" ? " (community)" : "";
-      lines.push(`  ${statusBadge} ${t.name} v${t.version} [${t.status}]${tierBadge}`);
-    }
-    sectionCount++;
-  }
-
-  if (pipelines.length > 0) {
-    if (sectionCount > 0) lines.push("");
-    lines.push(`Installed pipelines (${pipelines.length}):`, "");
-    for (const p of pipelines) {
-      const statusBadge = p.status === "active" ? "✅" : "⏸️";
-      const tierBadge = p.tier === "official" ? " (official)" : p.tier === "community" ? " (community)" : "";
-      lines.push(`  ${statusBadge} ${p.name} v${p.version} [${p.status}]${tierBadge}`);
-    }
-  }
+  formatSection(skills, "skills");
+  formatSection(tools, "tools");
+  formatSection(actions, "actions");
+  formatSection(pipelines, "pipelines");
 
   if (result.skills.some((s) => s.customization_path)) {
     lines.push("", "  * = has local customizations");


### PR DESCRIPTION
## Summary

- Actions (type: action) now display under "Installed actions" instead of being lumped with skills
- Refactored `formatList()` to use shared `formatSection` helper — eliminates duplicated rendering code

Fixes #33

## Test plan

- [x] 267 tests pass
- [x] Manual: `arc list` now shows separate sections for skills, tools, actions, pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)