### PR TITLE
chore(blueprint): add A-600 external runtime dependency shims

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -154,3 +154,13 @@ features:
     iteration: 6
     depends: [A-200, A-404]
     description: "arc info <name> for uninstalled packages — resolve from registry, clone to cache, show manifest, capabilities, and library artifacts list"
+
+  # External runtime dependencies — DD-72 plug-and-play prerequisite
+  - id: A-600
+    name: External runtime dependency shims
+    status: planned
+    iteration: 10
+    effort: m
+    issue: 47
+    depends: [A-100, A-101]
+    description: "externalDeps[] manifest field + install postcheck. arc detects external binaries (claude, gh, bun, etc.) declared by a package, finds them across known paths (native installer, npm, fnm, homebrew), and creates shims in paths.shimDir (~/bin) so spawned subprocesses on stripped PATH (launchd, nohup, system services) can resolve them. Includes arc doctor command for first-run diagnosis. Closes the DD-72 gap surfaced by 2026-04-07 grove-bot/Luna outage where Bun.spawn(['claude', ...]) hit ENOENT because the bot inherited a minimal PATH without ~/.local/bin."


### PR DESCRIPTION
## Summary

Adds **A-600 External runtime dependency shims** to `blueprint.yaml` as a planned iteration-10 feature, depending on A-100 (manifest format) and A-101 (install pipeline).

A-600 is the structural fix for the gap surfaced by today's grove-bot/Luna outage: arc-installed long-running processes (grove-bot, future bots) inherit a stripped PATH from launchd/nohup/system services, so `Bun.spawn(["claude", ...])` in `grove/src/bot/lib/cc-session.ts:115` hits ENOENT even though `claude` is installed on the machine — just not in any directory the bot's PATH sees.

Full design and acceptance criteria are in #47. This PR is **blueprint-only** — it does not implement A-600, just makes it visible on the dependency graph.

## What this PR contains

```yaml
- id: A-600
  name: External runtime dependency shims
  status: planned
  iteration: 10
  effort: m
  issue: 47
  depends: [A-100, A-101]
  description: "externalDeps[] manifest field + install postcheck. arc detects
    external binaries (claude, gh, bun, etc.) declared by a package, finds them
    across known paths (native installer, npm, fnm, homebrew), and creates
    shims in paths.shimDir (~/bin) so spawned subprocesses on stripped PATH
    (launchd, nohup, system services) can resolve them. Includes arc doctor
    command for first-run diagnosis. Closes the DD-72 gap surfaced by
    2026-04-07 grove-bot/Luna outage where Bun.spawn(['claude', ...]) hit
    ENOENT because the bot inherited a minimal PATH without ~/.local/bin."
```

## Verification

```bash
$ BLUEPRINT_DEV_ROOT=/tmp/bp-test bun run src/cli.ts lint
✓ All checks passed.

$ BLUEPRINT_DEV_ROOT=/tmp/bp-test bun run src/cli.ts ready --repo arc
Ready to start (6):
  [ready] arc/A-600 External runtime dependency shims
  [ready] arc/A-400 Runtime enforcement (SecurityValidator)
  [ready] arc/A-401 metafactory registry source
  [ready] arc/A-406 SHA-256 registry verification
  [ready] arc/A-500 Remote package info
  [ready] arc/A-402 Version pinning
```

(Lint run via `/tmp/bp-test` symlink farm with arc pointing at this worktree branch — same pattern used for grove#171 and meta-factory#67 launch-plan imports.)

## Connection to launch plan

A-600 is a **DD-72 prerequisite**, not a launch blocker. We worked around today's incident with a one-off `~/bin/claude` symlink, and Luna is functional again. But A-600 is the right structural fix and should land in iteration 10 alongside the launch plan, ideally before grove's first non-founder install (`grove:S2-11`).

Cross-stream context: see meta-factory `docs/critical-path-to-launch.md` and the launch-plan blueprint imports in:
- the-metafactory/grove#171 (Stream B — grove launch features S1-* + S2-10..12)
- the-metafactory/meta-factory#67 (Stream C — metafactory launch features S2-01..32)

## Test plan

- [x] `blueprint lint` clean
- [x] `blueprint ready --repo arc` shows A-600
- [x] No new orphans, no missing deps
- [ ] Reviewer agrees A-600 is correctly framed (this is a planning PR — implementation is a separate PR)

Refs #47