### PR TITLE
feat: add registry install path with SHA-256 verification (A-401 F-4)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,14 @@ import {
 import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
+import {
+  parsePackageRef,
+  formatPackageRef,
+  resolveFromRegistry,
+  downloadPackage,
+  verifyChecksum,
+  extractPackage,
+} from "./lib/registry-install.js";
 import { loadCatalog, saveCatalog, findEntry } from "./lib/catalog.js";
 import {
   loadSources,
@@ -74,17 +82,20 @@ program
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);
 
+    // Check if input is a registry package ref (@scope/name[@version])
+    const pkgRef = parsePackageRef(nameOrUrl);
+
     // Parse library:artifact colon syntax (only for non-URL names)
     const isUrl =
-      nameOrUrl.includes("/") ||
       nameOrUrl.startsWith("git@") ||
-      nameOrUrl.startsWith("http");
+      nameOrUrl.startsWith("http") ||
+      nameOrUrl.startsWith("file://");
 
     let libraryName: string | undefined;
     let artifactName: string | undefined;
     let lookupName = nameOrUrl;
 
-    if (!isUrl) {
+    if (!isUrl && !pkgRef) {
       const libRef = parseLibraryRef(nameOrUrl);
       if (libRef?.artifactName) {
         libraryName = libRef.libraryName;
@@ -93,7 +104,62 @@ program
       }
     }
 
-    if (isUrl) {
+    if (pkgRef) {
+      // Registry install: @scope/name[@version] → download from metafactory API
+      const sources = await loadSources(paths.sourcesPath);
+      const resolved = await resolveFromRegistry(pkgRef, sources.sources);
+
+      if (!resolved) {
+        console.error(`Package "${formatPackageRef(pkgRef)}" not found in any metafactory registry.`);
+        console.error(`Try: arc search ${pkgRef.name}`);
+        process.exit(1);
+      }
+
+      console.log(`Found ${formatPackageRef(pkgRef)} v${resolved.version} in ${resolved.source.name} [${resolved.source.tier}]`);
+
+      // Download
+      console.log(`Downloading...`);
+      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir, resolved.source.token);
+      if (!download.success || !download.tempPath) {
+        console.error(`${download.error}`);
+        process.exit(1);
+      }
+      console.log(`Downloaded ${(download.bytesDownloaded! / 1024).toFixed(0)} KB`);
+
+      // Verify SHA-256
+      const verify = await verifyChecksum(download.tempPath, resolved.sha256);
+      if (!verify.valid) {
+        console.error(`Checksum verification failed!`);
+        console.error(`  Expected: ${verify.expected}`);
+        console.error(`  Actual:   ${verify.actual}`);
+        console.error(`This could indicate a corrupted download or compromised package.`);
+        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        process.exit(1);
+      }
+      console.log(`SHA-256 verified`);
+
+      // Extract
+      const packageDir = `${resolved.scope}__${resolved.name}`;
+      const extract = await extractPackage(download.tempPath, paths.reposDir, packageDir);
+      if (!extract.success) {
+        console.error(`${extract.error}`);
+        process.exit(1);
+      }
+
+      // Continue with standard install flow (manifest, symlinks, hooks, DB)
+      const result = await install({
+        paths,
+        db,
+        repoUrl: formatPackageRef({ scope: resolved.scope, name: resolved.name, version: resolved.version }),
+        yes: opts.yes,
+      });
+      if (result.success) {
+        console.log(`Installed ${result.name} v${result.version} (verified)`);
+      } else {
+        console.error(`${result.error}`);
+        process.exit(1);
+      }
+    } else if (isUrl) {
       // Direct git install
       const result = await install({ paths, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName });
       if (result.success) {
@@ -112,7 +178,7 @@ program
       const found = await findInAllSources(sources, lookupName, paths.cachePath);
 
       if (!found) {
-        console.error(`❌ "${lookupName}" not found in any source. Try: arc search <keyword>`);
+        console.error(`"${lookupName}" not found in any source. Try: arc search <keyword>`);
         process.exit(1);
       }
 
@@ -136,7 +202,7 @@ program
           console.log(`✅ Installed ${result.name} v${result.version}`);
         }
       } else {
-        console.error(`❌ ${result.error}`);
+        console.error(`${result.error}`);
         process.exit(1);
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,12 +146,16 @@ program
         process.exit(1);
       }
 
-      // Continue with standard install flow (manifest, symlinks, hooks, DB)
+      // Continue with standard install flow (manifest, symlinks, hooks, DB).
+      // Use preExtractedPath so install() skips git clone.
       const result = await install({
         paths,
         db,
         repoUrl: formatPackageRef({ scope: resolved.scope, name: resolved.name, version: resolved.version }),
         yes: opts.yes,
+        preExtractedPath: extract.extractedPath,
+        sourceName: resolved.source.name,
+        sourceTier: resolved.source.tier,
       });
       if (result.success) {
         console.log(`Installed ${result.name} v${result.version} (verified)`);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -26,6 +26,11 @@ export interface InstallOptions {
   artifactName?: string;
   /** When installing from a library, the library name (for DB tracking) */
   libraryName?: string;
+  /**
+   * Pre-extracted install path (for registry installs from F-4).
+   * When provided, skips git clone and uses this directory as the source.
+   */
+  preExtractedPath?: string;
 }
 
 export interface InstallResult {
@@ -53,9 +58,11 @@ export interface InstallResult {
 export async function install(opts: InstallOptions): Promise<InstallResult> {
   const { paths, db, repoUrl } = opts;
 
-  // 1. Clone repo
-  const repoName = extractRepoName(repoUrl);
-  const installPath = join(paths.reposDir, repoName);
+  // 1. Clone repo (or use pre-extracted path for registry installs)
+  const repoName = opts.preExtractedPath
+    ? opts.preExtractedPath.split("/").pop() ?? extractRepoName(repoUrl)
+    : extractRepoName(repoUrl);
+  const installPath = opts.preExtractedPath ?? join(paths.reposDir, repoName);
 
   // S2: Path traversal guard — ensure installPath stays inside reposDir
   const normalizedInstall = join(installPath); // resolves ../ segments
@@ -101,8 +108,8 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     }
   }
 
-  // Only clone if not already present (library repos may already be cloned)
-  if (!existsSync(installPath)) {
+  // Only clone if not already present and no pre-extracted path (registry installs skip git)
+  if (!existsSync(installPath) && !opts.preExtractedPath) {
     const cloneResult = Bun.spawnSync(["git", "clone", repoUrl, installPath], {
       stdout: "pipe",
       stderr: "pipe",

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -1,0 +1,244 @@
+import { join } from "path";
+import { existsSync } from "fs";
+import { writeFile, unlink, mkdir } from "fs/promises";
+import type {
+  PackageRef,
+  VerifyResult,
+  RegistrySource,
+} from "../types.js";
+import { getSourceType } from "./sources.js";
+import { fetchMetafactoryPackageDetail } from "./metafactory-api.js";
+
+// ---------------------------------------------------------------------------
+// Package reference parsing
+// ---------------------------------------------------------------------------
+
+const PACKAGE_REF_RE = /^@?([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)(?:@(.+))?$/;
+
+/** Parse @scope/name[@version] from CLI input. Returns null for URLs/paths. */
+export function parsePackageRef(input: string): PackageRef | null {
+  // Skip URLs and local paths
+  if (input.startsWith("http") || input.startsWith("git@") || input.startsWith("file://")) return null;
+  if (input.startsWith("./") || input.startsWith("/") || input.startsWith("~")) return null;
+
+  const match = input.match(PACKAGE_REF_RE);
+  if (!match) return null;
+
+  return {
+    scope: match[1]!,
+    name: match[2]!,
+    version: match[3] || undefined,
+  };
+}
+
+/** Format a PackageRef as @scope/name[@version] */
+export function formatPackageRef(ref: PackageRef): string {
+  const base = `@${ref.scope}/${ref.name}`;
+  return ref.version ? `${base}@${ref.version}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Registry resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolvedRegistryPackage {
+  scope: string;
+  name: string;
+  version: string;
+  sha256: string;
+  downloadUrl: string;
+  source: RegistrySource;
+}
+
+/** Resolve a package from metafactory registry sources */
+export async function resolveFromRegistry(
+  ref: PackageRef,
+  sources: RegistrySource[],
+): Promise<ResolvedRegistryPackage | null> {
+  const mfSources = sources.filter((s) => getSourceType(s) === "metafactory");
+  if (!mfSources.length) return null;
+
+  for (const source of mfSources) {
+    const detail = await fetchMetafactoryPackageDetail(source, `@${ref.scope}`, ref.name);
+    if (!detail) continue;
+
+    // Resolve version
+    const targetVersion = ref.version ?? detail.latest_version;
+    if (!targetVersion) continue;
+
+    // Fetch version detail to get SHA-256
+    const versionDetailUrl = `${source.url}/api/v1/packages/@${ref.scope}/${ref.name}/versions`;
+    try {
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (source.token) headers.Authorization = `Bearer ${source.token}`;
+
+      const resp = await fetch(versionDetailUrl, {
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!resp.ok) continue;
+
+      const body = (await resp.json()) as {
+        versions: Array<{ version: string; sha256: string }>;
+      };
+
+      const versionEntry = body.versions.find((v) => v.version === targetVersion);
+      if (!versionEntry) continue;
+
+      const downloadUrl = `${source.url}/api/v1/storage/download/${versionEntry.sha256}`;
+
+      return {
+        scope: ref.scope,
+        name: ref.name,
+        version: targetVersion,
+        sha256: versionEntry.sha256,
+        downloadUrl,
+        source,
+      };
+    } catch (_err) {
+      // Network error, try next source
+      continue;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+export interface DownloadResult {
+  success: boolean;
+  tempPath?: string;
+  bytesDownloaded?: number;
+  error?: string;
+}
+
+/** Download a package tarball from the storage endpoint */
+export async function downloadPackage(
+  url: string,
+  tempDir: string,
+  token?: string,
+): Promise<DownloadResult> {
+  const tempPath = join(tempDir, `arc-download-${Date.now()}.tar.gz`);
+
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  let lastError: string | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(60_000),
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        return { success: false, error: "Access denied. Run \"arc login\" to authenticate." };
+      }
+      if (response.status === 404) {
+        return { success: false, error: "Package artifact not found at storage endpoint." };
+      }
+      if (!response.ok) {
+        lastError = `Download failed: HTTP ${response.status}`;
+        continue;
+      }
+
+      const buffer = await response.arrayBuffer();
+      await writeFile(tempPath, Buffer.from(buffer));
+
+      return {
+        success: true,
+        tempPath,
+        bytesDownloaded: buffer.byteLength,
+      };
+    } catch (_err) {
+      lastError = "Download failed: network error. Check your connection and try again.";
+    }
+  }
+
+  return { success: false, error: lastError };
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 verification
+// ---------------------------------------------------------------------------
+
+/** Verify SHA-256 checksum of a downloaded file */
+export async function verifyChecksum(
+  filePath: string,
+  expectedSha256: string,
+): Promise<VerifyResult> {
+  const file = Bun.file(filePath);
+  const buffer = await file.arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buffer);
+  const actual = hasher.digest("hex");
+
+  return {
+    valid: actual === expectedSha256.toLowerCase(),
+    expected: expectedSha256.toLowerCase(),
+    actual,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+export interface ExtractResult {
+  success: boolean;
+  extractedPath: string;
+  error?: string;
+}
+
+/** Extract a tarball to the repos directory */
+export async function extractPackage(
+  tarballPath: string,
+  reposDir: string,
+  packageName: string,
+): Promise<ExtractResult> {
+  const extractedPath = join(reposDir, packageName);
+
+  if (!existsSync(reposDir)) {
+    await mkdir(reposDir, { recursive: true });
+  }
+
+  // Create target directory
+  await mkdir(extractedPath, { recursive: true });
+
+  const result = Bun.spawnSync(
+    ["tar", "xzf", tarballPath, "-C", extractedPath, "--strip-components=1"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  if (result.exitCode !== 0) {
+    // Clean up partial extraction
+    Bun.spawnSync(["rm", "-rf", extractedPath], { stdout: "pipe", stderr: "pipe" });
+    return {
+      success: false,
+      extractedPath,
+      error: `Extraction failed: ${result.stderr.toString().trim()}`,
+    };
+  }
+
+  // Clean up tarball
+  await unlink(tarballPath).catch(() => {});
+
+  // Verify manifest exists
+  const hasManifest = existsSync(join(extractedPath, "arc-manifest.yaml")) ||
+    existsSync(join(extractedPath, "pai-manifest.yaml"));
+
+  if (!hasManifest) {
+    Bun.spawnSync(["rm", "-rf", extractedPath], { stdout: "pipe", stderr: "pipe" });
+    return {
+      success: false,
+      extractedPath,
+      error: "Package archive does not contain arc-manifest.yaml. Invalid package format.",
+    };
+  }
+
+  return { success: true, extractedPath };
+}

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -13,7 +13,7 @@ import { fetchMetafactoryPackageDetail } from "./metafactory-api.js";
 // Package reference parsing
 // ---------------------------------------------------------------------------
 
-const PACKAGE_REF_RE = /^@?([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)(?:@(.+))?$/;
+const PACKAGE_REF_RE = /^@?([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)(?:@([^@]+))?$/;
 
 /** Parse @scope/name[@version] from CLI input. Returns null for URLs/paths. */
 export function parsePackageRef(input: string): PackageRef | null {
@@ -67,7 +67,7 @@ export async function resolveFromRegistry(
     if (!targetVersion) continue;
 
     // Fetch version detail to get SHA-256
-    const versionDetailUrl = `${source.url}/api/v1/packages/@${ref.scope}/${ref.name}/versions`;
+    const versionDetailUrl = `${source.url}/api/v1/packages/${encodeURIComponent(`@${ref.scope}`)}/${encodeURIComponent(ref.name)}/versions`;
     try {
       const headers: Record<string, string> = { Accept: "application/json" };
       if (source.token) headers.Authorization = `Bearer ${source.token}`;
@@ -224,8 +224,8 @@ export async function extractPackage(
     };
   }
 
-  // Clean up tarball
-  await unlink(tarballPath).catch(() => {});
+  // Clean up tarball -- cleanup failure is non-fatal
+  await unlink(tarballPath).catch((_err) => {});
 
   // Verify manifest exists
   const hasManifest = existsSync(join(extractedPath, "arc-manifest.yaml")) ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,20 @@ export interface SourcedSearchResult {
   sourceTier: PackageTier;
 }
 
+/** Parsed package reference from CLI input */
+export interface PackageRef {
+  scope: string;
+  name: string;
+  version?: string;
+}
+
+/** SHA-256 verification result */
+export interface VerifyResult {
+  valid: boolean;
+  expected: string;
+  actual: string;
+}
+
 /** Installed package record in packages.db (skills and tools) */
 export interface InstalledSkill {
   name: string;

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { join } from "path";
+import { writeFile } from "fs/promises";
+import {
+  parsePackageRef,
+  formatPackageRef,
+  verifyChecksum,
+  extractPackage,
+} from "../../src/lib/registry-install.js";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// parsePackageRef tests
+// ---------------------------------------------------------------------------
+
+describe("parsePackageRef", () => {
+  test("parses @scope/name", () => {
+    const ref = parsePackageRef("@metafactory/grove");
+    expect(ref).toEqual({ scope: "metafactory", name: "grove", version: undefined });
+  });
+
+  test("parses @scope/name@version", () => {
+    const ref = parsePackageRef("@metafactory/grove@1.2.3");
+    expect(ref).toEqual({ scope: "metafactory", name: "grove", version: "1.2.3" });
+  });
+
+  test("parses scope/name without @", () => {
+    const ref = parsePackageRef("metafactory/grove");
+    expect(ref).toEqual({ scope: "metafactory", name: "grove", version: undefined });
+  });
+
+  test("returns null for git URLs", () => {
+    expect(parsePackageRef("https://github.com/org/repo")).toBeNull();
+    expect(parsePackageRef("git@github.com:org/repo")).toBeNull();
+    expect(parsePackageRef("http://example.com/repo")).toBeNull();
+  });
+
+  test("returns null for local paths", () => {
+    expect(parsePackageRef("./local/path")).toBeNull();
+    expect(parsePackageRef("/absolute/path")).toBeNull();
+    expect(parsePackageRef("~/home/path")).toBeNull();
+  });
+
+  test("returns null for simple names without scope", () => {
+    expect(parsePackageRef("grove")).toBeNull();
+    expect(parsePackageRef("my-skill")).toBeNull();
+  });
+});
+
+describe("formatPackageRef", () => {
+  test("formats without version", () => {
+    expect(formatPackageRef({ scope: "mf", name: "grove" })).toBe("@mf/grove");
+  });
+
+  test("formats with version", () => {
+    expect(formatPackageRef({ scope: "mf", name: "grove", version: "1.0.0" })).toBe("@mf/grove@1.0.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyChecksum tests
+// ---------------------------------------------------------------------------
+
+describe("verifyChecksum", () => {
+  test("returns valid for matching hash", async () => {
+    const content = "test package content";
+    const filePath = join(env.paths.reposDir, "test-verify.bin");
+    await writeFile(filePath, content);
+
+    // Compute expected hash
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(content);
+    const expectedHash = hasher.digest("hex");
+
+    const result = await verifyChecksum(filePath, expectedHash);
+    expect(result.valid).toBe(true);
+    expect(result.actual).toBe(expectedHash);
+    expect(result.expected).toBe(expectedHash);
+  });
+
+  test("returns invalid for mismatched hash", async () => {
+    const filePath = join(env.paths.reposDir, "test-bad.bin");
+    await writeFile(filePath, "actual content");
+
+    const result = await verifyChecksum(filePath, "0000000000000000000000000000000000000000000000000000000000000000");
+    expect(result.valid).toBe(false);
+    expect(result.expected).toBe("0000000000000000000000000000000000000000000000000000000000000000");
+    expect(result.actual).not.toBe(result.expected);
+  });
+
+  test("handles case-insensitive comparison", async () => {
+    const content = "case test";
+    const filePath = join(env.paths.reposDir, "test-case.bin");
+    await writeFile(filePath, content);
+
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(content);
+    const hash = hasher.digest("hex");
+
+    const result = await verifyChecksum(filePath, hash.toUpperCase());
+    expect(result.valid).toBe(true);
+  });
+
+  test("empty file has deterministic hash", async () => {
+    const filePath = join(env.paths.reposDir, "test-empty.bin");
+    await writeFile(filePath, "");
+
+    const result = await verifyChecksum(filePath, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractPackage tests
+// ---------------------------------------------------------------------------
+
+describe("extractPackage", () => {
+  test("fails on invalid tarball", async () => {
+    const badTarball = join(env.paths.reposDir, "bad.tar.gz");
+    await writeFile(badTarball, "this is not a tarball");
+
+    const result = await extractPackage(badTarball, env.paths.reposDir, "test-pkg");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Extraction failed");
+  });
+});

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -7,7 +7,27 @@ import {
   formatPackageRef,
   verifyChecksum,
   extractPackage,
+  resolveFromRegistry,
+  downloadPackage,
 } from "../../src/lib/registry-install.js";
+import type { RegistrySource } from "../../src/types.js";
+
+function mockFetch(handler: (input: any, init?: any) => Promise<Response>): typeof fetch {
+  const fn = handler as typeof fetch;
+  (fn as any).preconnect = () => {};
+  return fn;
+}
+
+function metafactorySource(token?: string): RegistrySource {
+  return {
+    name: "mf-test",
+    url: "https://meta-factory.test",
+    tier: "official",
+    enabled: true,
+    type: "metafactory",
+    ...(token ? { token } : {}),
+  };
+}
 
 let env: TestEnv;
 
@@ -54,6 +74,11 @@ describe("parsePackageRef", () => {
   test("returns null for simple names without scope", () => {
     expect(parsePackageRef("grove")).toBeNull();
     expect(parsePackageRef("my-skill")).toBeNull();
+  });
+
+  test("rejects ambiguous multi-@ version", () => {
+    // @scope/name@version@evil should not parse as valid
+    expect(parsePackageRef("@scope/name@1.0.0@evil")).toBeNull();
   });
 });
 
@@ -132,5 +157,187 @@ describe("extractPackage", () => {
     const result = await extractPackage(badTarball, env.paths.reposDir, "test-pkg");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Extraction failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFromRegistry tests
+// ---------------------------------------------------------------------------
+
+describe("resolveFromRegistry", () => {
+  test("returns null when no metafactory sources configured", async () => {
+    const result = await resolveFromRegistry(
+      { scope: "foo", name: "bar" },
+      [{ name: "reg", url: "https://example.com/R.yaml", tier: "community", enabled: true }],
+    );
+    expect(result).toBeNull();
+  });
+
+  test("resolves package with latest version", async () => {
+    const originalFetch = globalThis.fetch;
+    let callCount = 0;
+    globalThis.fetch = mockFetch(async (input: any) => {
+      callCount++;
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/versions")) {
+        return new Response(JSON.stringify({
+          versions: [{ version: "1.2.0", sha256: "abc123" }, { version: "1.1.0", sha256: "def456" }],
+        }), { status: 200 });
+      }
+      // Package detail endpoint
+      return new Response(JSON.stringify({
+        namespace: "@metafactory",
+        name: "grove",
+        display_name: null,
+        description: "",
+        type: "tool",
+        license: "MIT",
+        latest_version: "1.2.0",
+        versions: ["1.2.0", "1.1.0"],
+        publisher: { display_name: "Test", tier: "official", mfa_enabled: true, github_username: null },
+        sponsor: null,
+        created_at: 0,
+        updated_at: 0,
+      }), { status: 200 });
+    });
+
+    try {
+      const result = await resolveFromRegistry(
+        { scope: "metafactory", name: "grove" },
+        [metafactorySource()],
+      );
+      expect(result).not.toBeNull();
+      expect(result!.version).toBe("1.2.0");
+      expect(result!.sha256).toBe("abc123");
+      expect(result!.downloadUrl).toContain("/api/v1/storage/download/abc123");
+      expect(callCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("resolves specific version when provided", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/versions")) {
+        return new Response(JSON.stringify({
+          versions: [{ version: "1.2.0", sha256: "abc" }, { version: "1.1.0", sha256: "def" }],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        namespace: "@metafactory", name: "grove",
+        display_name: null, description: "", type: "tool", license: "MIT",
+        latest_version: "1.2.0", versions: ["1.2.0", "1.1.0"],
+        publisher: { display_name: "Test", tier: "official", mfa_enabled: true, github_username: null },
+        sponsor: null, created_at: 0, updated_at: 0,
+      }), { status: 200 });
+    });
+
+    try {
+      const result = await resolveFromRegistry(
+        { scope: "metafactory", name: "grove", version: "1.1.0" },
+        [metafactorySource()],
+      );
+      expect(result!.version).toBe("1.1.0");
+      expect(result!.sha256).toBe("def");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns null when package not found", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Not found", { status: 404 }));
+
+    try {
+      const result = await resolveFromRegistry(
+        { scope: "nobody", name: "nothing" },
+        [metafactorySource()],
+      );
+      expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadPackage tests
+// ---------------------------------------------------------------------------
+
+describe("downloadPackage", () => {
+  test("downloads successfully and writes to temp", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(new ArrayBuffer(1024), { status: 200 }));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(true);
+      expect(result.bytesDownloaded).toBe(1024);
+      expect(result.tempPath).toBeDefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("sends Bearer token when provided", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedAuth: string | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      capturedAuth = new Headers(init?.headers).get("Authorization") ?? undefined;
+      return new Response(new ArrayBuffer(10), { status: 200 });
+    });
+
+    try {
+      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir, "my-token");
+      expect(capturedAuth).toBe("Bearer my-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns error on 401", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Unauthorized", { status: 401 }));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("arc login");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns error on 404", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Not found", { status: 404 }));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not found");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("retries once on network error then fails", async () => {
+    const originalFetch = globalThis.fetch;
+    let attempts = 0;
+    globalThis.fetch = mockFetch(async () => {
+      attempts++;
+      throw new Error("ECONNREFUSED");
+    });
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(attempts).toBe(2); // original + 1 retry
+      expect(result.error).toContain("network");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `arc install @scope/name[@version]` -- new registry install path
- Downloads tarball from metafactory storage endpoint, verifies SHA-256, extracts, installs
- Three-way CLI routing: package ref -> registry / URL -> git clone / simple name -> source lookup
- Backward compatible: existing git URL and simple name installs unchanged

## New library: src/lib/registry-install.ts
- `parsePackageRef` / `formatPackageRef` -- @scope/name[@version] handling
- `resolveFromRegistry` -- version + SHA-256 lookup via F-3 API client
- `downloadPackage` -- Bearer auth, 60s timeout, single retry
- `verifyChecksum` -- mandatory SHA-256, no bypass
- `extractPackage` -- tar extraction, manifest validation, cleanup on failure

## Security
- SHA-256 verification is mandatory for registry installs
- Checksum mismatch: abort + clear security warning
- Bearer tokens never logged
- Partial downloads cleaned up on failure

## Tests
13 new tests. Full suite: **365/365 passing**.

| Group | Tests | Covers |
|-------|-------|--------|
| parsePackageRef | 6 | Valid formats, null for URLs/paths/simple names |
| formatPackageRef | 2 | With/without version |
| verifyChecksum | 4 | Match, mismatch, case-insensitive, empty file |
| extractPackage | 1 | Invalid tarball rejection |

## SpecFlow
F-4 of A-401 series. Depends on F-1, F-2, F-3 (all merged).

F-5 (search across sources) is the final feature in this series.

@the-metafactory/luna -- requesting review

Generated with [Claude Code](https://claude.com/claude-code)