### PR TITLE
fix: route private-repo registry fetches through Contents API

### DIFF
--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -80,15 +80,28 @@ export async function fetchRemoteRegistry(
   try {
     const headers: Record<string, string> = {};
 
+    // raw.githubusercontent.com does NOT honor Authorization headers for
+    // private repos — only browser session cookies. For private repos we
+    // have to go through the Contents API, which respects PAT auth.
+    // Rewrite raw URLs transparently so existing sources.yaml entries
+    // keep working unchanged.
+    let fetchUrl = source.url;
+    const rewritten = rewriteRawToContentsApi(source.url);
+    if (rewritten) {
+      fetchUrl = rewritten;
+      headers["Accept"] = "application/vnd.github.raw";
+      headers["X-GitHub-Api-Version"] = "2022-11-28";
+    }
+
     // Add GitHub token for private repos accessed via raw.githubusercontent.com or api.github.com
-    if (source.url.includes("github")) {
+    if (fetchUrl.includes("github")) {
       const token = process.env.GITHUB_TOKEN ?? getGhToken();
       if (token) {
-        headers["Authorization"] = `token ${token}`;
+        headers["Authorization"] = `Bearer ${token}`;
       }
     }
 
-    const response = await fetch(source.url, {
+    const response = await fetch(fetchUrl, {
       signal: AbortSignal.timeout(10_000),
       headers,
     });
@@ -243,6 +256,28 @@ export function formatSourcedSearch(results: SourcedSearchResult[]): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Rewrite a raw.githubusercontent.com URL to the equivalent GitHub
+ * Contents API URL. Returns null if the URL doesn't match the raw
+ * pattern (in which case the caller should fetch the original URL
+ * unchanged).
+ *
+ * Input:  https://raw.githubusercontent.com/OWNER/REPO/REF/PATH/TO/FILE
+ * Output: https://api.github.com/repos/OWNER/REPO/contents/PATH/TO/FILE?ref=REF
+ *
+ * The Contents API honors PAT authentication for private repos, which
+ * raw.githubusercontent.com does not. With Accept: application/vnd.github.raw
+ * the response body is the raw file content (same shape as the raw URL).
+ */
+export function rewriteRawToContentsApi(url: string): string | null {
+  const match = url.match(
+    /^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/,
+  );
+  if (!match) return null;
+  const [, owner, repo, ref, path] = match;
+  return `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref!)}`;
 }
 
 /** Try to get GitHub token from gh CLI auth */

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -4,6 +4,7 @@ import {
   fetchRemoteRegistry,
   searchAllSources,
   formatSourcedSearch,
+  rewriteRawToContentsApi,
 } from "../../src/lib/remote-registry.js";
 import type { RegistryConfig, SourcesConfig, RegistrySource } from "../../src/types.js";
 import YAML from "yaml";
@@ -171,6 +172,42 @@ describe("searchAllSources", () => {
 
     // Should not find anything (disabled source skipped, no local fallback since no registry)
     expect(results).toHaveLength(0);
+  });
+});
+
+describe("rewriteRawToContentsApi", () => {
+  test("rewrites a raw.githubusercontent.com URL to the Contents API", () => {
+    const out = rewriteRawToContentsApi(
+      "https://raw.githubusercontent.com/the-metafactory/meta-factory/main/REGISTRY.yaml",
+    );
+    expect(out).toBe(
+      "https://api.github.com/repos/the-metafactory/meta-factory/contents/REGISTRY.yaml?ref=main",
+    );
+  });
+
+  test("preserves nested paths", () => {
+    const out = rewriteRawToContentsApi(
+      "https://raw.githubusercontent.com/owner/repo/branch/path/to/file.yaml",
+    );
+    expect(out).toBe(
+      "https://api.github.com/repos/owner/repo/contents/path/to/file.yaml?ref=branch",
+    );
+  });
+
+  test("encodes refs containing slashes", () => {
+    const out = rewriteRawToContentsApi(
+      "https://raw.githubusercontent.com/owner/repo/release%2Fv1/file.yaml",
+    );
+    expect(out).not.toBeNull();
+    expect(out).toContain("?ref=");
+  });
+
+  test("returns null for non-raw URLs", () => {
+    expect(rewriteRawToContentsApi("https://example.com/file.yaml")).toBeNull();
+    expect(
+      rewriteRawToContentsApi("https://api.github.com/repos/o/r/contents/f.yaml"),
+    ).toBeNull();
+    expect(rewriteRawToContentsApi("file:///tmp/registry.yaml")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a fetch failure when arc tries to read a private `REGISTRY.yaml` from a `raw.githubusercontent.com` URL using a fine-grained PAT.

`raw.githubusercontent.com` does **not** honor `Authorization` headers for private repos when the token is a fine-grained PAT — it only accepts classic PATs and browser session cookies. The GitHub Contents API accepts both fine-grained and classic PATs.

This rewrites raw URLs transparently to the Contents API and asks for the raw body via `Accept: application/vnd.github.raw`, so existing `sources.yaml` entries keep working unchanged.

## How it surfaced

While bringing up `test-rig` CI against the private `the-metafactory/meta-factory` registry, `arc install grove` failed with:

```
"grove" not found in any source. Try: arc search <keyword>
```

even though `GITHUB_TOKEN` was correctly plumbed into the container. Tracing the fetch showed `raw.githubusercontent.com` returning 404 for the registry URL because the token was a fine-grained PAT.

## Changes

- `src/lib/remote-registry.ts`
  - New `rewriteRawToContentsApi(url)` helper. Rewrites `https://raw.githubusercontent.com/OWNER/REPO/REF/PATH` → `https://api.github.com/repos/OWNER/REPO/contents/PATH?ref=REF`. Returns `null` for non-raw URLs (caller falls through to original behavior).
  - `fetchRemoteRegistry` calls the helper before fetching. When rewritten, sets `Accept: application/vnd.github.raw` and `X-GitHub-Api-Version: 2022-11-28`.
  - Switches `Authorization: token <t>` → `Authorization: Bearer <t>` (works for both classic and fine-grained PATs; Contents API standard).
- `test/unit/remote-registry.test.ts`
  - 4 new unit tests for `rewriteRawToContentsApi`: happy path, nested paths, refs with slashes, pass-through for non-raw URLs.

## Test plan

- [x] `bun test` — 300/300 passing (4 new tests for the rewrite helper)
- [x] `bunx tsc --noEmit` clean
- [x] Manual verification: Contents API returns the registry body with `Accept: application/vnd.github.raw` against the private `meta-factory` repo
- [ ] After merge: re-run test-rig e2e workflow and confirm `arc install grove` resolves grove from the registry

## Compatibility

Existing `sources.yaml` entries pointing at `raw.githubusercontent.com` continue to work unchanged — the rewrite is transparent. Non-GitHub sources are untouched. `file://` sources are untouched. Caching behavior is unchanged (cached under the original source name, not the rewritten URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)