### PR TITLE
feat: add metafactory registry API client (A-401 F-3)

### DIFF
--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -131,6 +131,9 @@ function convertToRegistryConfig(packages: MetafactoryPackageListItem[]): Regist
 
   for (const pkg of packages) {
     const { entry, artifactType } = mapApiPackageToRegistryEntry(pkg);
+    // pipeline, action, rules all route to skills — arc's registry model treats them
+    // as skill subtypes. Separate arrays exist in RegistryConfig but are only used
+    // by REGISTRY.yaml sources that explicitly categorize them.
     const target = artifactType === "tool" ? config.registry.tools!
       : artifactType === "agent" ? config.registry.agents!
       : artifactType === "prompt" ? config.registry.prompts!
@@ -194,6 +197,10 @@ export async function fetchMetafactoryRegistry(
       }
 
       const body = (await response.json()) as MetafactoryPackageListResponse;
+      if (!body.packages || !Array.isArray(body.packages)) {
+        debugLog(`Invalid response from ${source.name}: missing packages array`);
+        return readCachedRegistry(cachePath, source);
+      }
       allPackages.push(...body.packages);
 
       // Check if there are more pages
@@ -201,6 +208,10 @@ export async function fetchMetafactoryRegistry(
         break;
       }
       page++;
+    }
+
+    if (page > MAX_PAGES) {
+      debugLog(`Hit MAX_PAGES (${MAX_PAGES}) for ${source.name} — ${allPackages.length} of ${allPackages.length}+ packages fetched. Some packages may be missing.`);
     }
   } catch (_err) {
     // Network error -- try stale cache
@@ -235,7 +246,7 @@ export async function fetchMetafactoryPackageDetail(
   scope: string,
   name: string,
 ): Promise<MetafactoryPackageDetail | null> {
-  const url = `${source.url}/api/v1/packages/${scope}/${name}`;
+  const url = `${source.url}/api/v1/packages/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`;
   debugLog(`Fetching detail: ${url}`);
 
   try {

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -1,0 +1,263 @@
+import { readFile, writeFile, mkdir, stat } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import type {
+  RegistrySource,
+  RegistryConfig,
+  RegistryEntry,
+  ArtifactType,
+  MetafactoryPackageListItem,
+  MetafactoryPackageListResponse,
+  MetafactoryPackageDetail,
+} from "../types.js";
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_PAGES = 5;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Mapping
+// ---------------------------------------------------------------------------
+
+/** Convert a metafactory API package to arc's RegistryEntry format */
+export function mapApiPackageToRegistryEntry(pkg: MetafactoryPackageListItem): {
+  entry: RegistryEntry;
+  artifactType: ArtifactType;
+} {
+  const entry: RegistryEntry = {
+    name: `${pkg.namespace}/${pkg.name}`,
+    description: pkg.description ?? "",
+    author: pkg.publisher.display_name ?? "unknown",
+    version: pkg.latest_version ?? "0.0.0",
+    source: "", // Not available from list endpoint; resolved in detail fetch
+    type: "community",
+    status: "shipped",
+  };
+
+  // Map API type to arc ArtifactType
+  const typeMap: Record<string, ArtifactType> = {
+    skill: "skill",
+    tool: "tool",
+    agent: "agent",
+    prompt: "prompt",
+    component: "component",
+    pipeline: "pipeline",
+    action: "action",
+    rules: "skill", // rules are a skill subtype in arc
+    playbook: "skill",
+    graph: "component",
+  };
+  const artifactType: ArtifactType = typeMap[pkg.type] ?? "skill";
+
+  return { entry, artifactType };
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+function cacheFileName(source: RegistrySource): string {
+  return `${source.name}-metafactory.json`;
+}
+
+async function isCacheFresh(cachePath: string, source: RegistrySource): Promise<boolean> {
+  const filePath = join(cachePath, cacheFileName(source));
+  if (!existsSync(filePath)) return false;
+  try {
+    const st = await stat(filePath);
+    return Date.now() - st.mtimeMs < CACHE_TTL_MS;
+  } catch (_err) {
+    return false;
+  }
+}
+
+async function readCachedRegistry(cachePath: string, source: RegistrySource): Promise<RegistryConfig | null> {
+  const filePath = join(cachePath, cacheFileName(source));
+  try {
+    const content = await readFile(filePath, "utf-8");
+    return JSON.parse(content) as RegistryConfig;
+  } catch (_err) {
+    return null;
+  }
+}
+
+async function cacheRegistry(cachePath: string, source: RegistrySource, config: RegistryConfig): Promise<void> {
+  if (!existsSync(cachePath)) {
+    await mkdir(cachePath, { recursive: true });
+  }
+  const filePath = join(cachePath, cacheFileName(source));
+  await writeFile(filePath, JSON.stringify(config), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Debug logging
+// ---------------------------------------------------------------------------
+
+function debugLog(msg: string): void {
+  if (process.env.ARC_DEBUG === "1") {
+    process.stderr.write(`[arc:metafactory] ${msg}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function buildHeaders(source: RegistrySource): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (source.token) {
+    headers.Authorization = `Bearer ${source.token}`;
+  }
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// Convert API response to RegistryConfig
+// ---------------------------------------------------------------------------
+
+function convertToRegistryConfig(packages: MetafactoryPackageListItem[]): RegistryConfig {
+  const config: RegistryConfig = {
+    registry: {
+      skills: [],
+      tools: [],
+      agents: [],
+      prompts: [],
+      components: [],
+      rules: [],
+    },
+  };
+
+  for (const pkg of packages) {
+    const { entry, artifactType } = mapApiPackageToRegistryEntry(pkg);
+    const target = artifactType === "tool" ? config.registry.tools!
+      : artifactType === "agent" ? config.registry.agents!
+      : artifactType === "prompt" ? config.registry.prompts!
+      : artifactType === "component" ? config.registry.components!
+      : config.registry.skills;
+    target.push(entry);
+  }
+
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// fetchMetafactoryRegistry
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch package list from metafactory API and return as RegistryConfig.
+ * Caches for 1 hour. Falls back to stale cache on error.
+ */
+export async function fetchMetafactoryRegistry(
+  source: RegistrySource,
+  cachePath: string,
+  forceRefresh?: boolean,
+): Promise<RegistryConfig | null> {
+  // Check cache
+  if (!forceRefresh && await isCacheFresh(cachePath, source)) {
+    const cached = await readCachedRegistry(cachePath, source);
+    if (cached) {
+      debugLog(`Using cached data for ${source.name}`);
+      return cached;
+    }
+  }
+
+  // Fetch from API (with pagination)
+  const allPackages: MetafactoryPackageListItem[] = [];
+  let page = 1;
+
+  try {
+    while (page <= MAX_PAGES) {
+      const url = `${source.url}/api/v1/packages?per_page=100&page=${page}`;
+      debugLog(`Fetching ${url} (token: ${source.token ? "***" : "none"})`);
+
+      const response = await fetch(url, {
+        headers: buildHeaders(source),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (response.status === 401) {
+        process.stderr.write(`Token expired for ${source.name}. Run arc login to re-authenticate.\n`);
+        return readCachedRegistry(cachePath, source);
+      }
+
+      if (response.status === 429) {
+        process.stderr.write(`Rate limited by ${source.name}. Try again later.\n`);
+        return readCachedRegistry(cachePath, source);
+      }
+
+      if (!response.ok) {
+        debugLog(`API error from ${source.name}: ${response.status}`);
+        return readCachedRegistry(cachePath, source);
+      }
+
+      const body = (await response.json()) as MetafactoryPackageListResponse;
+      allPackages.push(...body.packages);
+
+      // Check if there are more pages
+      if (body.packages.length < body.per_page || allPackages.length >= body.total) {
+        break;
+      }
+      page++;
+    }
+  } catch (_err) {
+    // Network error -- try stale cache
+    debugLog(`Network error for ${source.name}, trying stale cache`);
+    const stale = await readCachedRegistry(cachePath, source);
+    if (stale) return stale;
+    return null;
+  }
+
+  const config = convertToRegistryConfig(allPackages);
+  debugLog(`Fetched ${allPackages.length} packages from ${source.name}`);
+
+  // Cache the result
+  await cacheRegistry(cachePath, source, config).catch((_err) => {
+    // Cache write failure is non-fatal
+    debugLog(`Failed to cache results for ${source.name}`);
+  });
+
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// fetchMetafactoryPackageDetail
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch detailed package info from metafactory API.
+ * Used by install flow (F-4) to get versions, SHA-256, trust metadata.
+ */
+export async function fetchMetafactoryPackageDetail(
+  source: RegistrySource,
+  scope: string,
+  name: string,
+): Promise<MetafactoryPackageDetail | null> {
+  const url = `${source.url}/api/v1/packages/${scope}/${name}`;
+  debugLog(`Fetching detail: ${url}`);
+
+  try {
+    const response = await fetch(url, {
+      headers: buildHeaders(source),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (response.status === 401) {
+      process.stderr.write(`Token expired for ${source.name}. Run arc login to re-authenticate.\n`);
+      return null;
+    }
+
+    if (!response.ok) {
+      debugLog(`Package detail error: ${response.status}`);
+      return null;
+    }
+
+    return (await response.json()) as MetafactoryPackageDetail;
+  } catch (_err) {
+    // Network error
+    debugLog(`Network error fetching package detail from ${source.name}`);
+    return null;
+  }
+}

--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -44,10 +44,10 @@ export async function fetchRemoteRegistry(
   cachePath: string,
   forceRefresh?: boolean
 ): Promise<RegistryConfig | null> {
-  // metafactory API sources are handled by a dedicated client (F-3).
-  // Skip gracefully here so arc search/update don't choke on HTML responses.
+  // metafactory API sources use the dedicated API client
   if (source.type === "metafactory") {
-    return null;
+    const { fetchMetafactoryRegistry } = await import("./metafactory-api.js");
+    return fetchMetafactoryRegistry(source, cachePath, forceRefresh);
   }
 
   // Local file source — read directly, no caching

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,14 +303,6 @@ export interface MetafactoryPackageListResponse {
   per_page: number;
 }
 
-/** Version info from metafactory API */
-export interface MetafactoryVersionInfo {
-  version: string;
-  sha256: string;
-  size_bytes: number;
-  published_by: { id: string; display_name: string | null };
-  created_at: number;
-}
 
 /** Detailed package info from metafactory API */
 export interface MetafactoryPackageDetail {

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,6 +277,62 @@ export interface DeviceAuthResult {
   errorCode?: "expired" | "denied" | "timeout" | "network" | "no_source" | "wrong_type";
 }
 
+/** Package summary from metafactory API list endpoint */
+export interface MetafactoryPackageListItem {
+  namespace: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  type: string;
+  license: string;
+  latest_version: string | null;
+  publisher: {
+    display_name: string | null;
+    tier: string | null;
+    mfa_enabled: boolean;
+  };
+  created_at: number;
+  updated_at: number;
+}
+
+/** Paginated list response from metafactory API */
+export interface MetafactoryPackageListResponse {
+  packages: MetafactoryPackageListItem[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+/** Version info from metafactory API */
+export interface MetafactoryVersionInfo {
+  version: string;
+  sha256: string;
+  size_bytes: number;
+  published_by: { id: string; display_name: string | null };
+  created_at: number;
+}
+
+/** Detailed package info from metafactory API */
+export interface MetafactoryPackageDetail {
+  namespace: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  type: string;
+  license: string;
+  latest_version: string | null;
+  versions: string[];
+  publisher: {
+    display_name: string | null;
+    tier: string | null;
+    mfa_enabled: boolean;
+    github_username: string | null;
+  };
+  sponsor: { display_name: string; tier: string; github_username: string | null } | null;
+  created_at: number;
+  updated_at: number;
+}
+
 /** A search result annotated with its source */
 export interface SourcedSearchResult {
   entry: RegistryEntry;

--- a/test/unit/metafactory-api.test.ts
+++ b/test/unit/metafactory-api.test.ts
@@ -1,0 +1,286 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import {
+  mapApiPackageToRegistryEntry,
+  fetchMetafactoryRegistry,
+  fetchMetafactoryPackageDetail,
+} from "../../src/lib/metafactory-api.js";
+import type {
+  MetafactoryPackageListItem,
+  MetafactoryPackageListResponse,
+  RegistrySource,
+} from "../../src/types.js";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Mapping tests (T-5.1)
+// ---------------------------------------------------------------------------
+
+function sampleApiPackage(overrides?: Partial<MetafactoryPackageListItem>): MetafactoryPackageListItem {
+  return {
+    namespace: "@mellanon",
+    name: "research",
+    display_name: "Research",
+    description: "Multi-agent parallel research",
+    type: "skill",
+    license: "MIT",
+    latest_version: "1.2.0",
+    publisher: { display_name: "Andreas", tier: "trusted", mfa_enabled: true },
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    ...overrides,
+  };
+}
+
+describe("mapApiPackageToRegistryEntry", () => {
+  test("maps all fields correctly", () => {
+    const { entry, artifactType } = mapApiPackageToRegistryEntry(sampleApiPackage());
+    expect(entry.name).toBe("@mellanon/research");
+    expect(entry.description).toBe("Multi-agent parallel research");
+    expect(entry.author).toBe("Andreas");
+    expect(entry.version).toBe("1.2.0");
+    expect(entry.status).toBe("shipped");
+    expect(artifactType).toBe("skill");
+  });
+
+  test("handles missing optional fields", () => {
+    const { entry } = mapApiPackageToRegistryEntry(sampleApiPackage({
+      description: null,
+      latest_version: null,
+      publisher: { display_name: null, tier: null, mfa_enabled: false },
+    }));
+    expect(entry.description).toBe("");
+    expect(entry.version).toBe("0.0.0");
+    expect(entry.author).toBe("unknown");
+  });
+
+  test("maps tool type correctly", () => {
+    const { artifactType } = mapApiPackageToRegistryEntry(sampleApiPackage({ type: "tool" }));
+    expect(artifactType).toBe("tool");
+  });
+
+  test("maps agent type correctly", () => {
+    const { artifactType } = mapApiPackageToRegistryEntry(sampleApiPackage({ type: "agent" }));
+    expect(artifactType).toBe("agent");
+  });
+
+  test("maps prompt type correctly", () => {
+    const { artifactType } = mapApiPackageToRegistryEntry(sampleApiPackage({ type: "prompt" }));
+    expect(artifactType).toBe("prompt");
+  });
+
+  test("maps unknown type to skill", () => {
+    const { artifactType } = mapApiPackageToRegistryEntry(sampleApiPackage({ type: "unknown-future-type" }));
+    expect(artifactType).toBe("skill");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchMetafactoryRegistry tests (T-5.2 + T-5.4)
+// ---------------------------------------------------------------------------
+
+function metafactorySource(token?: string): RegistrySource {
+  return {
+    name: "mf-test",
+    url: "https://meta-factory.test",
+    tier: "official",
+    enabled: true,
+    type: "metafactory",
+    ...(token ? { token } : {}),
+  };
+}
+
+function mockFetchResponse(packages: MetafactoryPackageListItem[], total?: number): Response {
+  const body: MetafactoryPackageListResponse = {
+    packages,
+    total: total ?? packages.length,
+    page: 1,
+    per_page: 100,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Create a fetch mock that satisfies Bun's typeof fetch (includes preconnect) */
+function mockFetch(handler: (input: any, init?: any) => Promise<Response>): typeof fetch {
+  const fn = handler as typeof fetch;
+  (fn as any).preconnect = () => {};
+  return fn;
+}
+
+describe("fetchMetafactoryRegistry", () => {
+  test("returns RegistryConfig from API response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => mockFetchResponse([sampleApiPackage()]));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath);
+      expect(result).not.toBeNull();
+      expect(result!.registry.skills.length).toBe(1);
+      expect(result!.registry.skills[0].name).toBe("@mellanon/research");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("sends Authorization header when token present", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      capturedHeaders = new Headers(init?.headers);
+      return mockFetchResponse([]);
+    });
+
+    try {
+      await fetchMetafactoryRegistry(metafactorySource("my-secret-token"), env.paths.cachePath, true);
+      expect(capturedHeaders?.get("Authorization")).toBe("Bearer my-secret-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not send Authorization when no token", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      capturedHeaders = new Headers(init?.headers);
+      return mockFetchResponse([]);
+    });
+
+    try {
+      await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(capturedHeaders?.get("Authorization")).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on API error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Internal Server Error", { status: 500 }));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on network error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => { throw new Error("ECONNREFUSED"); });
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("caches result and reads from cache", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCount = 0;
+    globalThis.fetch = mockFetch(async () => {
+      fetchCount++;
+      return mockFetchResponse([sampleApiPackage()]);
+    });
+
+    try {
+      // First call fetches
+      const result1 = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result1).not.toBeNull();
+      expect(fetchCount).toBe(1);
+
+      // Second call uses cache (not forceRefresh)
+      const result2 = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath);
+      expect(result2).not.toBeNull();
+      expect(fetchCount).toBe(1); // no additional fetch
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("places tools in registry.tools", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => mockFetchResponse([sampleApiPackage({ type: "tool" })]));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result!.registry.tools.length).toBe(1);
+      expect(result!.registry.skills.length).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchMetafactoryPackageDetail tests (T-5.2 extension)
+// ---------------------------------------------------------------------------
+
+describe("fetchMetafactoryPackageDetail", () => {
+  test("returns parsed detail on success", async () => {
+    const detail = {
+      namespace: "@mellanon",
+      name: "research",
+      display_name: "Research",
+      description: "Multi-agent research",
+      type: "skill",
+      license: "MIT",
+      latest_version: "1.2.0",
+      versions: ["1.2.0", "1.1.0"],
+      publisher: { display_name: "Andreas", tier: "trusted", mfa_enabled: true, github_username: "mellanon" },
+      sponsor: null,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(JSON.stringify(detail), { status: 200 }));
+
+    try {
+      const result = await fetchMetafactoryPackageDetail(metafactorySource(), "@mellanon", "research");
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("research");
+      expect(result!.versions).toEqual(["1.2.0", "1.1.0"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on 404", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response('{"error":"Not found"}', { status: 404 }));
+
+    try {
+      const result = await fetchMetafactoryPackageDetail(metafactorySource(), "@mellanon", "nonexistent");
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on network error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => { throw new Error("ECONNREFUSED"); });
+
+    try {
+      const result = await fetchMetafactoryPackageDetail(metafactorySource(), "@mellanon", "research");
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/test/unit/metafactory-api.test.ts
+++ b/test/unit/metafactory-api.test.ts
@@ -225,6 +225,43 @@ describe("fetchMetafactoryRegistry", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("returns null and logs on 401 (token expired)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Unauthorized", { status: 401 }));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource("expired-token"), env.paths.cachePath, true);
+      // Returns null (or stale cache) -- not a crash
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on 429 (rate limited)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Too Many Requests", { status: 429 }));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null on invalid JSON response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("<html>not json</html>", { status: 200 }));
+
+    try {
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `src/lib/metafactory-api.ts` -- HTTP client for metafactory registry API
- `fetchMetafactoryRegistry`: paginated package list fetch with 1h cache
- `fetchMetafactoryPackageDetail`: version info with SHA-256 for install flow (F-4 prep)
- `mapApiPackageToRegistryEntry`: API response to RegistryEntry conversion
- Integration: `remote-registry.ts` delegates to API client for type:metafactory sources
- Bearer token auth when available, token never logged (masked as ***)

## Key behaviors
- Graceful degradation: API errors return null, other sources keep working
- Stale cache fallback on network errors
- 401: logs "Token expired. Run arc login to re-authenticate."
- 429: logs "Rate limited. Try again later."
- Pagination: up to 5 pages of 100 packages each

## Tests
16 new tests. Full suite: **349/349 passing**.

| Group | Tests | Covers |
|-------|-------|--------|
| Mapping | 6 | Field mapping, missing fields, type mapping |
| Fetch | 7 | Success, auth headers, caching, API error, network error |
| Detail | 3 | Success, 404, network error |

## SpecFlow
F-3 of A-401 series. Depends on F-1 + F-2 (both merged).

@the-metafactory/luna -- requesting review

Generated with [Claude Code](https://claude.com/claude-code)