### PR TITLE
feat: add arc bundle and arc publish commands (F-006)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,8 @@ import {
 import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
+import { bundle, formatBundle } from "./commands/bundle.js";
+import { publish, formatPublish } from "./commands/publish.js";
 import {
   searchAcrossSources,
   formatSearch,
@@ -710,6 +712,46 @@ program
       console.error(`Error: ${result.error}`);
       process.exit(1);
     }
+  });
+
+// ── Bundle and publish commands ────────────────────────────
+
+program
+  .command("bundle [path]")
+  .description("Create a distributable tarball from a package directory")
+  .option("-o, --output <path>", "Output path for the tarball")
+  .action(async (path: string | undefined, opts: { output?: string }) => {
+    const paths = createPaths();
+    const result = await bundle({
+      paths,
+      packageDir: path ?? process.cwd(),
+      outputPath: opts.output,
+    });
+
+    console.log(formatBundle(result));
+    if (!result.success) process.exit(1);
+  });
+
+program
+  .command("publish [path]")
+  .description("Publish a package to the metafactory registry")
+  .option("-t, --tarball <path>", "Publish from existing tarball (skip bundling)")
+  .option("--dry-run", "Validate and show what would be published without uploading")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .option("--scope <namespace>", "Override publish scope/namespace")
+  .action(async (path: string | undefined, opts: { tarball?: string; dryRun?: boolean; source?: string; scope?: string }) => {
+    const paths = createPaths();
+    const result = await publish({
+      paths,
+      packageDir: path ?? process.cwd(),
+      tarballPath: opts.tarball,
+      dryRun: opts.dryRun,
+      sourceName: opts.source,
+      scope: opts.scope,
+    });
+
+    console.log(formatPublish(result));
+    if (!result.success) process.exit(1);
   });
 
 // ── Catalog commands ────────────────────────────────────────

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -1,0 +1,82 @@
+import { resolve } from "path";
+import { createBundle } from "../lib/bundle.js";
+import type { PaiPaths } from "../types.js";
+
+export interface BundleOptions {
+  paths: PaiPaths;
+  packageDir: string;
+  outputPath?: string;
+}
+
+export interface BundleCommandResult {
+  success: boolean;
+  name?: string;
+  version?: string;
+  type?: string;
+  tarballPath?: string;
+  sha256?: string;
+  sizeBytes?: number;
+  fileCount?: number;
+  warnings?: string[];
+  error?: string;
+}
+
+/** Execute the arc bundle command */
+export async function bundle(opts: BundleOptions): Promise<BundleCommandResult> {
+  const packageDir = resolve(opts.packageDir);
+  const outputPath = opts.outputPath ? resolve(opts.outputPath) : undefined;
+
+  const result = await createBundle(packageDir, outputPath);
+
+  if (!result.success) {
+    return {
+      success: false,
+      warnings: result.warnings,
+      error: result.error,
+    };
+  }
+
+  return {
+    success: true,
+    name: result.manifest.name,
+    version: result.manifest.version,
+    type: result.manifest.type,
+    tarballPath: result.tarballPath,
+    sha256: result.sha256,
+    sizeBytes: result.sizeBytes,
+    fileCount: result.fileCount,
+    warnings: result.warnings,
+  };
+}
+
+/** Format bundle result for terminal output */
+export function formatBundle(result: BundleCommandResult): string {
+  if (!result.success) {
+    return `Error: ${result.error}`;
+  }
+
+  const sizeStr = formatSize(result.sizeBytes ?? 0);
+  const lines = [
+    `Bundled ${result.name} v${result.version}`,
+    `  Type:     ${result.type}`,
+    `  Files:    ${result.fileCount}`,
+    `  Size:     ${sizeStr}`,
+    `  SHA-256:  ${result.sha256}`,
+    `  Output:   ${result.tarballPath}`,
+  ];
+
+  if (result.warnings?.length) {
+    lines.push("");
+    for (const w of result.warnings) {
+      lines.push(`  Warning: ${w}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,162 @@
+import { resolve } from "path";
+import { rm } from "fs/promises";
+import { createBundle, computeChecksum } from "../lib/bundle.js";
+import {
+  extractReadme,
+  resolvePublishScope,
+  uploadBundle,
+  ensurePackageExists,
+  registerVersion,
+} from "../lib/publish.js";
+import { loadSources, findMetafactorySource } from "../lib/sources.js";
+import { readManifest } from "../lib/manifest.js";
+import type { PaiPaths } from "../types.js";
+
+export interface PublishOptions {
+  paths: PaiPaths;
+  packageDir: string;
+  tarballPath?: string;
+  dryRun?: boolean;
+  sourceName?: string;
+  scope?: string;
+}
+
+export interface PublishCommandResult {
+  success: boolean;
+  name?: string;
+  version?: string;
+  scope?: string;
+  sha256?: string;
+  url?: string;
+  dryRun?: boolean;
+  error?: string;
+}
+
+/** Execute the arc publish command */
+export async function publish(opts: PublishOptions): Promise<PublishCommandResult> {
+  const packageDir = resolve(opts.packageDir);
+
+  // 1. Find metafactory source
+  const sourcesConfig = await loadSources(opts.paths.sourcesPath);
+  const sourceResult = findMetafactorySource(sourcesConfig, opts.sourceName);
+  if ("error" in sourceResult) {
+    return { success: false, error: sourceResult.error };
+  }
+  const source = sourceResult.source;
+
+  // 2. Check authentication
+  if (!source.token) {
+    return { success: false, error: 'Not authenticated. Run "arc login" first.' };
+  }
+
+  // 3. Read manifest
+  const manifest = await readManifest(packageDir);
+  if (!manifest) {
+    return { success: false, error: "No arc-manifest.yaml found in package directory." };
+  }
+
+  // 4. Resolve scope
+  const scope = await resolvePublishScope(manifest, source, opts.scope);
+  if (!scope) {
+    return { success: false, error: "Could not determine publish scope. Use --scope <namespace> or add namespace to arc-manifest.yaml." };
+  }
+
+  // 5. Bundle (or use existing tarball)
+  let tarballPath: string;
+  let sha256: string;
+  let tempTarball = false;
+
+  if (opts.tarballPath) {
+    tarballPath = resolve(opts.tarballPath);
+    sha256 = await computeChecksum(tarballPath);
+  } else {
+    const bundleResult = await createBundle(packageDir);
+    if (!bundleResult.success) {
+      return { success: false, error: bundleResult.error };
+    }
+    tarballPath = bundleResult.tarballPath;
+    sha256 = bundleResult.sha256;
+    tempTarball = true;
+  }
+
+  // 6. Dry run — validate and display, then clean up
+  if (opts.dryRun) {
+    if (tempTarball) {
+      await rm(tarballPath).catch(() => {});
+    }
+    return {
+      success: true,
+      name: manifest.name,
+      version: manifest.version,
+      scope,
+      sha256,
+      dryRun: true,
+    };
+  }
+
+  try {
+    // 7. Upload tarball
+    const uploadResult = await uploadBundle(tarballPath, source, sha256);
+    if (!uploadResult.success) {
+      return { success: false, error: uploadResult.error };
+    }
+
+    // 8. Ensure package exists
+    const ensureResult = await ensurePackageExists(source, scope, manifest.name, manifest);
+    if (!ensureResult.exists) {
+      return { success: false, error: ensureResult.error ?? "Failed to create package." };
+    }
+
+    // 9. Extract README
+    const readme = await extractReadme(packageDir);
+
+    // 10. Register version
+    const registerResult = await registerVersion(source, scope, manifest.name, {
+      version: manifest.version,
+      sha256: uploadResult.sha256,
+      r2_key: uploadResult.r2Key,
+      size_bytes: uploadResult.sizeBytes,
+      manifest,
+      readme: readme ?? undefined,
+    });
+
+    if (!registerResult.success) {
+      return { success: false, error: registerResult.error };
+    }
+
+    return {
+      success: true,
+      name: manifest.name,
+      version: manifest.version,
+      scope,
+      sha256: uploadResult.sha256,
+      url: `${source.url}/package/@${scope}/${manifest.name}`,
+    };
+  } finally {
+    // Clean up temp tarball
+    if (tempTarball) {
+      await rm(tarballPath).catch(() => {});
+    }
+  }
+}
+
+/** Format publish result for terminal output */
+export function formatPublish(result: PublishCommandResult): string {
+  if (!result.success) {
+    return `Error: ${result.error}`;
+  }
+
+  if (result.dryRun) {
+    return [
+      `[DRY RUN] Would publish @${result.scope}/${result.name} v${result.version}`,
+      `  SHA-256:  ${result.sha256}`,
+      `  Source:   metafactory`,
+    ].join("\n");
+  }
+
+  return [
+    `Published @${result.scope}/${result.name} v${result.version}`,
+    `  SHA-256:  ${result.sha256}`,
+    `  URL:      ${result.url}`,
+  ].join("\n");
+}

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -1,0 +1,238 @@
+import { join } from "path";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
+import { readManifest } from "./manifest.js";
+import type { ArcManifest, BundleResult, PublishValidation } from "../types.js";
+
+// ── Constants ────────────────────────────────────────────────
+
+export const DEFAULT_EXCLUSIONS = [
+  ".git",
+  "node_modules",
+  ".env",
+  ".env.*",
+  "*.db",
+  "*.sqlite",
+  ".DS_Store",
+  "Thumbs.db",
+  ".specify",
+  "test",
+  "tests",
+  "dist",
+  "*.log",
+  ".wrangler",
+  ".claude",
+];
+
+const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50MB
+const WARN_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
+
+// ── Checksum ─────────────────────────────────────────────────
+
+/** Compute SHA-256 hex digest of a file */
+export async function computeChecksum(filePath: string): Promise<string> {
+  const file = Bun.file(filePath);
+  const buffer = await file.arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buffer);
+  return hasher.digest("hex");
+}
+
+// ── Temp directory lifecycle ─────────────────────────────────
+
+/** Execute a function with a temp directory that is cleaned up afterward */
+export async function withTempDir<T>(
+  fn: (tempDir: string) => Promise<T>,
+): Promise<T> {
+  const tempDir = await mkdtemp(join(tmpdir(), "arc-publish-"));
+  try {
+    return await fn(tempDir);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// ── Exclusion patterns ───────────────────────────────────────
+
+/** Merge default exclusions with manifest overrides */
+export function getExclusionPatterns(manifest: ArcManifest): string[] {
+  const patterns = [...DEFAULT_EXCLUSIONS];
+  if (manifest.bundle?.exclude) {
+    patterns.push(...manifest.bundle.exclude);
+  }
+  return patterns;
+}
+
+// ── Publish validation ───────────────────────────────────────
+
+const VALID_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?(?:\+[a-zA-Z0-9.]+)?$/;
+
+const VALID_TYPES = [
+  "skill", "tool", "agent", "prompt", "component",
+  "pipeline", "rules", "library", "action",
+];
+
+/** Validate a manifest for publishing (stricter than install validation) */
+export function validateForPublish(manifest: ArcManifest): PublishValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!manifest.name) {
+    errors.push("name is required");
+  } else if (!VALID_NAME_RE.test(manifest.name)) {
+    errors.push("name must be lowercase alphanumeric with hyphens, dots, or underscores");
+  }
+
+  if (!manifest.version) {
+    errors.push("version is required");
+  } else if (!SEMVER_RE.test(manifest.version)) {
+    errors.push(`version "${manifest.version}" is not valid semver`);
+  }
+
+  if (!manifest.type) {
+    errors.push("type is required");
+  } else if (!VALID_TYPES.includes(manifest.type)) {
+    errors.push(`type "${manifest.type}" is not a recognized artifact type`);
+  }
+
+  if (!manifest.description) {
+    warnings.push("description is missing (recommended for registry listing)");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    name: manifest.name ?? "",
+    version: manifest.version ?? "",
+  };
+}
+
+// ── Tarball creation ─────────────────────────────────────────
+
+/** Create a .tar.gz bundle from a package directory */
+export async function createBundle(
+  packageDir: string,
+  outputPath?: string,
+): Promise<BundleResult> {
+  const warnings: string[] = [];
+
+  // Read manifest
+  const manifest = await readManifest(packageDir);
+  if (!manifest) {
+    return {
+      success: false,
+      tarballPath: "",
+      sha256: "",
+      sizeBytes: 0,
+      fileCount: 0,
+      manifest: {} as ArcManifest,
+      warnings: [],
+      error: "No arc-manifest.yaml found in package directory",
+    };
+  }
+
+  // Validate for publish
+  const validation = validateForPublish(manifest);
+  if (!validation.valid) {
+    return {
+      success: false,
+      tarballPath: "",
+      sha256: "",
+      sizeBytes: 0,
+      fileCount: 0,
+      manifest,
+      warnings: validation.warnings,
+      error: `Manifest validation failed: ${validation.errors.join(", ")}`,
+    };
+  }
+  warnings.push(...validation.warnings);
+
+  // Check for README
+  const hasReadme = existsSync(join(packageDir, "README.md")) ||
+    existsSync(join(packageDir, "readme.md")) ||
+    existsSync(join(packageDir, "Readme.md"));
+  if (!hasReadme) {
+    warnings.push("No README.md found (recommended for registry listing)");
+  }
+
+  // Build tar args
+  const tarballName = outputPath ?? join(packageDir, `${manifest.name}-${manifest.version}.tar.gz`);
+  const exclusions = getExclusionPatterns(manifest);
+  // Handle bundle.include by removing those patterns from exclusions
+  // (include overrides exclude — force specific paths into the tarball)
+  const includePatterns = manifest.bundle?.include ?? [];
+
+  const finalExcludeArgs: string[] = [];
+  for (const pattern of exclusions) {
+    const isOverridden = includePatterns.some((inc) => inc === pattern);
+    if (!isOverridden) {
+      finalExcludeArgs.push("--exclude", pattern);
+    }
+  }
+
+  // Create tarball
+  const result = Bun.spawnSync(
+    ["tar", "czf", tarballName, ...finalExcludeArgs, "."],
+    { cwd: packageDir, stdout: "pipe", stderr: "pipe" },
+  );
+
+  if (result.exitCode !== 0) {
+    return {
+      success: false,
+      tarballPath: tarballName,
+      sha256: "",
+      sizeBytes: 0,
+      fileCount: 0,
+      manifest,
+      warnings,
+      error: `tar failed: ${result.stderr.toString().trim()}`,
+    };
+  }
+
+  // Compute checksum
+  const sha256 = await computeChecksum(tarballName);
+
+  // Get size
+  const file = Bun.file(tarballName);
+  const sizeBytes = file.size;
+
+  // Get file count
+  const listResult = Bun.spawnSync(
+    ["tar", "tzf", tarballName],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const fileCount = listResult.stdout.toString().trim().split("\n").filter(Boolean).length;
+
+  // Size checks
+  if (sizeBytes > MAX_PACKAGE_SIZE) {
+    // Clean up the tarball
+    await rm(tarballName).catch(() => {});
+    return {
+      success: false,
+      tarballPath: tarballName,
+      sha256,
+      sizeBytes,
+      fileCount,
+      manifest,
+      warnings,
+      error: `Package tarball exceeds 50MB limit (${(sizeBytes / 1024 / 1024).toFixed(1)}MB)`,
+    };
+  }
+
+  if (sizeBytes > WARN_PACKAGE_SIZE) {
+    warnings.push(`Tarball is ${(sizeBytes / 1024 / 1024).toFixed(1)}MB (consider reducing size)`);
+  }
+
+  return {
+    success: true,
+    tarballPath: tarballName,
+    sha256,
+    sizeBytes,
+    fileCount,
+    manifest,
+    warnings,
+  };
+}

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -5,6 +5,8 @@ import { existsSync } from "fs";
 import { readManifest } from "./manifest.js";
 import type { ArcManifest, BundleResult, PublishValidation } from "../types.js";
 
+export const README_VARIANTS = ["README.md", "readme.md", "Readme.md"];
+
 // ── Constants ────────────────────────────────────────────────
 
 export const DEFAULT_EXCLUSIONS = [
@@ -110,6 +112,28 @@ export function validateForPublish(manifest: ArcManifest): PublishValidation {
   };
 }
 
+// ── Tarball helpers ──────────────────────────────────────────
+
+/** Build tar --exclude args from exclusion/include pattern lists */
+function buildTarArgs(exclusions: string[], includePatterns: string[]): string[] {
+  const args: string[] = [];
+  for (const pattern of exclusions) {
+    if (!includePatterns.includes(pattern)) {
+      args.push("--exclude", pattern);
+    }
+  }
+  return args;
+}
+
+/** Compute checksum, size, and file count for a tarball */
+async function getBundleStats(tarballPath: string): Promise<{ sha256: string; sizeBytes: number; fileCount: number }> {
+  const sha256 = await computeChecksum(tarballPath);
+  const sizeBytes = Bun.file(tarballPath).size;
+  const listResult = Bun.spawnSync(["tar", "tzf", tarballPath], { stdout: "pipe", stderr: "pipe" });
+  const fileCount = listResult.stdout.toString().trim().split("\n").filter(Boolean).length;
+  return { sha256, sizeBytes, fileCount };
+}
+
 // ── Tarball creation ─────────────────────────────────────────
 
 /** Create a .tar.gz bundle from a package directory */
@@ -119,120 +143,46 @@ export async function createBundle(
 ): Promise<BundleResult> {
   const warnings: string[] = [];
 
-  // Read manifest
   const manifest = await readManifest(packageDir);
   if (!manifest) {
-    return {
-      success: false,
-      tarballPath: "",
-      sha256: "",
-      sizeBytes: 0,
-      fileCount: 0,
-      manifest: {} as ArcManifest,
-      warnings: [],
-      error: "No arc-manifest.yaml found in package directory",
-    };
+    return { success: false, tarballPath: "", sha256: "", sizeBytes: 0, fileCount: 0, manifest: {} as ArcManifest, warnings: [], error: "No arc-manifest.yaml found in package directory" };
   }
 
-  // Validate for publish
   const validation = validateForPublish(manifest);
   if (!validation.valid) {
-    return {
-      success: false,
-      tarballPath: "",
-      sha256: "",
-      sizeBytes: 0,
-      fileCount: 0,
-      manifest,
-      warnings: validation.warnings,
-      error: `Manifest validation failed: ${validation.errors.join(", ")}`,
-    };
+    return { success: false, tarballPath: "", sha256: "", sizeBytes: 0, fileCount: 0, manifest, warnings: validation.warnings, error: `Manifest validation failed: ${validation.errors.join(", ")}` };
   }
   warnings.push(...validation.warnings);
 
-  // Check for README
-  const hasReadme = existsSync(join(packageDir, "README.md")) ||
-    existsSync(join(packageDir, "readme.md")) ||
-    existsSync(join(packageDir, "Readme.md"));
+  const hasReadme = README_VARIANTS.some((v) => existsSync(join(packageDir, v)));
   if (!hasReadme) {
     warnings.push("No README.md found (recommended for registry listing)");
   }
 
-  // Build tar args
   const tarballName = outputPath ?? join(packageDir, `${manifest.name}-${manifest.version}.tar.gz`);
   const exclusions = getExclusionPatterns(manifest);
-  // Handle bundle.include by removing those patterns from exclusions
-  // (include overrides exclude — force specific paths into the tarball)
   const includePatterns = manifest.bundle?.include ?? [];
+  const excludeArgs = buildTarArgs(exclusions, includePatterns);
 
-  const finalExcludeArgs: string[] = [];
-  for (const pattern of exclusions) {
-    const isOverridden = includePatterns.some((inc) => inc === pattern);
-    if (!isOverridden) {
-      finalExcludeArgs.push("--exclude", pattern);
-    }
-  }
-
-  // Create tarball
   const result = Bun.spawnSync(
-    ["tar", "czf", tarballName, ...finalExcludeArgs, "."],
+    ["tar", "czf", tarballName, ...excludeArgs, "."],
     { cwd: packageDir, stdout: "pipe", stderr: "pipe" },
   );
 
   if (result.exitCode !== 0) {
-    return {
-      success: false,
-      tarballPath: tarballName,
-      sha256: "",
-      sizeBytes: 0,
-      fileCount: 0,
-      manifest,
-      warnings,
-      error: `tar failed: ${result.stderr.toString().trim()}`,
-    };
+    return { success: false, tarballPath: tarballName, sha256: "", sizeBytes: 0, fileCount: 0, manifest, warnings, error: `tar failed: ${result.stderr.toString().trim()}` };
   }
 
-  // Compute checksum
-  const sha256 = await computeChecksum(tarballName);
+  const { sha256, sizeBytes, fileCount } = await getBundleStats(tarballName);
 
-  // Get size
-  const file = Bun.file(tarballName);
-  const sizeBytes = file.size;
-
-  // Get file count
-  const listResult = Bun.spawnSync(
-    ["tar", "tzf", tarballName],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const fileCount = listResult.stdout.toString().trim().split("\n").filter(Boolean).length;
-
-  // Size checks
   if (sizeBytes > MAX_PACKAGE_SIZE) {
-    // Clean up the tarball
     await rm(tarballName).catch(() => {});
-    return {
-      success: false,
-      tarballPath: tarballName,
-      sha256,
-      sizeBytes,
-      fileCount,
-      manifest,
-      warnings,
-      error: `Package tarball exceeds 50MB limit (${(sizeBytes / 1024 / 1024).toFixed(1)}MB)`,
-    };
+    return { success: false, tarballPath: tarballName, sha256, sizeBytes, fileCount, manifest, warnings, error: `Package tarball exceeds 50MB limit (${(sizeBytes / 1024 / 1024).toFixed(1)}MB)` };
   }
 
   if (sizeBytes > WARN_PACKAGE_SIZE) {
     warnings.push(`Tarball is ${(sizeBytes / 1024 / 1024).toFixed(1)}MB (consider reducing size)`);
   }
 
-  return {
-    success: true,
-    tarballPath: tarballName,
-    sha256,
-    sizeBytes,
-    fileCount,
-    manifest,
-    warnings,
-  };
+  return { success: true, tarballPath: tarballName, sha256, sizeBytes, fileCount, manifest, warnings };
 }

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -1,0 +1,261 @@
+import { join } from "path";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import type {
+  ArcManifest,
+  RegistrySource,
+  UploadResult,
+  RegisterResult,
+  EnsurePackageResult,
+} from "../types.js";
+
+// ── README extraction ────────────────────────────────────────
+
+const README_VARIANTS = ["README.md", "readme.md", "Readme.md"];
+
+/** Extract raw README markdown from a package directory */
+export async function extractReadme(packageDir: string): Promise<string | null> {
+  for (const variant of README_VARIANTS) {
+    const readmePath = join(packageDir, variant);
+    if (existsSync(readmePath)) {
+      return readFile(readmePath, "utf-8");
+    }
+  }
+  return null;
+}
+
+// ── Scope resolution ─────────────────────────────────────────
+
+/** Resolve the publish scope (namespace) with three-tier priority */
+export async function resolvePublishScope(
+  manifest: ArcManifest,
+  source: RegistrySource,
+  cliScope?: string,
+): Promise<string | null> {
+  // 1. CLI --scope flag
+  if (cliScope) return cliScope;
+
+  // 2. Manifest namespace field
+  if (manifest.namespace) return manifest.namespace;
+
+  // 3. Fetch from /auth/me API
+  if (!source.token) return null;
+
+  try {
+    const resp = await fetch(`${source.url}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${source.token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!resp.ok) return null;
+
+    const body = (await resp.json()) as { namespace?: string };
+    return body.namespace ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Upload ───────────────────────────────────────────────────
+
+/** Upload a tarball to the registry storage endpoint */
+export async function uploadBundle(
+  tarballPath: string,
+  source: RegistrySource,
+  clientSha256: string,
+): Promise<UploadResult> {
+  const file = Bun.file(tarballPath);
+  const buffer = await file.arrayBuffer();
+
+  try {
+    const resp = await fetch(`${source.url}/api/v1/storage/upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${source.token}`,
+        "Content-Type": "application/octet-stream",
+      },
+      body: buffer,
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (resp.status === 401) {
+      return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: 'Not authenticated. Run "arc login" first.' };
+    }
+
+    if (resp.status === 413) {
+      return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Package too large for server." };
+    }
+
+    const body = (await resp.json()) as { sha256: string; r2_key: string; size_bytes: number; error?: string };
+
+    // 409 = content already exists — treat as success (idempotent)
+    if (resp.status === 409) {
+      return {
+        success: true,
+        sha256: body.sha256,
+        r2Key: body.r2_key,
+        sizeBytes: body.size_bytes ?? 0,
+      };
+    }
+
+    if (!resp.ok) {
+      return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: body.error ?? `Upload failed: HTTP ${resp.status}` };
+    }
+
+    // Verify SHA-256 match
+    if (body.sha256 !== clientSha256) {
+      return {
+        success: false,
+        sha256: body.sha256,
+        r2Key: body.r2_key,
+        sizeBytes: body.size_bytes,
+        error: `SHA-256 mismatch: client=${clientSha256}, server=${body.sha256}`,
+      };
+    }
+
+    return {
+      success: true,
+      sha256: body.sha256,
+      r2Key: body.r2_key,
+      sizeBytes: body.size_bytes,
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Upload timed out (120s limit)." };
+    }
+    return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Upload failed: network error." };
+  }
+}
+
+// ── Package existence check ──────────────────────────────────
+
+/** Check if package exists; auto-create on first publish */
+export async function ensurePackageExists(
+  source: RegistrySource,
+  scope: string,
+  name: string,
+  manifest: ArcManifest,
+): Promise<EnsurePackageResult> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${source.token}`,
+  };
+
+  try {
+    // Check existence
+    const getResp = await fetch(
+      `${source.url}/api/v1/packages/${encodeURIComponent(`@${scope}`)}/${encodeURIComponent(name)}`,
+      { headers, signal: AbortSignal.timeout(10_000) },
+    );
+
+    if (getResp.status === 200) {
+      return { exists: true, created: false };
+    }
+
+    if (getResp.status !== 404) {
+      const body = await getResp.json().catch(() => ({})) as { error?: string };
+      if (getResp.status === 403) {
+        return { exists: false, created: false, error: `You do not own namespace @${scope}. Complete identity verification at meta-factory.ai.` };
+      }
+      return { exists: false, created: false, error: body.error ?? `Unexpected status: ${getResp.status}` };
+    }
+
+    // Package doesn't exist — create it
+    const createResp = await fetch(`${source.url}/api/v1/packages`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        namespace: scope,
+        name,
+        type: manifest.type,
+        description: manifest.description ?? "",
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (createResp.status === 201 || createResp.status === 200) {
+      return { exists: true, created: true };
+    }
+
+    const createBody = await createResp.json().catch(() => ({})) as { error?: string };
+    if (createResp.status === 403) {
+      return { exists: false, created: false, error: `You do not own namespace @${scope}. Complete identity verification at meta-factory.ai.` };
+    }
+
+    return { exists: false, created: false, error: createBody.error ?? `Failed to create package: HTTP ${createResp.status}` };
+  } catch {
+    return { exists: false, created: false, error: "Network error checking package existence." };
+  }
+}
+
+// ── Version registration ─────────────────────────────────────
+
+export interface RegisterPayload {
+  version: string;
+  sha256: string;
+  r2_key: string;
+  size_bytes: number;
+  manifest: ArcManifest;
+  readme?: string;
+}
+
+/** Register a new version for an existing package */
+export async function registerVersion(
+  source: RegistrySource,
+  scope: string,
+  name: string,
+  payload: RegisterPayload,
+): Promise<RegisterResult> {
+  const url = `${source.url}/api/v1/packages/${encodeURIComponent(`@${scope}`)}/${encodeURIComponent(name)}/versions`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${source.token}`,
+    "Content-Type": "application/json",
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (resp.status === 201 || resp.status === 200) {
+        const body = (await resp.json()) as { version_id?: string };
+        return { success: true, versionId: body.version_id, statusCode: resp.status };
+      }
+
+      const body = (await resp.json().catch(() => ({}))) as { error?: string };
+
+      if (resp.status === 409) {
+        return {
+          success: false,
+          error: `Version ${payload.version} already exists. Published versions are immutable — bump the version in arc-manifest.yaml.`,
+          statusCode: 409,
+        };
+      }
+
+      if (resp.status === 400) {
+        return { success: false, error: body.error ?? "Manifest validation failed on server.", statusCode: 400 };
+      }
+
+      if (resp.status === 403) {
+        return { success: false, error: `Namespace @${scope} not owned. Complete identity verification at meta-factory.ai.`, statusCode: 403 };
+      }
+
+      if (resp.status === 401) {
+        return { success: false, error: 'Not authenticated. Run "arc login" first.', statusCode: 401 };
+      }
+
+      // Retry on server error
+      if (resp.status >= 500 && attempt === 0) continue;
+
+      return { success: false, error: body.error ?? `Registration failed: HTTP ${resp.status}`, statusCode: resp.status };
+    } catch {
+      if (attempt === 0) continue;
+      return { success: false, error: "Network error during version registration." };
+    }
+  }
+
+  return { success: false, error: "Registration failed after retries." };
+}

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -8,10 +8,28 @@ import type {
   RegisterResult,
   EnsurePackageResult,
 } from "../types.js";
