### PR TITLE
fix: arc info works for installed libraries

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,25 +1,38 @@
 import type { Database } from "bun:sqlite";
-import { getSkill, getCapabilities } from "../lib/db.js";
+import { getSkill, getCapabilities, listByLibrary } from "../lib/db.js";
 import { readManifest, assessRisk, formatCapabilities } from "../lib/manifest.js";
+import { findGitRoot } from "../lib/paths.js";
 import type { InstalledSkill, ArcManifest } from "../types.js";
 
 export interface InfoResult {
   skill: InstalledSkill | null;
   manifest: ArcManifest | null;
   releaseNotes: string | null;
+  /** For library info: the artifacts installed from this library */
+  libraryArtifacts?: InstalledSkill[];
   error?: string;
 }
 
 /**
- * Get detailed info about an installed skill.
+ * Get detailed info about an installed skill or library.
  */
 export async function info(
   db: Database,
   name: string
 ): Promise<InfoResult> {
   const skill = getSkill(db, name);
+
   if (!skill) {
-    return { skill: null, manifest: null, releaseNotes: null, error: `Skill '${name}' is not installed` };
+    // Check if name matches a library (library itself isn't a DB entry, but its artifacts are)
+    const libraryArtifacts = listByLibrary(db, name);
+    if (libraryArtifacts.length > 0) {
+      // Read the library root manifest from the git root of any artifact
+      const gitRoot = findGitRoot(libraryArtifacts[0].install_path);
+      const manifest = gitRoot ? await readManifest(gitRoot) : null;
+      const releaseNotes = gitRoot ? await fetchReleaseNotesFromUrl(libraryArtifacts[0].repo_url, manifest?.version ?? libraryArtifacts[0].version) : null;
+      return { skill: null, manifest, releaseNotes, libraryArtifacts };
+    }
+    return { skill: null, manifest: null, releaseNotes: null, error: `'${name}' is not installed` };
   }
 
   const manifest = await readManifest(skill.install_path);
@@ -30,15 +43,17 @@ export async function info(
 
 /**
  * Fetch release notes for the installed version.
- * Tries: gh release view from the source repo.
  */
 async function fetchReleaseNotes(skill: InstalledSkill): Promise<string | null> {
-  const tag = `v${skill.version}`;
+  return fetchReleaseNotesFromUrl(skill.repo_url, skill.version);
+}
 
-  // Extract owner/repo from repo_url for gh CLI
-  const ghMatch = skill.repo_url.match(
-    /github\.com[:/]([^/]+)\/([^/.]+)/
-  );
+/**
+ * Fetch release notes by repo URL and version tag.
+ */
+async function fetchReleaseNotesFromUrl(repoUrl: string, version: string): Promise<string | null> {
+  const tag = `v${version}`;
+  const ghMatch = repoUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
   if (!ghMatch) return null;
 
   const nwo = `${ghMatch[1]}/${ghMatch[2]}`;
@@ -65,8 +80,13 @@ async function fetchReleaseNotes(skill: InstalledSkill): Promise<string | null> 
 export function formatInfo(result: InfoResult): string {
   if (result.error) return `Error: ${result.error}`;
 
+  // Library info — no skill entry, but has artifacts
+  if (!result.skill && result.libraryArtifacts?.length) {
+    return formatLibraryInfo(result);
+  }
+
   const { skill, manifest } = result;
-  if (!skill) return "Skill not found.";
+  if (!skill) return "Package not found.";
 
   const lines: string[] = [
     `${skill.name} v${skill.version}`,
@@ -97,6 +117,60 @@ export function formatInfo(result: InfoResult): string {
       for (const t of manifest.provides.skill) {
         lines.push(`    - "${t.trigger}"`);
       }
+    }
+  }
+
+  if (result.releaseNotes) {
+    lines.push("");
+    lines.push("  Release Notes:");
+    for (const line of result.releaseNotes.split("\n").slice(0, 15)) {
+      lines.push(`    ${line}`);
+    }
+    if (result.releaseNotes.split("\n").length > 15) {
+      lines.push("    ...(truncated)");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format library info from its artifacts.
+ */
+function formatLibraryInfo(result: InfoResult): string {
+  const { manifest, libraryArtifacts } = result;
+  const artifacts = libraryArtifacts ?? [];
+
+  const name = manifest?.name ?? artifacts[0]?.library_name ?? "unknown";
+  const version = manifest?.version ?? artifacts[0]?.version ?? "?";
+  const lines: string[] = [];
+
+  lines.push(`\u{1F4DA} ${name} v${version} (library)`);
+
+  if (manifest) {
+    const author = manifest.author ?? manifest.authors?.[0];
+    if (author) {
+      lines.push(`  Author: ${author.name} (${author.github})`);
+    }
+  }
+
+  lines.push(`  Repo: ${artifacts[0]?.repo_url ?? "unknown"}`);
+  lines.push(`  Installed artifacts: ${artifacts.length}`);
+
+  // Group by type
+  const byType = new Map<string, InstalledSkill[]>();
+  for (const a of artifacts) {
+    const type = a.artifact_type;
+    if (!byType.has(type)) byType.set(type, []);
+    byType.get(type)!.push(a);
+  }
+
+  lines.push("");
+  for (const [type, items] of byType) {
+    lines.push(`  ${type}s (${items.length}):`);
+    for (const item of items) {
+      const statusBadge = item.status === "active" ? "\u2705" : "\u23F8\uFE0F";
+      lines.push(`    ${statusBadge} ${item.name} v${item.version}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- `arc info metafactory-actions` now works for installed libraries
- Falls back to `listByLibrary()` when package name isn't a direct DB entry
- Reads library root manifest from git root of first artifact
- Displays library-level info with grouped artifact list by type

Fixes #34

## Example output

```
📚 metafactory-actions v1.0.0 (library)
  Author: metafactory (the-metafactory)
  Repo: git@github.com:the-metafactory/metafactory-actions.git
  Installed artifacts: 28

  actions (22):
    ✅ A_DISCOVER_REPOS v1.0.0
    ✅ A_FETCH_REPOS v1.0.0
    ...

  pipelines (6):
    ✅ F_NEXT_PICK v1.0.0
    ...
```

## Test plan

- [x] 267 tests pass
- [x] Manual: `arc info metafactory-actions` shows library info with artifact list

🤖 Generated with [Claude Code](https://claude.com/claude-code)