### PR TITLE
feat: add search-across-sources with filters, JSON, warnings (A-401 F-5)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,10 +63,8 @@ import {
   validateSource,
 } from "./lib/sources.js";
 import {
-  searchAllSources,
   findInAllSources,
   updateAllSources,
-  formatSourcedSearch,
 } from "./lib/remote-registry.js";
 import { homedir } from "os";
 import { join } from "path";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,14 @@ import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceTyp
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
 import {
+  searchAcrossSources,
+  formatSearch,
+  formatSearchJson,
+  formatWarnings,
+  parseArtifactType,
+  parsePackageTier,
+} from "./commands/search.js";
+import {
   parsePackageRef,
   formatPackageRef,
   resolveFromRegistry,
@@ -545,11 +553,46 @@ program
 program
   .command("search [keyword]")
   .description("Search all configured sources (omit keyword to list all)")
-  .action(async (keyword?: string) => {
+  .option("--json", "Output as JSON for machine consumption")
+  .option("--type <type>", "Filter by artifact type (skill, tool, agent, prompt, component, pipeline, action)")
+  .option("--tier <tier>", "Filter by source tier (official, community, custom)")
+  .action(async (keyword: string | undefined, opts: { json?: boolean; type?: string; tier?: string }) => {
     const paths = createPaths();
     const sources = await loadSources(paths.sourcesPath);
-    const results = await searchAllSources(sources, keyword ?? "", paths.cachePath);
-    console.log(formatSourcedSearch(results));
+
+    // Validate filters
+    let typeFilter;
+    if (opts.type) {
+      typeFilter = parseArtifactType(opts.type);
+      if (!typeFilter) {
+        console.error(`Error: invalid --type "${opts.type}". Valid: skill, tool, agent, prompt, component, pipeline, action`);
+        process.exit(1);
+      }
+    }
+    let tierFilter;
+    if (opts.tier) {
+      tierFilter = parsePackageTier(opts.tier);
+      if (!tierFilter) {
+        console.error(`Error: invalid --tier "${opts.tier}". Valid: official, community, custom`);
+        process.exit(1);
+      }
+    }
+
+    const result = await searchAcrossSources(sources, paths.cachePath, {
+      keyword,
+      type: typeFilter,
+      tier: tierFilter,
+    });
+
+    // Emit warnings to stderr
+    const warnings = formatWarnings(result);
+    if (warnings) console.error(warnings);
+
+    if (opts.json) {
+      console.log(formatSearchJson(result));
+    } else {
+      console.log(formatSearch(result));
+    }
   });
 
 // ── Source commands ─────────────────────────────────────────

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,168 @@
+import type {
+  SearchOptions,
+  SearchResult,
+  SourcesConfig,
+  SourcedSearchResult,
+  ArtifactType,
+  PackageTier,
+} from "../types.js";
+import { fetchRemoteRegistry } from "../lib/remote-registry.js";
+import { searchRegistry } from "../lib/registry.js";
+
+/**
+ * Search across all enabled sources and return results with metadata.
+ * Captures per-source success/failure for actionable warnings.
+ */
+export async function searchAcrossSources(
+  sources: SourcesConfig,
+  cachePath: string,
+  opts?: SearchOptions,
+): Promise<SearchResult> {
+  const enabledSources = sources.sources.filter((s) => s.enabled);
+  const totalSources = enabledSources.length;
+  const keyword = opts?.keyword ?? "";
+
+  const results: SourcedSearchResult[] = [];
+  const warnings: SearchResult["warnings"] = [];
+  let successfulSources = 0;
+
+  const fetches = enabledSources.map(async (source) => {
+    try {
+      const registry = await fetchRemoteRegistry(source, cachePath);
+      if (!registry) {
+        warnings.push({
+          sourceName: source.name,
+          reason: "unreachable",
+          message: `Source "${source.name}" unreachable`,
+          usedStaleCache: false,
+        });
+        return;
+      }
+
+      successfulSources++;
+
+      const matches = searchRegistry(registry, keyword);
+      for (const m of matches) {
+        results.push({
+          entry: m.entry,
+          artifactType: m.artifactType,
+          sourceName: source.name,
+          sourceTier: source.tier,
+        });
+      }
+    } catch (_err) {
+      warnings.push({
+        sourceName: source.name,
+        reason: "malformed",
+        message: `Source "${source.name}" returned malformed data`,
+        usedStaleCache: false,
+      });
+    }
+  });
+
+  await Promise.all(fetches);
+
+  // Apply filters
+  let filtered = results;
+  if (opts?.type) {
+    filtered = filtered.filter((r) => r.artifactType === opts.type);
+  }
+  if (opts?.tier) {
+    filtered = filtered.filter((r) => r.sourceTier === opts.tier);
+  }
+
+  return {
+    results: filtered,
+    warnings,
+    totalSources,
+    successfulSources,
+  };
+}
+
+/** Format search results for human-readable terminal output */
+export function formatSearch(result: SearchResult): string {
+  if (!result.results.length) {
+    if (result.totalSources === 0) {
+      return "No sources configured. Run: arc source add metafactory https://meta-factory.ai --type metafactory";
+    }
+    return "No matches found across any source.";
+  }
+
+  const lines: string[] = [
+    `Found ${result.results.length} match(es) across ${result.successfulSources}/${result.totalSources} sources:`,
+    "",
+  ];
+
+  for (const r of result.results) {
+    const statusBadge =
+      r.entry.status === "shipped"
+        ? ""
+        : r.entry.status === "beta"
+          ? " (beta)"
+          : " (deprecated)";
+    const tierBadge = `[${r.sourceTier}]`;
+
+    lines.push(
+      `  ${r.entry.name} [${r.artifactType}]${statusBadge} ${tierBadge} — ${r.entry.description}`,
+    );
+    lines.push(`    by ${r.entry.author} | source: ${r.sourceName}`);
+    if (r.entry.reviewed_by?.length) {
+      lines.push(`    reviewed by: ${r.entry.reviewed_by.join(", ")}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Format search warnings for stderr output */
+export function formatWarnings(result: SearchResult): string {
+  if (!result.warnings.length) return "";
+  return result.warnings
+    .map((w) => {
+      const staleSuffix = w.usedStaleCache ? " (using stale cache)" : "";
+      return `Warning: ${w.message}${staleSuffix}`;
+    })
+    .join("\n");
+}
+
+/** Format search results as JSON for machine consumption */
+export function formatSearchJson(result: SearchResult): string {
+  const output = {
+    results: result.results.map((r) => ({
+      name: r.entry.name,
+      description: r.entry.description,
+      type: r.artifactType,
+      author: r.entry.author,
+      version: r.entry.version,
+      status: r.entry.status,
+      source: {
+        name: r.sourceName,
+        tier: r.sourceTier,
+        url: r.entry.source,
+      },
+      reviewedBy: r.entry.reviewed_by ?? [],
+    })),
+    meta: {
+      total: result.results.length,
+      sources: {
+        total: result.totalSources,
+        successful: result.successfulSources,
+        failed: result.warnings.length,
+      },
+      warnings: result.warnings,
+    },
+  };
+  return JSON.stringify(output, null, 2);
+}
+
+/** Parse and validate an ArtifactType string from CLI */
+export function parseArtifactType(input: string): ArtifactType | null {
+  const valid: ArtifactType[] = ["skill", "tool", "agent", "prompt", "component", "pipeline", "action"];
+  return valid.includes(input as ArtifactType) ? (input as ArtifactType) : null;
+}
+
+/** Parse and validate a PackageTier string from CLI */
+export function parsePackageTier(input: string): PackageTier | null {
+  const valid: PackageTier[] = ["official", "community", "custom"];
+  return valid.includes(input as PackageTier) ? (input as PackageTier) : null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,30 @@ export interface SourcedSearchResult {
   sourceTier: PackageTier;
 }
 
+/** Search command options */
+export interface SearchOptions {
+  keyword?: string;
+  json?: boolean;
+  type?: ArtifactType;
+  tier?: PackageTier;
+}
+
+/** Warning about a source that failed during search */
+export interface SearchWarning {
+  sourceName: string;
+  reason: "unreachable" | "auth_required" | "rate_limited" | "malformed";
+  message: string;
+  usedStaleCache: boolean;
+}
+
+/** Search result with metadata and warnings */
+export interface SearchResult {
+  results: SourcedSearchResult[];
+  warnings: SearchWarning[];
+  totalSources: number;
+  successfulSources: number;
+}
+
 /** Parsed package reference from CLI input */
 export interface PackageRef {
   scope: string;

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -1,0 +1,434 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import {
+  searchAcrossSources,
+  formatSearch,
+  formatSearchJson,
+  formatWarnings,
+  parseArtifactType,
+  parsePackageTier,
+} from "../../src/commands/search.js";
+import { saveSources } from "../../src/lib/sources.js";
+import type { SourcesConfig, SearchResult } from "../../src/types.js";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import YAML from "yaml";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+// Helper: create a REGISTRY.yaml file and return file:// URL
+async function createLocalRegistry(content: object): Promise<string> {
+  const path = join(env.paths.reposDir, `reg-${Math.random()}.yaml`);
+  await writeFile(path, YAML.stringify(content));
+  return `file://${path}`;
+}
+
+// ---------------------------------------------------------------------------
+// parseArtifactType / parsePackageTier
+// ---------------------------------------------------------------------------
+
+describe("parseArtifactType", () => {
+  test("accepts valid types", () => {
+    expect(parseArtifactType("skill")).toBe("skill");
+    expect(parseArtifactType("tool")).toBe("tool");
+    expect(parseArtifactType("agent")).toBe("agent");
+    expect(parseArtifactType("prompt")).toBe("prompt");
+    expect(parseArtifactType("component")).toBe("component");
+    expect(parseArtifactType("pipeline")).toBe("pipeline");
+    expect(parseArtifactType("action")).toBe("action");
+  });
+
+  test("rejects invalid types", () => {
+    expect(parseArtifactType("invalid")).toBeNull();
+    expect(parseArtifactType("")).toBeNull();
+    expect(parseArtifactType("SKILL")).toBeNull();
+  });
+});
+
+describe("parsePackageTier", () => {
+  test("accepts valid tiers", () => {
+    expect(parsePackageTier("official")).toBe("official");
+    expect(parsePackageTier("community")).toBe("community");
+    expect(parsePackageTier("custom")).toBe("custom");
+  });
+
+  test("rejects invalid tiers", () => {
+    expect(parsePackageTier("invalid")).toBeNull();
+    expect(parsePackageTier("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAcrossSources
+// ---------------------------------------------------------------------------
+
+describe("searchAcrossSources", () => {
+  test("returns empty result with zero sources when none configured", async () => {
+    const config: SourcesConfig = { sources: [] };
+    const result = await searchAcrossSources(config, env.paths.cachePath);
+    expect(result.results).toEqual([]);
+    expect(result.totalSources).toBe(0);
+    expect(result.successfulSources).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("returns results from local file registry", async () => {
+    const url = await createLocalRegistry({
+      registry: {
+        skills: [
+          { name: "research", description: "Multi-agent research", author: "alice", version: "1.0.0", source: "", type: "community", status: "shipped" },
+          { name: "writer", description: "Content writer", author: "bob", version: "1.0.0", source: "", type: "community", status: "shipped" },
+        ],
+        tools: [],
+        agents: [],
+        prompts: [],
+      },
+    });
+
+    const config: SourcesConfig = {
+      sources: [{ name: "local", url, tier: "community", enabled: true }],
+    };
+    await saveSources(env.paths.sourcesPath, config);
+
+    const result = await searchAcrossSources(config, env.paths.cachePath);
+    expect(result.results.length).toBe(2);
+    expect(result.successfulSources).toBe(1);
+    expect(result.totalSources).toBe(1);
+  });
+
+  test("filters by keyword", async () => {
+    const url = await createLocalRegistry({
+      registry: {
+        skills: [
+          { name: "research", description: "Multi-agent research", author: "alice", version: "1.0.0", source: "", type: "community", status: "shipped" },
+          { name: "writer", description: "Content writer", author: "bob", version: "1.0.0", source: "", type: "community", status: "shipped" },
+        ],
+        tools: [], agents: [], prompts: [],
+      },
+    });
+
+    const config: SourcesConfig = {
+      sources: [{ name: "local", url, tier: "community", enabled: true }],
+    };
+
+    const result = await searchAcrossSources(config, env.paths.cachePath, { keyword: "research" });
+    expect(result.results.length).toBe(1);
+    expect(result.results[0].entry.name).toBe("research");
+  });
+
+  test("filters by type", async () => {
+    const url = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s1", description: "Skill 1", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [{ name: "t1", description: "Tool 1", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        agents: [], prompts: [],
+      },
+    });
+
+    const config: SourcesConfig = {
+      sources: [{ name: "local", url, tier: "community", enabled: true }],
+    };
+
+    const skillsOnly = await searchAcrossSources(config, env.paths.cachePath, { type: "skill" });
+    expect(skillsOnly.results.length).toBe(1);
+    expect(skillsOnly.results[0].artifactType).toBe("skill");
+
+    const toolsOnly = await searchAcrossSources(config, env.paths.cachePath, { type: "tool" });
+    expect(toolsOnly.results.length).toBe(1);
+    expect(toolsOnly.results[0].artifactType).toBe("tool");
+  });
+
+  test("filters by tier", async () => {
+    const officialUrl = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s1", description: "Skill", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [], agents: [], prompts: [],
+      },
+    });
+    const communityUrl = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s2", description: "Skill", author: "b", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [], agents: [], prompts: [],
+      },
+    });
+
+    const config: SourcesConfig = {
+      sources: [
+        { name: "off", url: officialUrl, tier: "official", enabled: true },
+        { name: "com", url: communityUrl, tier: "community", enabled: true },
+      ],
+    };
+
+    const officialOnly = await searchAcrossSources(config, env.paths.cachePath, { tier: "official" });
+    expect(officialOnly.results.length).toBe(1);
+    expect(officialOnly.results[0].sourceTier).toBe("official");
+  });
+
+  test("combines type and tier filters", async () => {
+    const url = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s1", description: "Skill", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [{ name: "t1", description: "Tool", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        agents: [], prompts: [],
+      },
+    });
+    const config: SourcesConfig = {
+      sources: [{ name: "local", url, tier: "official", enabled: true }],
+    };
+
+    const result = await searchAcrossSources(config, env.paths.cachePath, { type: "skill", tier: "official" });
+    expect(result.results.length).toBe(1);
+    expect(result.results[0].artifactType).toBe("skill");
+    expect(result.results[0].sourceTier).toBe("official");
+
+    const emptyResult = await searchAcrossSources(config, env.paths.cachePath, { type: "skill", tier: "community" });
+    expect(emptyResult.results.length).toBe(0);
+  });
+
+  test("captures warnings for unreachable sources", async () => {
+    const config: SourcesConfig = {
+      sources: [
+        { name: "missing", url: "file:///nonexistent/path.yaml", tier: "community", enabled: true },
+      ],
+    };
+    const result = await searchAcrossSources(config, env.paths.cachePath);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0].sourceName).toBe("missing");
+    expect(result.warnings[0].reason).toBe("unreachable");
+    expect(result.successfulSources).toBe(0);
+  });
+
+  test("healthy sources work when another fails", async () => {
+    const workingUrl = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s1", description: "Works", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [], agents: [], prompts: [],
+      },
+    });
+    const config: SourcesConfig = {
+      sources: [
+        { name: "broken", url: "file:///nonexistent/path.yaml", tier: "community", enabled: true },
+        { name: "working", url: workingUrl, tier: "official", enabled: true },
+      ],
+    };
+
+    const result = await searchAcrossSources(config, env.paths.cachePath);
+    expect(result.results.length).toBe(1);
+    expect(result.successfulSources).toBe(1);
+    expect(result.warnings.length).toBe(1);
+  });
+
+  test("disabled sources are ignored", async () => {
+    const url = await createLocalRegistry({
+      registry: {
+        skills: [{ name: "s1", description: "Skill", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" }],
+        tools: [], agents: [], prompts: [],
+      },
+    });
+    const config: SourcesConfig = {
+      sources: [{ name: "local", url, tier: "community", enabled: false }],
+    };
+
+    const result = await searchAcrossSources(config, env.paths.cachePath);
+    expect(result.totalSources).toBe(0);
+    expect(result.results.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSearch
+// ---------------------------------------------------------------------------
+
+describe("formatSearch", () => {
+  test("shows no-sources message when zero sources", () => {
+    const result: SearchResult = { results: [], warnings: [], totalSources: 0, successfulSources: 0 };
+    const output = formatSearch(result);
+    expect(output).toContain("No sources configured");
+    expect(output).toContain("arc source add");
+  });
+
+  test("shows no-matches message when sources exist but no results", () => {
+    const result: SearchResult = { results: [], warnings: [], totalSources: 2, successfulSources: 2 };
+    const output = formatSearch(result);
+    expect(output).toContain("No matches found");
+  });
+
+  test("shows results with tier badge", () => {
+    const result: SearchResult = {
+      results: [{
+        entry: { name: "research", description: "Multi-agent", author: "alice", version: "1.0.0", source: "", type: "community", status: "shipped" },
+        artifactType: "skill",
+        sourceName: "metafactory",
+        sourceTier: "official",
+      }],
+      warnings: [],
+      totalSources: 1,
+      successfulSources: 1,
+    };
+    const output = formatSearch(result);
+    expect(output).toContain("research");
+    expect(output).toContain("[skill]");
+    expect(output).toContain("[official]");
+    expect(output).toContain("Multi-agent");
+    expect(output).toContain("by alice");
+    expect(output).toContain("source: metafactory");
+  });
+
+  test("shows beta and deprecated badges", () => {
+    const result: SearchResult = {
+      results: [
+        { entry: { name: "b", description: "Beta", author: "a", version: "1.0.0", source: "", type: "community", status: "beta" }, artifactType: "skill", sourceName: "s", sourceTier: "community" },
+        { entry: { name: "d", description: "Old", author: "a", version: "1.0.0", source: "", type: "community", status: "deprecated" }, artifactType: "skill", sourceName: "s", sourceTier: "community" },
+      ],
+      warnings: [],
+      totalSources: 1,
+      successfulSources: 1,
+    };
+    const output = formatSearch(result);
+    expect(output).toContain("(beta)");
+    expect(output).toContain("(deprecated)");
+  });
+
+  test("shows source ratio in header", () => {
+    const result: SearchResult = {
+      results: [{
+        entry: { name: "x", description: "Test", author: "a", version: "1.0.0", source: "", type: "community", status: "shipped" },
+        artifactType: "skill", sourceName: "s", sourceTier: "community",
+      }],
+      warnings: [],
+      totalSources: 3,
+      successfulSources: 2,
+    };
+    const output = formatSearch(result);
+    expect(output).toContain("2/3 sources");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatWarnings
+// ---------------------------------------------------------------------------
+
+describe("formatWarnings", () => {
+  test("returns empty string when no warnings", () => {
+    const result: SearchResult = { results: [], warnings: [], totalSources: 1, successfulSources: 1 };
+    expect(formatWarnings(result)).toBe("");
+  });
+
+  test("formats single warning", () => {
+    const result: SearchResult = {
+      results: [],
+      warnings: [{
+        sourceName: "broken",
+        reason: "unreachable",
+        message: 'Source "broken" unreachable',
+        usedStaleCache: false,
+      }],
+      totalSources: 1,
+      successfulSources: 0,
+    };
+    const output = formatWarnings(result);
+    expect(output).toContain("Warning:");
+    expect(output).toContain("broken");
+    expect(output).toContain("unreachable");
+  });
+
+  test("shows stale cache suffix", () => {
+    const result: SearchResult = {
+      results: [],
+      warnings: [{
+        sourceName: "flaky",
+        reason: "unreachable",
+        message: 'Source "flaky" unreachable',
+        usedStaleCache: true,
+      }],
+      totalSources: 1,
+      successfulSources: 0,
+    };
+    const output = formatWarnings(result);
+    expect(output).toContain("using stale cache");
+  });
+
+  test("formats multiple warnings on separate lines", () => {
+    const result: SearchResult = {
+      results: [],
+      warnings: [
+        { sourceName: "a", reason: "unreachable", message: 'Source "a" unreachable', usedStaleCache: false },
+        { sourceName: "b", reason: "malformed", message: 'Source "b" returned malformed data', usedStaleCache: false },
+      ],
+      totalSources: 2,
+      successfulSources: 0,
+    };
+    const output = formatWarnings(result);
+    expect(output.split("\n").length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSearchJson
+// ---------------------------------------------------------------------------
+
+describe("formatSearchJson", () => {
+  test("returns valid JSON with results and meta", () => {
+    const result: SearchResult = {
+      results: [{
+        entry: { name: "research", description: "Multi-agent", author: "alice", version: "1.0.0", source: "https://example.com/r", type: "community", status: "shipped" },
+        artifactType: "skill",
+        sourceName: "metafactory",
+        sourceTier: "official",
+      }],
+      warnings: [],
+      totalSources: 1,
+      successfulSources: 1,
+    };
+
+    const json = formatSearchJson(result);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.results.length).toBe(1);
+    expect(parsed.results[0].name).toBe("research");
+    expect(parsed.results[0].type).toBe("skill");
+    expect(parsed.results[0].source.name).toBe("metafactory");
+    expect(parsed.results[0].source.tier).toBe("official");
+    expect(parsed.meta.total).toBe(1);
+    expect(parsed.meta.sources.total).toBe(1);
+    expect(parsed.meta.sources.successful).toBe(1);
+    expect(parsed.meta.sources.failed).toBe(0);
+    expect(parsed.meta.warnings).toEqual([]);
+  });
+
+  test("includes warnings in meta", () => {
+    const result: SearchResult = {
+      results: [],
+      warnings: [{
+        sourceName: "broken",
+        reason: "unreachable",
+        message: 'Source "broken" unreachable',
+        usedStaleCache: false,
+      }],
+      totalSources: 1,
+      successfulSources: 0,
+    };
+
+    const json = formatSearchJson(result);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.meta.warnings.length).toBe(1);
+    expect(parsed.meta.warnings[0].sourceName).toBe("broken");
+    expect(parsed.meta.sources.failed).toBe(1);
+  });
+
+  test("output is pretty-printed", () => {
+    const result: SearchResult = { results: [], warnings: [], totalSources: 0, successfulSources: 0 };
+    const json = formatSearchJson(result);
+    // Pretty JSON has newlines
+    expect(json).toContain("\n");
+  });
+});


### PR DESCRIPTION
## Summary
Closes the A-401 series by extracting `arc search` into a proper command module with trust-aware filters, JSON output, and actionable warnings.

## New file: src/commands/search.ts
- `searchAcrossSources` — returns `SearchResult` with `results + warnings + source counts`
- `formatSearch` — human-readable output with tier/type badges and success ratio
- `formatSearchJson` — machine-readable JSON for CI/scripting
- `formatWarnings` — stderr warnings for failed sources
- `parseArtifactType` / `parsePackageTier` — CLI input validators

## CLI additions
- `--json` flag for machine-readable output
- `--type <type>` filter (skill/tool/agent/prompt/component/pipeline/action)
- `--tier <tier>` filter (official/community/custom)
- stderr warnings for unreachable sources and malformed responses
- "No sources configured" actionable message with `arc source add` hint

## Example outputs

**Normal:**
```
Found 3 match(es) across 2/3 sources:

  research [skill] [official] — Multi-agent research
    by alice | source: metafactory
  writer [skill] [community] — Content writer
    by bob | source: community-registry
```

**With warnings on stderr:**
```
Warning: Source "broken-registry" unreachable
```

**JSON output:**
```json
{
  "results": [...],
  "meta": {
    "total": 3,
    "sources": { "total": 3, "successful": 2, "failed": 1 },
    "warnings": [...]
  }
}
```

## Tests
25 new tests, **400/400 passing**.

| Group | Tests | Covers |
|-------|-------|--------|
| parseArtifactType/parsePackageTier | 4 | Valid + invalid inputs |
| searchAcrossSources | 9 | Empty, keyword, type filter, tier filter, combined, unreachable, partial failure, disabled sources |
| formatSearch | 4 | No sources, no matches, results with badges, status badges, success ratio |
| formatWarnings | 4 | Empty, single, stale cache, multiple |
| formatSearchJson | 3 | Structure, warnings, pretty-printed |

## SpecFlow
F-5 of A-401 series. Depends on F-1..F-4 (all merged).

**This closes the A-401 epic.** With all 5 features merged, arc can:
1. Add metafactory sources (F-1)
2. Authenticate via device code flow (F-2)
3. Search/fetch from the metafactory API (F-3)
4. Install packages with SHA-256 verification (F-4)
5. Search across all source types with filters and warnings (F-5)

Unblocks **S2-23** (trust signals in CLI) on the critical path to launch.

@the-metafactory/luna @the-metafactory/mellanon -- requesting review

Generated with [Claude Code](https://claude.com/claude-code)