+import { README_VARIANTS } from "./bundle.js";
+
+// ── Constants ────────────────────────────────────────────────
+
+const API_TIMEOUT_MS = 10_000;
+const UPLOAD_TIMEOUT_MS = 120_000;
+
+// ── Debug logging ────────────────────────────────────────────
+
+function debugLog(msg: string): void {
+  if (process.env.ARC_DEBUG === "1") {
+    process.stderr.write(`[arc:publish] ${msg}\n`);
+  }
+}
+
+// ── HTTP helpers ─────────────────────────────────────────────
+
+function buildPublishHeaders(source: RegistrySource): Record<string, string> {
+  return { Authorization: `Bearer ${source.token}` };
+}
 
 // ── README extraction ────────────────────────────────────────
-
-const README_VARIANTS = ["README.md", "readme.md", "Readme.md"];
 
 /** Extract raw README markdown from a package directory */
 export async function extractReadme(packageDir: string): Promise<string | null> {
@@ -43,15 +61,16 @@ export async function resolvePublishScope(
 
   try {
     const resp = await fetch(`${source.url}/api/v1/auth/me`, {
-      headers: { Authorization: `Bearer ${source.token}` },
-      signal: AbortSignal.timeout(10_000),
+      headers: buildPublishHeaders(source),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (!resp.ok) return null;
 
     const body = (await resp.json()) as { namespace?: string };
     return body.namespace ?? null;
-  } catch {
+  } catch (err) {
+    debugLog(`/auth/me scope resolution failed: ${(err as Error).message}`);
     return null;
   }
 }
@@ -71,11 +90,11 @@ export async function uploadBundle(
     const resp = await fetch(`${source.url}/api/v1/storage/upload`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${source.token}`,
+        ...buildPublishHeaders(source),
         "Content-Type": "application/octet-stream",
       },
       body: buffer,
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
     });
 
     if (resp.status === 401) {
@@ -86,44 +105,35 @@ export async function uploadBundle(
       return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Package too large for server." };
     }
 
-    const body = (await resp.json()) as { sha256: string; r2_key: string; size_bytes: number; error?: string };
+    const body = (await resp.json()) as { sha256?: string; r2_key?: string; size_bytes?: number; error?: string };
 
     // 409 = content already exists — treat as success (idempotent)
     if (resp.status === 409) {
-      return {
-        success: true,
-        sha256: body.sha256,
-        r2Key: body.r2_key,
-        sizeBytes: body.size_bytes ?? 0,
-      };
+      if (!body.sha256 || !body.r2_key) {
+        return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Server returned 409 with missing sha256/r2_key fields." };
+      }
+      return { success: true, sha256: body.sha256, r2Key: body.r2_key, sizeBytes: body.size_bytes ?? 0 };
     }
 
     if (!resp.ok) {
       return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: body.error ?? `Upload failed: HTTP ${resp.status}` };
     }
 
-    // Verify SHA-256 match
-    if (body.sha256 !== clientSha256) {
-      return {
-        success: false,
-        sha256: body.sha256,
-        r2Key: body.r2_key,
-        sizeBytes: body.size_bytes,
-        error: `SHA-256 mismatch: client=${clientSha256}, server=${body.sha256}`,
-      };
+    if (!body.sha256 || !body.r2_key) {
+      return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Server response missing sha256 or r2_key fields." };
     }
 
-    return {
-      success: true,
-      sha256: body.sha256,
-      r2Key: body.r2_key,
-      sizeBytes: body.size_bytes,
-    };
+    // Verify SHA-256 match
+    if (body.sha256 !== clientSha256) {
+      return { success: false, sha256: body.sha256, r2Key: body.r2_key, sizeBytes: body.size_bytes ?? 0, error: `SHA-256 mismatch: client=${clientSha256}, server=${body.sha256}` };
+    }
+
+    return { success: true, sha256: body.sha256, r2Key: body.r2_key, sizeBytes: body.size_bytes ?? 0 };
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") {
       return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Upload timed out (120s limit)." };
     }
-    return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: "Upload failed: network error." };
+    return { success: false, sha256: "", r2Key: "", sizeBytes: 0, error: `Upload failed: ${(err as Error).message}` };
   }
 }
 
@@ -136,15 +146,12 @@ export async function ensurePackageExists(
   name: string,
   manifest: ArcManifest,
 ): Promise<EnsurePackageResult> {
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${source.token}`,
-  };
+  const headers = buildPublishHeaders(source);
 
   try {
-    // Check existence
     const getResp = await fetch(
       `${source.url}/api/v1/packages/${encodeURIComponent(`@${scope}`)}/${encodeURIComponent(name)}`,
-      { headers, signal: AbortSignal.timeout(10_000) },
+      { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) },
     );
 
     if (getResp.status === 200) {
@@ -159,17 +166,11 @@ export async function ensurePackageExists(
       return { exists: false, created: false, error: body.error ?? `Unexpected status: ${getResp.status}` };
     }
 
-    // Package doesn't exist — create it
     const createResp = await fetch(`${source.url}/api/v1/packages`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        namespace: scope,
-        name,
-        type: manifest.type,
-        description: manifest.description ?? "",
-      }),
-      signal: AbortSignal.timeout(10_000),
+      body: JSON.stringify({ namespace: scope, name, type: manifest.type, description: manifest.description ?? "" }),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
     });
 
     if (createResp.status === 201 || createResp.status === 200) {
@@ -182,8 +183,8 @@ export async function ensurePackageExists(
     }
 
     return { exists: false, created: false, error: createBody.error ?? `Failed to create package: HTTP ${createResp.status}` };
-  } catch {
-    return { exists: false, created: false, error: "Network error checking package existence." };
+  } catch (err) {
+    return { exists: false, created: false, error: `Network error checking package existence: ${(err as Error).message}` };
   }
 }
 
@@ -206,10 +207,7 @@ export async function registerVersion(
   payload: RegisterPayload,
 ): Promise<RegisterResult> {
   const url = `${source.url}/api/v1/packages/${encodeURIComponent(`@${scope}`)}/${encodeURIComponent(name)}/versions`;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${source.token}`,
-    "Content-Type": "application/json",
-  };
+  const headers = { ...buildPublishHeaders(source), "Content-Type": "application/json" };
 
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
@@ -217,7 +215,7 @@ export async function registerVersion(
         method: "POST",
         headers,
         body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(10_000),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
       });
 
       if (resp.status === 201 || resp.status === 200) {
@@ -228,11 +226,7 @@ export async function registerVersion(
       const body = (await resp.json().catch(() => ({}))) as { error?: string };
 
       if (resp.status === 409) {
-        return {
-          success: false,
-          error: `Version ${payload.version} already exists. Published versions are immutable — bump the version in arc-manifest.yaml.`,
-          statusCode: 409,
-        };
+        return { success: false, error: `Version ${payload.version} already exists. Published versions are immutable — bump the version in arc-manifest.yaml.`, statusCode: 409 };
       }
 
       if (resp.status === 400) {
@@ -247,13 +241,12 @@ export async function registerVersion(
         return { success: false, error: 'Not authenticated. Run "arc login" first.', statusCode: 401 };
       }
 
-      // Retry on server error
       if (resp.status >= 500 && attempt === 0) continue;
 
       return { success: false, error: body.error ?? `Registration failed: HTTP ${resp.status}`, statusCode: resp.status };
-    } catch {
+    } catch (err) {
       if (attempt === 0) continue;
-      return { success: false, error: "Network error during version registration." };
+      return { success: false, error: `Network error during version registration: ${(err as Error).message}` };
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,7 +479,6 @@ export interface PublishValidation {
   valid: boolean;
   errors: string[];
   warnings: string[];
-  scope?: string;
   name: string;
   version: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,12 @@ export interface ArcManifest {
     preupgrade?: string;
     postupgrade?: string;
   };
+  /** Optional namespace for publishing (alternative to account default) */
+  namespace?: string;
+  /** Bundle configuration for arc publish */
+  bundle?: BundleConfig;
+  /** Package description */
+  description?: string;
 }
 
 /** Trust tier for installed packages */
@@ -446,4 +452,58 @@ export interface PaiPaths {
   actionsDir: string;
   /** Claude settings path (~/.claude/settings.json) */
   settingsPath: string;
+}
+
+// ── Bundle and publish types ─────────────────────────────────
+
+/** Bundle exclusion configuration (from arc-manifest.yaml) */
+export interface BundleConfig {
+  exclude?: string[];
+  include?: string[];
+}
+
+/** Result of tarball creation */
+export interface BundleResult {
+  success: boolean;
+  tarballPath: string;
+  sha256: string;
+  sizeBytes: number;
+  fileCount: number;
+  manifest: ArcManifest;
+  warnings: string[];
+  error?: string;
+}
+
+/** Manifest validation for publishing (stricter than install) */
+export interface PublishValidation {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  scope?: string;
+  name: string;
+  version: string;
+}
+
+/** Result of R2 storage upload */
+export interface UploadResult {
+  success: boolean;
+  sha256: string;
+  r2Key: string;
+  sizeBytes: number;
+  error?: string;
+}
+
+/** Result of version registration */
+export interface RegisterResult {
+  success: boolean;
+  versionId?: string;
+  error?: string;
+  statusCode?: number;
+}
+
+/** Result of package existence check/creation */
+export interface EnsurePackageResult {
+  exists: boolean;
+  created: boolean;
+  error?: string;
 }

--- a/test/commands/bundle.test.ts
+++ b/test/commands/bundle.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
+import YAML from "yaml";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { bundle, formatBundle } from "../../src/commands/bundle.js";
+
+let env: TestEnv;
+let testDir: string;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  testDir = await mkdtemp(join(tmpdir(), "arc-bundle-cmd-"));
+});
+
+afterEach(async () => {
+  await env.cleanup();
+  await rm(testDir, { recursive: true, force: true });
+});
+
+async function createPackage(
+  dir: string,
+  manifest: Record<string, any>,
+  opts?: { withReadme?: boolean },
+): Promise<string> {
+  const pkgDir = join(dir, "pkg");
+  await mkdir(pkgDir, { recursive: true });
+  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(manifest));
+  await mkdir(join(pkgDir, "skill"), { recursive: true });
+  await writeFile(join(pkgDir, "skill/SKILL.md"), "# Test\n\nSkill content.\n");
+  if (opts?.withReadme !== false) {
+    await writeFile(join(pkgDir, "README.md"), "# Test Package\n");
+  }
+  return pkgDir;
+}
+
+describe("arc bundle command", () => {
+  test("bundles a valid package", async () => {
+    const pkgDir = await createPackage(testDir, {
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A skill",
+      capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
+    });
+
+    const result = await bundle({ paths: env.paths, packageDir: pkgDir });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("my-skill");
+    expect(result.version).toBe("1.0.0");
+    expect(result.type).toBe("skill");
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.tarballPath).toBeDefined();
+    expect(existsSync(result.tarballPath!)).toBe(true);
+
+    // Clean up
+    await rm(result.tarballPath!).catch(() => {});
+  });
+
+  test("custom output path", async () => {
+    const pkgDir = await createPackage(testDir, {
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A skill",
+      capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
+    });
+
+    const outputPath = join(testDir, "custom.tar.gz");
+    const result = await bundle({ paths: env.paths, packageDir: pkgDir, outputPath });
+
+    expect(result.success).toBe(true);
+    expect(result.tarballPath).toBe(outputPath);
+    expect(existsSync(outputPath)).toBe(true);
+
+    await rm(outputPath).catch(() => {});
+  });
+
+  test("fails with missing manifest", async () => {
+    const emptyDir = join(testDir, "empty");
+    await mkdir(emptyDir, { recursive: true });
+
+    const result = await bundle({ paths: env.paths, packageDir: emptyDir });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("arc-manifest.yaml");
+  });
+
+  test("fails with invalid manifest", async () => {
+    const pkgDir = await createPackage(testDir, {
+      name: "My Bad Name!",
+      version: "not-semver",
+      type: "skill",
+      capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
+    });
+
+    const result = await bundle({ paths: env.paths, packageDir: pkgDir });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("validation failed");
+  });
+
+  test("formatBundle produces readable output", async () => {
+    const result = {
+      success: true,
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+      tarballPath: "/tmp/my-skill-1.0.0.tar.gz",
+      sha256: "abc123def456",
+      sizeBytes: 24576,
+      fileCount: 12,
+      warnings: [],
+    };
+
+    const output = formatBundle(result);
+    expect(output).toContain("Bundled my-skill v1.0.0");
+    expect(output).toContain("Type:     skill");
+    expect(output).toContain("Files:    12");
+    expect(output).toContain("SHA-256:  abc123def456");
+  });
+
+  test("formatBundle includes warnings", () => {
+    const result = {
+      success: true,
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+      tarballPath: "/tmp/test.tar.gz",
+      sha256: "abc123",
+      sizeBytes: 100,
+      fileCount: 1,
+      warnings: ["No README.md found"],
+    };
+
+    const output = formatBundle(result);
+    expect(output).toContain("Warning: No README.md found");
+  });
+
+  test("formatBundle shows error on failure", () => {
+    const result = {
+      success: false,
+      error: "Something went wrong",
+    };
+
+    const output = formatBundle(result);
+    expect(output).toContain("Error: Something went wrong");
+  });
+});

--- a/test/commands/bundle.test.ts
+++ b/test/commands/bundle.test.ts
@@ -1,10 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { mkdtemp, rm, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { existsSync } from "fs";
-import YAML from "yaml";
-import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { createTestEnv, createPackageDir, type TestEnv } from "../helpers/test-env.js";
 import { bundle, formatBundle } from "../../src/commands/bundle.js";
 
 let env: TestEnv;
@@ -20,25 +19,9 @@ afterEach(async () => {
   await rm(testDir, { recursive: true, force: true });
 });
 
-async function createPackage(
-  dir: string,
-  manifest: Record<string, any>,
-  opts?: { withReadme?: boolean },
-): Promise<string> {
-  const pkgDir = join(dir, "pkg");
-  await mkdir(pkgDir, { recursive: true });
-  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(manifest));
-  await mkdir(join(pkgDir, "skill"), { recursive: true });
-  await writeFile(join(pkgDir, "skill/SKILL.md"), "# Test\n\nSkill content.\n");
-  if (opts?.withReadme !== false) {
-    await writeFile(join(pkgDir, "README.md"), "# Test Package\n");
-  }
-  return pkgDir;
-}
-
 describe("arc bundle command", () => {
   test("bundles a valid package", async () => {
-    const pkgDir = await createPackage(testDir, {
+    const pkgDir = await createPackageDir(testDir, {
       name: "my-skill",
       version: "1.0.0",
       type: "skill",
@@ -61,7 +44,7 @@ describe("arc bundle command", () => {
   });
 
   test("custom output path", async () => {
-    const pkgDir = await createPackage(testDir, {
+    const pkgDir = await createPackageDir(testDir, {
       name: "my-skill",
       version: "1.0.0",
       type: "skill",
@@ -89,7 +72,7 @@ describe("arc bundle command", () => {
   });
 
   test("fails with invalid manifest", async () => {
-    const pkgDir = await createPackage(testDir, {
+    const pkgDir = await createPackageDir(testDir, {
       name: "My Bad Name!",
       version: "not-semver",
       type: "skill",

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import YAML from "yaml";
-import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { createTestEnv, createPackageDir, type TestEnv } from "../helpers/test-env.js";
+import { mockFetch } from "../helpers/mock-fetch.js";
 import { publish, formatPublish } from "../../src/commands/publish.js";
 import { saveSources } from "../../src/lib/sources.js";
 import type { SourcesConfig } from "../../src/types.js";
@@ -11,10 +11,6 @@ import type { SourcesConfig } from "../../src/types.js";
 let env: TestEnv;
 let testDir: string;
 let savedFetch: typeof fetch;
-
-function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
-  (globalThis as any).fetch = fn;
-}
 
 beforeEach(async () => {
   env = await createTestEnv();
@@ -41,16 +37,6 @@ function metafactorySource(token = "test-token"): SourcesConfig {
   };
 }
 
-async function createPackage(dir: string, manifest: Record<string, any>): Promise<string> {
-  const pkgDir = join(dir, "pkg");
-  await mkdir(pkgDir, { recursive: true });
-  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(manifest));
-  await mkdir(join(pkgDir, "skill"), { recursive: true });
-  await writeFile(join(pkgDir, "skill/SKILL.md"), "# Test\n");
-  await writeFile(join(pkgDir, "README.md"), "# Test Package\n");
-  return pkgDir;
-}
-
 const validManifest = {
   name: "my-skill",
   version: "1.0.0",
@@ -63,7 +49,7 @@ const validManifest = {
 describe("arc publish command", () => {
   test("fails without metafactory source", async () => {
     await saveSources(env.paths.sourcesPath, { sources: [] });
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     const result = await publish({ paths: env.paths, packageDir: pkgDir });
     expect(result.success).toBe(false);
@@ -71,8 +57,6 @@ describe("arc publish command", () => {
   });
 
   test("fails without authentication", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource(undefined as any));
-    // Remove token by saving without it
     await saveSources(env.paths.sourcesPath, {
       sources: [{
         name: "mf-test",
@@ -82,7 +66,7 @@ describe("arc publish command", () => {
         type: "metafactory",
       }],
     });
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     const result = await publish({ paths: env.paths, packageDir: pkgDir });
     expect(result.success).toBe(false);
@@ -91,7 +75,7 @@ describe("arc publish command", () => {
 
   test("dry-run validates without uploading", async () => {
     await saveSources(env.paths.sourcesPath, metafactorySource());
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     // No fetch mock needed — dry run should not make any HTTP calls
     const result = await publish({ paths: env.paths, packageDir: pkgDir, dryRun: true });
@@ -104,7 +88,7 @@ describe("arc publish command", () => {
 
   test("scope override via --scope flag", async () => {
     await saveSources(env.paths.sourcesPath, metafactorySource());
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     const result = await publish({
       paths: env.paths,
@@ -118,7 +102,7 @@ describe("arc publish command", () => {
 
   test("full publish flow with mocked API", async () => {
     await saveSources(env.paths.sourcesPath, metafactorySource());
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     let uploadCalled = false;
     let ensureCalled = false;
@@ -159,7 +143,7 @@ describe("arc publish command", () => {
 
   test("version exists error (409)", async () => {
     await saveSources(env.paths.sourcesPath, metafactorySource());
-    const pkgDir = await createPackage(testDir, validManifest);
+    const pkgDir = await createPackageDir(testDir, validManifest);
 
     mockFetch(async (url: any) => {
       const urlStr = String(url);

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { publish, formatPublish } from "../../src/commands/publish.js";
+import { saveSources } from "../../src/lib/sources.js";
+import type { SourcesConfig } from "../../src/types.js";
+
+let env: TestEnv;
+let testDir: string;
+let savedFetch: typeof fetch;
+
+function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
+  (globalThis as any).fetch = fn;
+}
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  testDir = await mkdtemp(join(tmpdir(), "arc-publish-cmd-"));
+  savedFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = savedFetch;
+  await env.cleanup();
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function metafactorySource(token = "test-token"): SourcesConfig {
+  return {
+    sources: [{
+      name: "mf-test",
+      url: "https://meta-factory.test",
+      tier: "official",
+      enabled: true,
+      type: "metafactory",
+      token,
+    }],
+  };
+}
+
+async function createPackage(dir: string, manifest: Record<string, any>): Promise<string> {
+  const pkgDir = join(dir, "pkg");
+  await mkdir(pkgDir, { recursive: true });
+  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(manifest));
+  await mkdir(join(pkgDir, "skill"), { recursive: true });
+  await writeFile(join(pkgDir, "skill/SKILL.md"), "# Test\n");
+  await writeFile(join(pkgDir, "README.md"), "# Test Package\n");
+  return pkgDir;
+}
+
+const validManifest = {
+  name: "my-skill",
+  version: "1.0.0",
+  type: "skill",
+  description: "A skill",
+  namespace: "testns",
+  capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
+};
+
+describe("arc publish command", () => {
+  test("fails without metafactory source", async () => {
+    await saveSources(env.paths.sourcesPath, { sources: [] });
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("metafactory");
+  });
+
+  test("fails without authentication", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource(undefined as any));
+    // Remove token by saving without it
+    await saveSources(env.paths.sourcesPath, {
+      sources: [{
+        name: "mf-test",
+        url: "https://meta-factory.test",
+        tier: "official",
+        enabled: true,
+        type: "metafactory",
+      }],
+    });
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("login");
+  });
+
+  test("dry-run validates without uploading", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    // No fetch mock needed — dry run should not make any HTTP calls
+    const result = await publish({ paths: env.paths, packageDir: pkgDir, dryRun: true });
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.name).toBe("my-skill");
+    expect(result.version).toBe("1.0.0");
+    expect(result.scope).toBe("testns");
+  });
+
+  test("scope override via --scope flag", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    const result = await publish({
+      paths: env.paths,
+      packageDir: pkgDir,
+      dryRun: true,
+      scope: "custom-ns",
+    });
+    expect(result.success).toBe(true);
+    expect(result.scope).toBe("custom-ns");
+  });
+
+  test("full publish flow with mocked API", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    let uploadCalled = false;
+    let ensureCalled = false;
+    let registerCalled = false;
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        uploadCalled = true;
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/versions")) {
+        registerCalled = true;
+        return new Response(JSON.stringify({ version_id: "uuid-1" }), { status: 201 });
+      }
+
+      if (urlStr.includes("/packages/")) {
+        ensureCalled = true;
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("my-skill");
+    expect(result.version).toBe("1.0.0");
+    expect(uploadCalled).toBe(true);
+    expect(ensureCalled).toBe(true);
+    expect(registerCalled).toBe(true);
+  });
+
+  test("version exists error (409)", async () => {
+    await saveSources(env.paths.sourcesPath, metafactorySource());
+    const pkgDir = await createPackage(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "x", r2_key: "packages/x.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/versions")) {
+        return new Response(
+          JSON.stringify({ error: "Version 1.0.0 already exists" }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("immutable");
+  });
+
+  test("formatPublish dry run output", () => {
+    const output = formatPublish({
+      success: true,
+      name: "my-skill",
+      version: "1.0.0",
+      scope: "testns",
+      sha256: "abc123",
+      dryRun: true,
+    });
+    expect(output).toContain("[DRY RUN]");
+    expect(output).toContain("@testns/my-skill");
+  });
+
+  test("formatPublish success output", () => {
+    const output = formatPublish({
+      success: true,
+      name: "my-skill",
+      version: "1.0.0",
+      scope: "testns",
+      sha256: "abc123",
+      url: "https://meta-factory.ai/package/@testns/my-skill",
+    });
+    expect(output).toContain("Published @testns/my-skill");
+    expect(output).toContain("URL:");
+  });
+
+  test("formatPublish error output", () => {
+    const output = formatPublish({
+      success: false,
+      error: "Not authenticated",
+    });
+    expect(output).toContain("Error: Not authenticated");
+  });
+});

--- a/test/helpers/mock-fetch.ts
+++ b/test/helpers/mock-fetch.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared fetch mock helper for tests that intercept HTTP calls.
+ * Replaces globalThis.fetch with a test handler.
+ * Restore the original with the value returned by saveFetch().
+ */
+
+export function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
+  (globalThis as any).fetch = fn;
+}

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -5,10 +5,11 @@
  * Every test gets its own fresh environment — no cross-test contamination.
  */
 
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { Database } from "bun:sqlite";
+import YAML from "yaml";
 import { createPaths } from "../../src/lib/paths.js";
 import { openDatabase } from "../../src/lib/db.js";
 import { ensureDirectories } from "../../src/lib/paths.js";
@@ -335,6 +336,35 @@ export async function createMockLibraryRepo(
   );
 
   return { path: repoDir, url: repoDir };
+}
+
+/**
+ * Create an isolated package directory with an arc-manifest.yaml.
+ * Used across bundle and publish tests to reduce boilerplate.
+ */
+export async function createPackageDir(
+  dir: string,
+  manifest: Record<string, any>,
+  opts?: { withReadme?: boolean; withSkillDir?: boolean; extraFiles?: Record<string, string> },
+): Promise<string> {
+  const pkgDir = join(dir, "pkg");
+  await mkdir(pkgDir, { recursive: true });
+  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(manifest));
+  if (opts?.withSkillDir !== false) {
+    await mkdir(join(pkgDir, "skill"), { recursive: true });
+    await writeFile(join(pkgDir, "skill/SKILL.md"), "# Test\n\nSkill content.\n");
+  }
+  if (opts?.withReadme !== false) {
+    await writeFile(join(pkgDir, "README.md"), "# Test Package\n");
+  }
+  if (opts?.extraFiles) {
+    for (const [filePath, content] of Object.entries(opts.extraFiles)) {
+      const fullPath = join(pkgDir, filePath);
+      await mkdir(join(fullPath, ".."), { recursive: true });
+      await writeFile(fullPath, content);
+    }
+  }
+  return pkgDir;
 }
 
 /**

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -12,6 +12,7 @@ import {
   createBundle,
   DEFAULT_EXCLUSIONS,
 } from "../../src/lib/bundle.js";
+import { createPackageDir } from "../helpers/test-env.js";
 import type { ArcManifest } from "../../src/types.js";
 
 // ── Helper ───────────────────────────────────────────────────
@@ -31,29 +32,12 @@ async function createMockPackage(
   manifest: Partial<ArcManifest> & { name: string; version: string; type: string },
   opts?: { withReadme?: boolean; extraFiles?: Record<string, string> },
 ): Promise<string> {
-  const pkgDir = join(dir, "pkg");
-  await mkdir(pkgDir, { recursive: true });
-
   const fullManifest = {
     schema: "arc/v1",
     ...manifest,
     capabilities: manifest.capabilities ?? { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
   };
-  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(fullManifest));
-
-  if (opts?.withReadme !== false) {
-    await writeFile(join(pkgDir, "README.md"), `# ${manifest.name}\n\nTest package.\n`);
-  }
-
-  if (opts?.extraFiles) {
-    for (const [path, content] of Object.entries(opts.extraFiles)) {
-      const fullPath = join(pkgDir, path);
-      await mkdir(join(fullPath, ".."), { recursive: true });
-      await writeFile(fullPath, content);
-    }
-  }
-
-  return pkgDir;
+  return createPackageDir(dir, fullManifest, { ...opts, withSkillDir: false });
 }
 
 // ── computeChecksum ──────────────────────────────────────────

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -1,0 +1,341 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
+import YAML from "yaml";
+import {
+  computeChecksum,
+  withTempDir,
+  getExclusionPatterns,
+  validateForPublish,
+  createBundle,
+  DEFAULT_EXCLUSIONS,
+} from "../../src/lib/bundle.js";
+import type { ArcManifest } from "../../src/types.js";
+
+// ── Helper ───────────────────────────────────────────────────
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "arc-bundle-test-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+async function createMockPackage(
+  dir: string,
+  manifest: Partial<ArcManifest> & { name: string; version: string; type: string },
+  opts?: { withReadme?: boolean; extraFiles?: Record<string, string> },
+): Promise<string> {
+  const pkgDir = join(dir, "pkg");
+  await mkdir(pkgDir, { recursive: true });
+
+  const fullManifest = {
+    schema: "arc/v1",
+    ...manifest,
+    capabilities: manifest.capabilities ?? { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
+  };
+  await writeFile(join(pkgDir, "arc-manifest.yaml"), YAML.stringify(fullManifest));
+
+  if (opts?.withReadme !== false) {
+    await writeFile(join(pkgDir, "README.md"), `# ${manifest.name}\n\nTest package.\n`);
+  }
+
+  if (opts?.extraFiles) {
+    for (const [path, content] of Object.entries(opts.extraFiles)) {
+      const fullPath = join(pkgDir, path);
+      await mkdir(join(fullPath, ".."), { recursive: true });
+      await writeFile(fullPath, content);
+    }
+  }
+
+  return pkgDir;
+}
+
+// ── computeChecksum ──────────────────────────────────────────
+
+describe("computeChecksum", () => {
+  test("returns SHA-256 hex digest", async () => {
+    const filePath = join(testDir, "test.bin");
+    await writeFile(filePath, "hello world");
+
+    const hash = await computeChecksum(filePath);
+
+    // Verify against known SHA-256 of "hello world"
+    expect(hash).toBe("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+  });
+
+  test("returns lowercase hex", async () => {
+    const filePath = join(testDir, "test.bin");
+    await writeFile(filePath, "test");
+    const hash = await computeChecksum(filePath);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ── withTempDir ──────────────────────────────────────────────
+
+describe("withTempDir", () => {
+  test("provides existing directory during callback", async () => {
+    let capturedDir = "";
+    await withTempDir(async (dir) => {
+      capturedDir = dir;
+      expect(existsSync(dir)).toBe(true);
+    });
+    // After callback, directory should be cleaned up
+    expect(existsSync(capturedDir)).toBe(false);
+  });
+
+  test("cleans up even on error", async () => {
+    let capturedDir = "";
+    try {
+      await withTempDir(async (dir) => {
+        capturedDir = dir;
+        throw new Error("boom");
+      });
+    } catch {
+      // expected
+    }
+    expect(existsSync(capturedDir)).toBe(false);
+  });
+});
+
+// ── getExclusionPatterns ─────────────────────────────────────
+
+describe("getExclusionPatterns", () => {
+  test("returns defaults when no manifest bundle config", () => {
+    const manifest = { name: "test", version: "1.0.0", type: "skill" } as ArcManifest;
+    const patterns = getExclusionPatterns(manifest);
+    expect(patterns).toEqual(DEFAULT_EXCLUSIONS);
+  });
+
+  test("appends manifest bundle.exclude", () => {
+    const manifest = {
+      name: "test", version: "1.0.0", type: "skill",
+      bundle: { exclude: ["*.tmp", "coverage"] },
+    } as ArcManifest;
+    const patterns = getExclusionPatterns(manifest);
+    expect(patterns).toContain("*.tmp");
+    expect(patterns).toContain("coverage");
+    expect(patterns.length).toBe(DEFAULT_EXCLUSIONS.length + 2);
+  });
+
+  test("handles empty bundle config", () => {
+    const manifest = {
+      name: "test", version: "1.0.0", type: "skill",
+      bundle: {},
+    } as ArcManifest;
+    const patterns = getExclusionPatterns(manifest);
+    expect(patterns).toEqual(DEFAULT_EXCLUSIONS);
+  });
+});
+
+// ── validateForPublish ───────────────────────────────────────
+
+describe("validateForPublish", () => {
+  test("valid manifest passes", () => {
+    const result = validateForPublish({
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("missing name fails", () => {
+    const result = validateForPublish({
+      version: "1.0.0",
+      type: "skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("name"))).toBe(true);
+  });
+
+  test("invalid name fails", () => {
+    const result = validateForPublish({
+      name: "My Skill!",
+      version: "1.0.0",
+      type: "skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("name"))).toBe(true);
+  });
+
+  test("missing version fails", () => {
+    const result = validateForPublish({
+      name: "my-skill",
+      type: "skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("version"))).toBe(true);
+  });
+
+  test("invalid version fails", () => {
+    const result = validateForPublish({
+      name: "my-skill",
+      version: "not-semver",
+      type: "skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("semver"))).toBe(true);
+  });
+
+  test("missing description warns but passes", () => {
+    const result = validateForPublish({
+      name: "my-skill",
+      version: "1.0.0",
+      type: "skill",
+    } as ArcManifest);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("description"))).toBe(true);
+  });
+
+  test("invalid type fails", () => {
+    const result = validateForPublish({
+      name: "my-skill",
+      version: "1.0.0",
+      type: "invalid" as any,
+    } as ArcManifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("type"))).toBe(true);
+  });
+});
+
+// ── createBundle ─────────────────────────────────────────────
+
+describe("createBundle", () => {
+  test("creates valid tarball from package directory", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    });
+
+    const result = await createBundle(pkgDir);
+
+    expect(result.success).toBe(true);
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.sizeBytes).toBeGreaterThan(0);
+    expect(result.fileCount).toBeGreaterThan(0);
+    expect(result.manifest.name).toBe("test-skill");
+    expect(existsSync(result.tarballPath)).toBe(true);
+
+    // Clean up tarball
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("excludes default patterns", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    }, {
+      extraFiles: {
+        ".git/config": "gitconfig",
+        "node_modules/dep/index.js": "module.exports = {}",
+        ".env": "SECRET=foo",
+        ".DS_Store": "junk",
+      },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+
+    // List tarball contents
+    const listResult = Bun.spawnSync(["tar", "tzf", result.tarballPath], { stdout: "pipe" });
+    const contents = listResult.stdout.toString();
+
+    expect(contents).not.toContain(".git/");
+    expect(contents).not.toContain("node_modules/");
+    expect(contents).not.toContain(".env");
+    expect(contents).not.toContain(".DS_Store");
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("bundle.include overrides exclusions", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+      bundle: { include: ["test"] },
+    }, {
+      extraFiles: {
+        "test/test.ts": "test code",
+      },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+
+    // "test" should be included since bundle.include overrides
+    const listResult = Bun.spawnSync(["tar", "tzf", result.tarballPath], { stdout: "pipe" });
+    const contents = listResult.stdout.toString();
+    expect(contents).toContain("test/");
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("warns when no README.md", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    }, { withReadme: false });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+    expect(result.warnings.some((w) => w.includes("README"))).toBe(true);
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("custom output path", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    });
+
+    const customOutput = join(testDir, "custom-output.tar.gz");
+    const result = await createBundle(pkgDir, customOutput);
+
+    expect(result.success).toBe(true);
+    expect(result.tarballPath).toBe(customOutput);
+    expect(existsSync(customOutput)).toBe(true);
+
+    await rm(customOutput).catch(() => {});
+  });
+
+  test("returns error for missing manifest", async () => {
+    const emptyDir = join(testDir, "empty");
+    await mkdir(emptyDir, { recursive: true });
+
+    const result = await createBundle(emptyDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("arc-manifest.yaml");
+  });
+
+  test("returns error for invalid manifest", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test",
+      version: "not-semver",
+      type: "skill",
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("validation failed");
+  });
+});

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -1,0 +1,288 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  extractReadme,
+  resolvePublishScope,
+  uploadBundle,
+  ensurePackageExists,
+  registerVersion,
+} from "../../src/lib/publish.js";
+import type { ArcManifest, RegistrySource } from "../../src/types.js";
+
+// ── Helper ───────────────────────────────────────────────────
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "arc-publish-test-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function makeSource(token = "test-token"): RegistrySource {
+  return {
+    name: "test-mf",
+    url: "https://meta-factory.test",
+    tier: "official",
+    enabled: true,
+    type: "metafactory",
+    token,
+  };
+}
+
+function makeManifest(overrides?: Partial<ArcManifest>): ArcManifest {
+  return {
+    name: "test-skill",
+    version: "1.0.0",
+    type: "skill",
+    description: "A test",
+    ...overrides,
+  } as ArcManifest;
+}
+
+function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
+  (globalThis as any).fetch = fn;
+}
+
+let savedFetch: typeof fetch;
+
+beforeEach(() => {
+  savedFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+});
+
+// ── extractReadme ────────────────────────────────────────────
+
+describe("extractReadme", () => {
+  test("returns README.md content", async () => {
+    await writeFile(join(testDir, "README.md"), "# Hello\n\nWorld");
+    const result = await extractReadme(testDir);
+    expect(result).toBe("# Hello\n\nWorld");
+  });
+
+  test("returns readme.md content (lowercase)", async () => {
+    await writeFile(join(testDir, "readme.md"), "# hello");
+    const result = await extractReadme(testDir);
+    expect(result).toBe("# hello");
+  });
+
+  test("returns Readme.md content (title case)", async () => {
+    await writeFile(join(testDir, "Readme.md"), "# Readme");
+    const result = await extractReadme(testDir);
+    expect(result).toBe("# Readme");
+  });
+
+  test("returns null when no README", async () => {
+    const result = await extractReadme(testDir);
+    expect(result).toBeNull();
+  });
+});
+
+// ── resolvePublishScope ──────────────────────────────────────
+
+describe("resolvePublishScope", () => {
+  test("CLI scope takes precedence", async () => {
+    const manifest = makeManifest({ namespace: "manifest-ns" });
+    const result = await resolvePublishScope(manifest, makeSource(), "cli-ns");
+    expect(result).toBe("cli-ns");
+  });
+
+  test("manifest namespace used when no CLI scope", async () => {
+    const manifest = makeManifest({ namespace: "manifest-ns" });
+    const result = await resolvePublishScope(manifest, makeSource());
+    expect(result).toBe("manifest-ns");
+  });
+
+  test("API fallback when neither available", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ namespace: "api-ns" }),
+      { status: 200 },
+    ));
+
+    const manifest = makeManifest();
+    const result = await resolvePublishScope(manifest, makeSource());
+    expect(result).toBe("api-ns");
+  });
+
+  test("returns null when API fails", async () => {
+    mockFetch(async () => new Response("error", { status: 500 }));
+
+    const manifest = makeManifest();
+    const result = await resolvePublishScope(manifest, makeSource());
+    expect(result).toBeNull();
+  });
+
+  test("returns null when no token", async () => {
+    const manifest = makeManifest();
+    const source = makeSource();
+    delete source.token;
+    const result = await resolvePublishScope(manifest, source);
+    expect(result).toBeNull();
+  });
+});
+
+// ── uploadBundle ─────────────────────────────────────────────
+
+describe("uploadBundle", () => {
+  test("successful upload returns result", async () => {
+    const filePath = join(testDir, "test.tar.gz");
+    await writeFile(filePath, "tarball content");
+
+    mockFetch(async () => new Response(
+      JSON.stringify({ sha256: "abc123", r2_key: "packages/abc123.tar.gz", size_bytes: 15 }),
+      { status: 201 },
+    ));
+
+    const result = await uploadBundle(filePath, makeSource(), "abc123");
+    expect(result.success).toBe(true);
+    expect(result.sha256).toBe("abc123");
+    expect(result.r2Key).toBe("packages/abc123.tar.gz");
+  });
+
+  test("SHA-256 mismatch returns error", async () => {
+    const filePath = join(testDir, "test.tar.gz");
+    await writeFile(filePath, "tarball content");
+
+    mockFetch(async () => new Response(
+      JSON.stringify({ sha256: "server-hash", r2_key: "packages/server-hash.tar.gz", size_bytes: 15 }),
+      { status: 201 },
+    ));
+
+    const result = await uploadBundle(filePath, makeSource(), "client-hash");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("SHA-256 mismatch");
+  });
+
+  test("401 returns auth error", async () => {
+    const filePath = join(testDir, "test.tar.gz");
+    await writeFile(filePath, "tarball content");
+
+    mockFetch(async () => new Response("Unauthorized", { status: 401 }));
+
+    const result = await uploadBundle(filePath, makeSource(), "hash");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("login");
+  });
+
+  test("409 treated as success (idempotent)", async () => {
+    const filePath = join(testDir, "test.tar.gz");
+    await writeFile(filePath, "tarball content");
+
+    mockFetch(async () => new Response(
+      JSON.stringify({ sha256: "abc123", r2_key: "packages/abc123.tar.gz", size_bytes: 15 }),
+      { status: 409 },
+    ));
+
+    const result = await uploadBundle(filePath, makeSource(), "abc123");
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── ensurePackageExists ──────────────────────────────────────
+
+describe("ensurePackageExists", () => {
+  test("returns exists=true when package already exists", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ namespace: "ns", name: "pkg" }),
+      { status: 200 },
+    ));
+
+    const result = await ensurePackageExists(makeSource(), "ns", "pkg", makeManifest());
+    expect(result.exists).toBe(true);
+    expect(result.created).toBe(false);
+  });
+
+  test("creates package when 404", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Not found", { status: 404 });
+      }
+      return new Response(JSON.stringify({ namespace: "ns", name: "pkg" }), { status: 201 });
+    });
+
+    const result = await ensurePackageExists(makeSource(), "ns", "pkg", makeManifest());
+    expect(result.exists).toBe(true);
+    expect(result.created).toBe(true);
+  });
+
+  test("returns error on 403 namespace not owned", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ error: "Forbidden" }),
+      { status: 403 },
+    ));
+
+    const result = await ensurePackageExists(makeSource(), "ns", "pkg", makeManifest());
+    expect(result.exists).toBe(false);
+    expect(result.error).toContain("namespace");
+  });
+});
+
+// ── registerVersion ──────────────────────────────────────────
+
+describe("registerVersion", () => {
+  const payload = {
+    version: "1.0.0",
+    sha256: "abc123",
+    r2_key: "packages/abc123.tar.gz",
+    size_bytes: 1000,
+    manifest: makeManifest(),
+  };
+
+  test("successful registration", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ version_id: "uuid-123" }),
+      { status: 201 },
+    ));
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(true);
+    expect(result.versionId).toBe("uuid-123");
+  });
+
+  test("409 version exists", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ error: "Already exists" }),
+      { status: 409 },
+    ));
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(409);
+    expect(result.error).toContain("immutable");
+  });
+
+  test("400 validation failed", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({ error: "Missing field" }),
+      { status: 400 },
+    ));
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(400);
+  });
+
+  test("retries on 500 error", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Internal error", { status: 500 });
+      }
+      return new Response(JSON.stringify({ version_id: "uuid-retry" }), { status: 201 });
+    });
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(true);
+    expect(callCount).toBe(2);
+  });
+});

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -9,17 +9,21 @@ import {
   ensurePackageExists,
   registerVersion,
 } from "../../src/lib/publish.js";
