### PR TITLE
feat: add arc login/logout with device code auth (A-401 F-2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,8 @@ import {
   formatCatalogSearch,
 } from "./commands/catalog.js";
 import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
+import { login } from "./commands/login.js";
+import { logout } from "./commands/logout.js";
 import { loadCatalog, saveCatalog, findEntry } from "./lib/catalog.js";
 import {
   loadSources,
@@ -558,6 +560,43 @@ source
       console.log(`Removed source "${name}"`);
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+// ── Auth commands ──────────────────────────────────────────
+
+program
+  .command("login")
+  .description("Authenticate with metafactory registry")
+  .option("-s, --source <name>", "Target source name (default: first metafactory source)")
+  .option("-f, --force", "Re-authenticate even if already logged in")
+  .action(async (opts: { source?: string; force?: boolean }) => {
+    const paths = createPaths();
+    const result = await login({ paths, sourceName: opts.source, force: opts.force });
+
+    if (result.success) {
+      console.log(`Logged in to ${result.sourceName}`);
+      if (result.scope) console.log(`  Scope: ${result.scope}`);
+      if (result.expiresAt) console.log(`  Expires: ${new Date(result.expiresAt * 1000).toISOString()}`);
+    } else {
+      console.error(`Error: ${result.error}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("logout")
+  .description("Remove authentication from metafactory source")
+  .option("-s, --source <name>", "Target source name (default: first metafactory source)")
+  .action(async (opts: { source?: string }) => {
+    const paths = createPaths();
+    const result = await logout({ paths, sourceName: opts.source });
+
+    if (result.success) {
+      console.log(`Logged out from ${result.sourceName}`);
+    } else {
+      console.error(`Error: ${result.error}`);
       process.exit(1);
     }
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,5 @@
 import type { PaiPaths } from "../types.js";
-import { loadSources, saveSources, getSourceType } from "../lib/sources.js";
+import { loadSources, saveSources, findMetafactorySource } from "../lib/sources.js";
 import { initiateDeviceCode, pollForToken, openBrowser } from "../lib/device-auth.js";
 
 export interface LoginOptions {
@@ -19,30 +19,11 @@ export interface LoginResult {
 export async function login(opts: LoginOptions): Promise<LoginResult> {
   const config = await loadSources(opts.paths.sourcesPath);
 
-  // Find target source
-  let source;
-  if (opts.sourceName) {
-    source = config.sources.find((s) => s.name === opts.sourceName);
-    if (!source) {
-      return { success: false, error: `Source "${opts.sourceName}" not found` };
-    }
-  } else {
-    source = config.sources.find((s) => getSourceType(s) === "metafactory");
-    if (!source) {
-      return {
-        success: false,
-        error: "No metafactory source configured. Run: arc source add metafactory https://meta-factory.ai --type metafactory",
-      };
-    }
+  const found = findMetafactorySource(config, opts.sourceName);
+  if ("error" in found) {
+    return { success: false, error: found.error };
   }
-
-  // Validate type
-  if (getSourceType(source) !== "metafactory") {
-    return {
-      success: false,
-      error: `Source "${source.name}" is type "${getSourceType(source)}", not "metafactory". Login is only for metafactory sources.`,
-    };
-  }
+  const source = found.source;
 
   // Check existing token
   if (source.token && !opts.force) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,104 @@
+import type { PaiPaths } from "../types.js";
+import { loadSources, saveSources, getSourceType } from "../lib/sources.js";
+import { initiateDeviceCode, pollForToken, openBrowser } from "../lib/device-auth.js";
+
+export interface LoginOptions {
+  paths: PaiPaths;
+  sourceName?: string;
+  force?: boolean;
+}
+
+export interface LoginResult {
+  success: boolean;
+  sourceName?: string;
+  scope?: string;
+  expiresAt?: number;
+  error?: string;
+}
+
+export async function login(opts: LoginOptions): Promise<LoginResult> {
+  const config = await loadSources(opts.paths.sourcesPath);
+
+  // Find target source
+  let source;
+  if (opts.sourceName) {
+    source = config.sources.find((s) => s.name === opts.sourceName);
+    if (!source) {
+      return { success: false, error: `Source "${opts.sourceName}" not found` };
+    }
+  } else {
+    source = config.sources.find((s) => getSourceType(s) === "metafactory");
+    if (!source) {
+      return {
+        success: false,
+        error: "No metafactory source configured. Run: arc source add metafactory https://meta-factory.ai --type metafactory",
+      };
+    }
+  }
+
+  // Validate type
+  if (getSourceType(source) !== "metafactory") {
+    return {
+      success: false,
+      error: `Source "${source.name}" is type "${getSourceType(source)}", not "metafactory". Login is only for metafactory sources.`,
+    };
+  }
+
+  // Check existing token
+  if (source.token && !opts.force) {
+    return {
+      success: false,
+      error: `Already logged in to ${source.name}. Use --force to re-authenticate.`,
+    };
+  }
+
+  // Initiate device code flow
+  let deviceCode;
+  try {
+    deviceCode = await initiateDeviceCode(source.url);
+  } catch (err: any) {
+    return {
+      success: false,
+      error: `Cannot reach ${source.url}: ${err.message}`,
+    };
+  }
+
+  // Display code and open browser
+  console.log(`\nVisit: ${deviceCode.verification_uri}`);
+  console.log(`Enter code: ${deviceCode.user_code}\n`);
+
+  if (!openBrowser(deviceCode.verification_uri)) {
+    console.log("(Could not open browser automatically. Open the URL above manually.)");
+  }
+
+  // Poll for approval
+  const result = await pollForToken(source.url, deviceCode.device_code, {
+    interval: deviceCode.interval,
+    expiresIn: deviceCode.expires_in,
+    onPoll: (_attempt, elapsed) => {
+      const remaining = deviceCode.expires_in - elapsed;
+      process.stdout.write(`\rWaiting for approval... (${remaining}s remaining) `);
+    },
+  });
+
+  // Clear the polling line
+  process.stdout.write("\r" + " ".repeat(60) + "\r");
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.error ?? "Login failed",
+    };
+  }
+
+  // Store token
+  source.token = result.token;
+  await saveSources(opts.paths.sourcesPath, config);
+
+  return {
+    success: true,
+    sourceName: source.name,
+    scope: result.scope,
+    expiresAt: result.expiresAt,
+  };
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,50 @@
+import type { PaiPaths } from "../types.js";
+import { loadSources, saveSources, getSourceType } from "../lib/sources.js";
+
+export interface LogoutOptions {
+  paths: PaiPaths;
+  sourceName?: string;
+}
+
+export interface LogoutResult {
+  success: boolean;
+  sourceName?: string;
+  error?: string;
+}
+
+export async function logout(opts: LogoutOptions): Promise<LogoutResult> {
+  const config = await loadSources(opts.paths.sourcesPath);
+
+  // Find target source
+  let source;
+  if (opts.sourceName) {
+    source = config.sources.find((s) => s.name === opts.sourceName);
+    if (!source) {
+      return { success: false, error: `Source "${opts.sourceName}" not found` };
+    }
+  } else {
+    source = config.sources.find((s) => getSourceType(s) === "metafactory");
+    if (!source) {
+      return { success: false, error: "No metafactory source configured" };
+    }
+  }
+
+  // Validate type
+  if (getSourceType(source) !== "metafactory") {
+    return {
+      success: false,
+      error: `Source "${source.name}" is type "${getSourceType(source)}", not "metafactory".`,
+    };
+  }
+
+  // Check token exists
+  if (!source.token) {
+    return { success: false, error: `Not logged in to ${source.name}` };
+  }
+
+  // Remove token
+  delete source.token;
+  await saveSources(opts.paths.sourcesPath, config);
+
+  return { success: true, sourceName: source.name };
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,5 +1,5 @@
 import type { PaiPaths } from "../types.js";
-import { loadSources, saveSources, getSourceType } from "../lib/sources.js";
+import { loadSources, saveSources, findMetafactorySource } from "../lib/sources.js";
 
 export interface LogoutOptions {
   paths: PaiPaths;
@@ -15,27 +15,11 @@ export interface LogoutResult {
 export async function logout(opts: LogoutOptions): Promise<LogoutResult> {
   const config = await loadSources(opts.paths.sourcesPath);
 
-  // Find target source
-  let source;
-  if (opts.sourceName) {
-    source = config.sources.find((s) => s.name === opts.sourceName);
-    if (!source) {
-      return { success: false, error: `Source "${opts.sourceName}" not found` };
-    }
-  } else {
-    source = config.sources.find((s) => getSourceType(s) === "metafactory");
-    if (!source) {
-      return { success: false, error: "No metafactory source configured" };
-    }
+  const found = findMetafactorySource(config, opts.sourceName);
+  if ("error" in found) {
+    return { success: false, error: found.error };
   }
-
-  // Validate type
-  if (getSourceType(source) !== "metafactory") {
-    return {
-      success: false,
-      error: `Source "${source.name}" is type "${getSourceType(source)}", not "metafactory".`,
-    };
-  }
+  const source = found.source;
 
   // Check token exists
   if (!source.token) {

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -1,0 +1,112 @@
+import type { DeviceCodeResponse, DeviceVerifyResponse, DeviceAuthResult } from "../types.js";
+
+interface PollOptions {
+  interval: number;
+  expiresIn: number;
+  onPoll?: (attempt: number, elapsed: number) => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Initiate device code flow against a metafactory API.
+ * POST /api/v1/auth/cli/initiate
+ */
+export async function initiateDeviceCode(baseUrl: string): Promise<DeviceCodeResponse> {
+  const url = `${baseUrl}/api/v1/auth/cli/initiate`;
+  const response = await fetch(url, {
+    method: "POST",
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Initiate failed: ${response.status} ${body}`.trim());
+  }
+
+  return (await response.json()) as DeviceCodeResponse;
+}
+
+/**
+ * Poll for token approval.
+ * POST /api/v1/auth/cli/verify with device_code
+ */
+export async function pollForToken(
+  baseUrl: string,
+  deviceCode: string,
+  opts: PollOptions,
+): Promise<DeviceAuthResult> {
+  const url = `${baseUrl}/api/v1/auth/cli/verify`;
+  const intervalMs = opts.interval * 1000;
+  const deadline = Date.now() + opts.expiresIn * 1000;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    const elapsed = Math.floor((Date.now() - (deadline - opts.expiresIn * 1000)) / 1000);
+    opts.onPoll?.(attempt, elapsed);
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_code: deviceCode }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (response.status === 410) {
+        return { success: false, error: "Device code expired", errorCode: "expired" };
+      }
+
+      if (response.status === 202) {
+        await sleep(intervalMs);
+        continue;
+      }
+
+      if (response.ok) {
+        const body = (await response.json()) as DeviceVerifyResponse;
+
+        if (body.status === "approved" && body.token) {
+          return {
+            success: true,
+            token: body.token,
+            expiresAt: body.expires_at,
+            scope: body.scope,
+          };
+        }
+
+        if (body.status === "denied") {
+          return { success: false, error: "Login denied", errorCode: "denied" };
+        }
+
+        // status: "pending" on 200 -- keep polling
+        await sleep(intervalMs);
+        continue;
+      }
+
+      // Unexpected status
+      await sleep(intervalMs);
+    } catch {
+      // Network error -- retry, don't abort
+      await sleep(intervalMs);
+    }
+  }
+
+  return { success: false, error: `Login timed out after ${opts.expiresIn}s`, errorCode: "timeout" };
+}
+
+/**
+ * Open a URL in the system browser.
+ * Returns true if spawn succeeded.
+ */
+export function openBrowser(url: string): boolean {
+  try {
+    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    Bun.spawn([cmd, url], { stdout: "ignore", stderr: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -88,8 +88,8 @@ export async function pollForToken(
 
       // Unexpected status
       await sleep(intervalMs);
-    } catch {
-      // Network error -- retry, don't abort
+    } catch (_err) {
+      // Network error -- retry, don't abort. Caller handles timeout.
       await sleep(intervalMs);
     }
   }
@@ -106,7 +106,8 @@ export function openBrowser(url: string): boolean {
     const cmd = process.platform === "darwin" ? "open" : "xdg-open";
     Bun.spawn([cmd, url], { stdout: "ignore", stderr: "ignore" });
     return true;
-  } catch {
+  } catch (_err) {
+    // spawn failed -- caller handles via return value
     return false;
   }
 }

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -119,6 +119,27 @@ export function removeSource(
   config.sources.splice(idx, 1);
 }
 
+/** Find a metafactory source by name or return the first one. */
+export function findMetafactorySource(
+  config: SourcesConfig,
+  sourceName?: string,
+): { source: RegistrySource } | { error: string } {
+  if (sourceName) {
+    const source = config.sources.find((s) => s.name === sourceName);
+    if (!source) return { error: `Source "${sourceName}" not found` };
+    if (getSourceType(source) !== "metafactory") {
+      return { error: `Source "${source.name}" is type "${getSourceType(source)}", not "metafactory". Login is only for metafactory sources.` };
+    }
+    return { source };
+  }
+
+  const source = config.sources.find((s) => getSourceType(s) === "metafactory");
+  if (!source) {
+    return { error: "No metafactory source configured. Run: arc source add metafactory https://meta-factory.ai --type metafactory" };
+  }
+  return { source };
+}
+
 export function formatSourceList(config: SourcesConfig): string {
   if (!config.sources.length) return "No sources configured.";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,35 @@ export interface SourcesConfig {
   sources: RegistrySource[];
 }
 
+/** Response from POST /api/v1/auth/cli/initiate */
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+/** Response from POST /api/v1/auth/cli/verify */
+export interface DeviceVerifyResponse {
+  status: "pending" | "approved" | "denied";
+  token?: string;
+  token_id?: string;
+  scope?: string;
+  expires_at?: number;
+  expires_in?: number;
+}
+
+/** Result of the complete device code auth flow */
+export interface DeviceAuthResult {
+  success: boolean;
+  token?: string;
+  expiresAt?: number;
+  scope?: string;
+  error?: string;
+  errorCode?: "expired" | "denied" | "timeout" | "network" | "no_source" | "wrong_type";
+}
+
 /** A search result annotated with its source */
 export interface SourcedSearchResult {
   entry: RegistryEntry;

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { login } from "../../src/commands/login.js";
+import { saveSources, loadSources } from "../../src/lib/sources.js";
+import type { SourcesConfig } from "../../src/types.js";
+import YAML from "yaml";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+function metafactorySource(token?: string): SourcesConfig {
+  return {
+    sources: [{
+      name: "mf-test",
+      url: "https://meta-factory.ai",
+      tier: "official",
+      enabled: true,
+      type: "metafactory",
+      ...(token ? { token } : {}),
+    }],
+  };
+}
+
+function registrySource(): SourcesConfig {
+  return {
+    sources: [{
+      name: "my-registry",
+      url: "https://example.com/REG.yaml",
+      tier: "community",
+      enabled: true,
+    }],
+  };
+}
+
+describe("login - source finding", () => {
+  test("returns error when no metafactory source configured", async () => {
+    await saveSources(env.paths.sourcesPath, registrySource());
+    const result = await login({ paths: env.paths });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No metafactory source configured");
+  });
+
+  test("returns error when --source name not found", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const result = await login({ paths: env.paths, sourceName: "nonexistent" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('"nonexistent" not found');
+  });
+
+  test("returns error when source is type registry", async () => {
+    await saveSources(env.paths.sourcesPath, registrySource());
+    const result = await login({ paths: env.paths, sourceName: "my-registry" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("registry");
+    expect(result.error).toContain("not \"metafactory\"");
+  });
+
+  test("finds first metafactory source by default", async () => {
+    const config: SourcesConfig = {
+      sources: [
+        { name: "reg", url: "https://example.com/R.yaml", tier: "community", enabled: true },
+        { name: "mf", url: "https://meta-factory.ai", tier: "official", enabled: true, type: "metafactory" },
+      ],
+    };
+    await saveSources(env.paths.sourcesPath, config);
+    // Will fail at network call, but proves it found the right source
+    const result = await login({ paths: env.paths });
+    // Either network error (expected) or already logged in -- not "no source" error
+    expect(result.error).not.toContain("No metafactory source configured");
+  });
+});
+
+describe("login - already logged in", () => {
+  test("returns error when token exists and no --force", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource("existing-token"));
+    const result = await login({ paths: env.paths });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Already logged in");
+  });
+
+  test("proceeds when token exists and --force", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource("existing-token"));
+    // Will fail at network call, but proves it didn't stop at "already logged in"
+    const result = await login({ paths: env.paths, force: true });
+    expect(result.error).not.toContain("Already logged in");
+  });
+});

--- a/test/commands/logout.test.ts
+++ b/test/commands/logout.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { logout } from "../../src/commands/logout.js";
+import { saveSources, loadSources } from "../../src/lib/sources.js";
+import type { SourcesConfig } from "../../src/types.js";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+function metafactorySource(token?: string): SourcesConfig {
+  return {
+    sources: [{
+      name: "mf-test",
+      url: "https://meta-factory.ai",
+      tier: "official",
+      enabled: true,
+      type: "metafactory",
+      ...(token ? { token } : {}),
+    }],
+  };
+}
+
+function registrySource(): SourcesConfig {
+  return {
+    sources: [{
+      name: "my-registry",
+      url: "https://example.com/REG.yaml",
+      tier: "community",
+      enabled: true,
+    }],
+  };
+}
+
+describe("logout - source finding", () => {
+  test("returns error when no metafactory source configured", async () => {
+    await saveSources(env.paths.sourcesPath, registrySource());
+    const result = await logout({ paths: env.paths });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No metafactory source configured");
+  });
+
+  test("returns error when --source name not found", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource("token"));
+    const result = await logout({ paths: env.paths, sourceName: "nonexistent" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('"nonexistent" not found');
+  });
+
+  test("returns error when source is type registry", async () => {
+    await saveSources(env.paths.sourcesPath, registrySource());
+    const result = await logout({ paths: env.paths, sourceName: "my-registry" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("registry");
+    expect(result.error).toContain("not \"metafactory\"");
+  });
+});
+
+describe("logout - token removal", () => {
+  test("returns error when not logged in", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const result = await logout({ paths: env.paths });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Not logged in");
+  });
+
+  test("removes token on success", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource("my-secret-token"));
+    const result = await logout({ paths: env.paths });
+    expect(result.success).toBe(true);
+    expect(result.sourceName).toBe("mf-test");
+
+    // Verify token removed from disk
+    const config = await loadSources(env.paths.sourcesPath);
+    const source = config.sources.find((s) => s.name === "mf-test");
+    expect(source).toBeDefined();
+    expect(source!.token).toBeUndefined();
+  });
+
+  test("source still exists after logout", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource("token-to-remove"));
+    await logout({ paths: env.paths });
+
+    const config = await loadSources(env.paths.sourcesPath);
+    expect(config.sources.find((s) => s.name === "mf-test")).toBeDefined();
+  });
+
+  test("other sources unchanged", async () => {
+    const config: SourcesConfig = {
+      sources: [
+        { name: "mf-test", url: "https://meta-factory.ai", tier: "official", enabled: true, type: "metafactory", token: "remove-me" },
+        { name: "other", url: "https://example.com/R.yaml", tier: "community", enabled: true },
+      ],
+    };
+    await saveSources(env.paths.sourcesPath, config);
+    await logout({ paths: env.paths });
+
+    const reloaded = await loadSources(env.paths.sourcesPath);
+    expect(reloaded.sources).toHaveLength(2);
+    expect(reloaded.sources[1].name).toBe("other");
+    expect(reloaded.sources[1].url).toBe("https://example.com/R.yaml");
+  });
+});


### PR DESCRIPTION
## Summary
- `arc login`: device code auth flow against metafactory API (initiate, browser open, poll, store token)
- `arc logout`: remove token from metafactory source in sources.yaml
- New library `src/lib/device-auth.ts` with `initiateDeviceCode`, `pollForToken`, `openBrowser`
- Flags: `--source` (target specific source), `--force` (re-authenticate)

## Error handling
- No metafactory source: suggests `arc source add` command
- Wrong source type: names the type and suggests correct usage
- Already logged in: suggests `--force`
- Network failure, expired, denied, timeout: clear actionable messages

## Tests
13 new tests across 2 files. Full suite: **333/333 passing**.

## SpecFlow
F-2 of A-401 series. Depends on F-1 (merged as `79f01b1`).

@the-metafactory/luna -- requesting review

Generated with [Claude Code](https://claude.com/claude-code)