+import { mockFetch } from "../helpers/mock-fetch.js";
 import type { ArcManifest, RegistrySource } from "../../src/types.js";
 
 // ── Helper ───────────────────────────────────────────────────
 
 let testDir: string;
+let savedFetch: typeof fetch;
 
 beforeEach(async () => {
   testDir = await mkdtemp(join(tmpdir(), "arc-publish-test-"));
+  savedFetch = globalThis.fetch;
 });
 
 afterEach(async () => {
+  globalThis.fetch = savedFetch;
   await rm(testDir, { recursive: true, force: true });
 });
 
@@ -43,20 +47,6 @@ function makeManifest(overrides?: Partial<ArcManifest>): ArcManifest {
     ...overrides,
   } as ArcManifest;
 }
-
-function mockFetch(fn: (...args: any[]) => Promise<Response>): void {
-  (globalThis as any).fetch = fn;
-}
-
-let savedFetch: typeof fetch;
-
-beforeEach(() => {
-  savedFetch = globalThis.fetch;
-});
-
-afterEach(() => {
-  globalThis.fetch = savedFetch;
-});
 
 // ── extractReadme ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Implements `arc bundle` and `arc publish` commands — publisher-side complement to F-4 (install from registry)
- Phase 1 bootstrap: bearer token auth, direct upload through Worker, content-addressed R2 storage
- Spec: `.specify/specs/f-6-bundle-and-publish/spec.md` (reviewed by Luna, two rounds)

### New commands

| Command | Description |
|---------|-------------|
| `arc bundle [path]` | Create `.tar.gz` from package directory with exclusions |
| `arc bundle --output <path>` | Custom output path for tarball |
| `arc publish [path]` | Bundle → upload → register version on metafactory |
| `arc publish --dry-run` | Validate without uploading |
| `arc publish --tarball <path>` | Publish from existing tarball |
| `arc publish --scope <ns>` | Override publish namespace |
| `arc publish --source <name>` | Target specific metafactory source |

### Key features

- **Default exclusions**: `.git`, `node_modules`, `.env`, `.DS_Store`, `test/`, `dist/`, etc.
- **Manifest overrides**: `bundle.exclude` and `bundle.include` in arc-manifest.yaml
- **SHA-256 verification**: client-computed hash verified against server response
- **Size limits**: 50MB hard limit (client pre-check), 10MB warning
- **Auto-create package**: first publish auto-creates the package entry
- **Scope resolution**: `--scope` flag > manifest `namespace` > `/auth/me` API
- **Idempotent uploads**: 409 on duplicate content treated as success (DD-14)
- **Retry on server error**: registration auto-retries once on 5xx

### New files

| File | Purpose |
|------|---------|
| `src/lib/bundle.ts` | Tarball creation, exclusions, checksum, validation |
| `src/lib/publish.ts` | Upload, scope resolution, package creation, version registration |
| `src/commands/bundle.ts` | `arc bundle` command handler |
| `src/commands/publish.ts` | `arc publish` command handler |
| `test/unit/bundle.test.ts` | 22 unit tests for bundle library |
| `test/unit/publish.test.ts` | 18 unit tests for publish library (mocked HTTP) |
| `test/commands/bundle.test.ts` | 8 command tests for arc bundle |
| `test/commands/publish.test.ts` | 9 command tests for arc publish (mocked API) |

## Test plan

- [x] 57 new tests pass (unit + command)
- [x] 457 total tests pass (0 regressions)
- [ ] Manual E2E: `arc bundle` on a real package → inspect tarball contents
- [ ] Manual E2E: `arc publish --dry-run` → verify validation output
- [ ] Manual E2E: `arc publish` against staging metafactory → `arc install` on clean machine

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)