### PR TITLE
feat: add metafactory API info for @scope/name packages (A-500)

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -158,7 +158,7 @@ features:
   # Remote info & inspection
   - id: A-500
     name: Remote package info
-    status: planned
+    status: done
     iteration: 6
     depends: [A-200, A-404]
     description: "arc info <name> for uninstalled packages — resolve from registry, clone to cache, show manifest, capabilities, and library artifacts list"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -6,9 +6,11 @@ import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } fr
 import { findGitRoot } from "../lib/paths.js";
 import { extractRepoName } from "../lib/repo-name.js";
 import { parseLibraryRef } from "../lib/artifact-installer.js";
-import { loadSources } from "../lib/sources.js";
+import { loadSources, getSourceType } from "../lib/sources.js";
 import { findInAllSources } from "../lib/remote-registry.js";
-import type { InstalledSkill, ArcManifest, PaiPaths } from "../types.js";
+import { parsePackageRef } from "../lib/registry-install.js";
+import { fetchMetafactoryPackageDetail } from "../lib/metafactory-api.js";
+import type { InstalledSkill, ArcManifest, PaiPaths, MetafactoryPackageDetail } from "../types.js";
 
 export interface InfoResult {
   skill: InstalledSkill | null;
@@ -22,6 +24,8 @@ export interface InfoResult {
     sourceTier: string;
     repoUrl: string;
   };
+  /** For metafactory API packages: full API detail */
+  apiDetail?: MetafactoryPackageDetail;
   error?: string;
 }
 
@@ -34,17 +38,27 @@ export async function info(
   name: string,
   paths?: PaiPaths
 ): Promise<InfoResult> {
-  const libRef = parseLibraryRef(name);
-  const lookupName = libRef?.artifactName ? libRef.libraryName : name;
+  // Check if input is a scoped package ref (@scope/name)
+  const pkgRef = parsePackageRef(name);
+
+  const libRef = pkgRef ? null : parseLibraryRef(name);
+  const lookupName = libRef?.artifactName ? libRef.libraryName : (pkgRef ? pkgRef.name : name);
   const artifactFilter = libRef?.artifactName;
 
-  // 1. Try installed packages
-  const installed = await resolveInstalled(db, lookupName, artifactFilter);
-  if (installed) return installed;
+  // 1. Try installed packages (skip for scoped refs — they go to API)
+  if (!pkgRef) {
+    const installed = await resolveInstalled(db, lookupName, artifactFilter);
+    if (installed) return installed;
+  }
 
   // 2. Not installed — try registry
   if (!paths) {
     return errorResult(`'${name}' is not installed`);
+  }
+
+  // 3. Scoped ref → try metafactory API sources first
+  if (pkgRef) {
+    return resolveMetafactoryInfo(pkgRef.scope, pkgRef.name, paths);
   }
 
   return resolveRemote(name, lookupName, artifactFilter, paths);
@@ -168,6 +182,67 @@ async function resolveRemoteLibraryArtifact(
     return errorResult(`Artifact '${artifactName}' not found in library '${libraryName}'. Available: ${available}`);
   }
   return { skill: null, manifest: match.manifest, releaseNotes: null, remote };
+}
+
+/**
+ * Resolve info for a scoped package (@scope/name) via metafactory API sources.
+ */
+async function resolveMetafactoryInfo(
+  scope: string,
+  name: string,
+  paths: PaiPaths,
+): Promise<InfoResult> {
+  const sources = await loadSources(paths.sourcesPath);
+  const mfSources = sources.sources.filter((s) => s.enabled && getSourceType(s) === "metafactory");
+
+  for (const source of mfSources) {
+    const detail = await fetchMetafactoryPackageDetail(source, `@${scope}`, name);
+    if (!detail) continue;
+
+    // Build a synthetic manifest from API data
+    const manifest: ArcManifest = {
+      name: detail.name,
+      version: detail.latest_version ?? "0.0.0",
+      type: (detail.type as ArcManifest["type"]) ?? "skill",
+      description: detail.description ?? undefined,
+      license: detail.license,
+      author: detail.publisher.github_username
+        ? { name: detail.publisher.display_name ?? scope, github: detail.publisher.github_username }
+        : { name: detail.publisher.display_name ?? scope, github: scope },
+    };
+
+    return {
+      skill: null,
+      manifest,
+      releaseNotes: null,
+      remote: {
+        sourceName: source.name,
+        sourceTier: source.tier,
+        repoUrl: `@${scope}/${name}`,
+      },
+      apiDetail: detail,
+    };
+  }
+
+  // No metafactory source found it — try git-based sources as fallback
+  const found = await findInAllSources(sources, name, paths.cachePath);
+  if (found) {
+    const cacheCloneDir = join(paths.cachePath, "info", extractRepoName(found.entry.source));
+    const cloneError = cloneToCache(found.entry.source, cacheCloneDir);
+    if (!cloneError) {
+      const manifest = await readManifest(cacheCloneDir);
+      if (manifest) {
+        return {
+          skill: null,
+          manifest,
+          releaseNotes: null,
+          remote: { sourceName: found.sourceName, sourceTier: found.sourceTier, repoUrl: found.entry.source },
+        };
+      }
+    }
+  }
+
+  return errorResult(`'@${scope}/${name}' not found in any configured source`);
 }
 
 /**
@@ -317,8 +392,10 @@ function formatRemoteInfo(result: InfoResult): string {
 
   appendReleaseNotes(lines, result.releaseNotes);
 
+  // Use @scope/name for API packages, plain name for git-based
+  const installRef = remote.repoUrl.startsWith("@") ? remote.repoUrl : manifest.name;
   lines.push("");
-  lines.push(`  Install: arc install ${manifest.name}`);
+  lines.push(`  Install: arc install ${installRef}`);
 
   return lines.join("\n");
 }
@@ -403,6 +480,20 @@ export function formatInfoJson(result: InfoResult): string {
     json.source = result.remote.sourceName;
     json.source_tier = result.remote.sourceTier;
     json.repo_url = result.remote.repoUrl;
+  }
+
+  if (result.apiDetail) {
+    json.versions = result.apiDetail.versions;
+    json.publisher = {
+      name: result.apiDetail.publisher.display_name,
+      tier: result.apiDetail.publisher.tier,
+      mfa_enabled: result.apiDetail.publisher.mfa_enabled,
+      github: result.apiDetail.publisher.github_username,
+    };
+    if (result.apiDetail.sponsor) {
+      json.sponsor = result.apiDetail.sponsor;
+    }
+    json.license = result.apiDetail.license;
   }
 
   if (result.libraryArtifacts?.length) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -42,7 +42,7 @@ export async function info(
   const pkgRef = parsePackageRef(name);
 
   const libRef = pkgRef ? null : parseLibraryRef(name);
-  const lookupName = libRef?.artifactName ? libRef.libraryName : (pkgRef ? pkgRef.name : name);
+  const lookupName = libRef?.artifactName ? libRef.libraryName : name;
   const artifactFilter = libRef?.artifactName;
 
   // 1. Try installed packages (skip for scoped refs — they go to API)

--- a/test/commands/info.test.ts
+++ b/test/commands/info.test.ts
@@ -356,3 +356,191 @@ describe("formatInfoJson", () => {
     expect(json.error).toBe("not found");
   });
 });
+
+describe("info — metafactory API packages (@scope/name)", () => {
+  let savedFetch: typeof globalThis.fetch;
+
+  afterEach(() => {
+    if (savedFetch) globalThis.fetch = savedFetch;
+  });
+
+  function mockApiDetail(detail: Record<string, unknown>) {
+    savedFetch = globalThis.fetch;
+    (globalThis as any).fetch = async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/api/v1/packages/")) {
+        return new Response(JSON.stringify(detail), { status: 200 });
+      }
+      return new Response("Not found", { status: 404 });
+    };
+  }
+
+  test("resolves info for @scope/name from metafactory API", async () => {
+    env = await createTestEnv();
+
+    // Configure a metafactory source
+    await writeFile(env.paths.sourcesPath, YAML.stringify({
+      sources: [{
+        name: "mf-test",
+        url: "https://api.example.com",
+        tier: "community",
+        enabled: true,
+        type: "metafactory",
+        token: "test-token",
+      }],
+    }));
+
+    mockApiDetail({
+      namespace: "jcfischer",
+      name: "demo-skill",
+      display_name: "Demo Skill",
+      description: "A demo skill for testing",
+      type: "skill",
+      license: "MIT",
+      latest_version: "0.1.0",
+      versions: ["0.1.0"],
+      publisher: {
+        display_name: "Jens-Christian Fischer",
+        tier: "steward",
+        mfa_enabled: true,
+        github_username: "jcfischer",
+      },
+      sponsor: null,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    });
+
+    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+
+    expect(result.error).toBeUndefined();
+    expect(result.manifest).not.toBeNull();
+    expect(result.manifest!.name).toBe("demo-skill");
+    expect(result.manifest!.version).toBe("0.1.0");
+    expect(result.manifest!.type).toBe("skill");
+    expect(result.manifest!.description).toBe("A demo skill for testing");
+    expect(result.remote).toBeDefined();
+    expect(result.remote!.sourceName).toBe("mf-test");
+    expect(result.skill).toBeNull();
+  });
+
+  test("returns error when @scope/name not found in any API source", async () => {
+    env = await createTestEnv();
+
+    await writeFile(env.paths.sourcesPath, YAML.stringify({
+      sources: [{
+        name: "mf-test",
+        url: "https://api.example.com",
+        tier: "community",
+        enabled: true,
+        type: "metafactory",
+        token: "test-token",
+      }],
+    }));
+
+    savedFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => new Response('{"error":"Not found"}', { status: 404 });
+
+    const result = await info(env.db, "@jcfischer/nonexistent", env.paths);
+
+    expect(result.error).toContain("not found");
+  });
+
+  test("shows publisher info in formatted output", async () => {
+    const result = formatInfo({
+      skill: null,
+      manifest: {
+        name: "demo-skill",
+        version: "0.1.0",
+        type: "skill",
+        description: "A demo skill",
+        author: { name: "Jens-Christian Fischer", github: "jcfischer" },
+      } as any,
+      releaseNotes: null,
+      remote: {
+        sourceName: "metafactory",
+        sourceTier: "community",
+        repoUrl: "@jcfischer/demo-skill",
+      },
+    });
+
+    expect(result).toContain("demo-skill");
+    expect(result).toContain("v0.1.0");
+    expect(result).toContain("Jens-Christian Fischer");
+    expect(result).toContain("arc install");
+  });
+
+  test("formats @scope/name in install hint for API packages", async () => {
+    env = await createTestEnv();
+
+    await writeFile(env.paths.sourcesPath, YAML.stringify({
+      sources: [{
+        name: "mf-test",
+        url: "https://api.example.com",
+        tier: "community",
+        enabled: true,
+        type: "metafactory",
+        token: "test-token",
+      }],
+    }));
+
+    mockApiDetail({
+      namespace: "jcfischer",
+      name: "demo-skill",
+      display_name: null,
+      description: "A demo",
+      type: "skill",
+      license: "MIT",
+      latest_version: "1.0.0",
+      versions: ["1.0.0"],
+      publisher: { display_name: "JCF", tier: "identified", mfa_enabled: false, github_username: "jcfischer" },
+      sponsor: null,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    });
+
+    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+    const formatted = formatInfo(result);
+
+    expect(formatted).toContain("arc install @jcfischer/demo-skill");
+  });
+
+  test("JSON output includes API metadata", async () => {
+    env = await createTestEnv();
+
+    await writeFile(env.paths.sourcesPath, YAML.stringify({
+      sources: [{
+        name: "mf-test",
+        url: "https://api.example.com",
+        tier: "community",
+        enabled: true,
+        type: "metafactory",
+        token: "test-token",
+      }],
+    }));
+
+    mockApiDetail({
+      namespace: "jcfischer",
+      name: "demo-skill",
+      display_name: "Demo",
+      description: "A demo",
+      type: "skill",
+      license: "MIT",
+      latest_version: "1.0.0",
+      versions: ["1.0.0", "0.9.0"],
+      publisher: { display_name: "JCF", tier: "steward", mfa_enabled: true, github_username: "jcfischer" },
+      sponsor: null,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    });
+
+    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+    const json = JSON.parse(formatInfoJson(result));
+
+    expect(json.installed).toBe(false);
+    expect(json.name).toBe("demo-skill");
+    expect(json.source).toBe("mf-test");
+    expect(json.versions).toEqual(["1.0.0", "0.9.0"]);
+    expect(json.publisher).toBeDefined();
+    expect(json.publisher.tier).toBe("steward");
+  });
+});

--- a/test/commands/info.test.ts
+++ b/test/commands/info.test.ts
@@ -364,10 +364,14 @@ describe("info — metafactory API packages (@scope/name)", () => {
     if (savedFetch) globalThis.fetch = savedFetch;
   });
 
+  const capturedUrls: string[] = [];
+
   function mockApiDetail(detail: Record<string, unknown>) {
     savedFetch = globalThis.fetch;
+    capturedUrls.length = 0;
     (globalThis as any).fetch = async (input: any) => {
       const url = typeof input === "string" ? input : input.url;
+      capturedUrls.push(url);
       if (url.includes("/api/v1/packages/")) {
         return new Response(JSON.stringify(detail), { status: 200 });
       }
@@ -421,6 +425,9 @@ describe("info — metafactory API packages (@scope/name)", () => {
     expect(result.remote).toBeDefined();
     expect(result.remote!.sourceName).toBe("mf-test");
     expect(result.skill).toBeNull();
+
+    // Verify API was called with correct scope and name in URL
+    expect(capturedUrls.some((u) => u.includes("/%40jcfischer/demo-skill"))).toBe(true);
   });
 
   test("returns error when @scope/name not found in any API source", async () => {
@@ -542,5 +549,42 @@ describe("info — metafactory API packages (@scope/name)", () => {
     expect(json.versions).toEqual(["1.0.0", "0.9.0"]);
     expect(json.publisher).toBeDefined();
     expect(json.publisher.tier).toBe("steward");
+  });
+
+  test("JSON output includes sponsor when present", async () => {
+    env = await createTestEnv();
+
+    await writeFile(env.paths.sourcesPath, YAML.stringify({
+      sources: [{
+        name: "mf-test",
+        url: "https://api.example.com",
+        tier: "community",
+        enabled: true,
+        type: "metafactory",
+        token: "test-token",
+      }],
+    }));
+
+    mockApiDetail({
+      namespace: "jcfischer",
+      name: "sponsored-skill",
+      display_name: null,
+      description: "A sponsored skill",
+      type: "skill",
+      license: "MIT",
+      latest_version: "1.0.0",
+      versions: ["1.0.0"],
+      publisher: { display_name: "JCF", tier: "identified", mfa_enabled: false, github_username: "jcfischer" },
+      sponsor: { display_name: "metafactory", tier: "steward", github_username: "mellanon" },
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    });
+
+    const result = await info(env.db, "@jcfischer/sponsored-skill", env.paths);
+    const json = JSON.parse(formatInfoJson(result));
+
+    expect(json.sponsor).toBeDefined();
+    expect(json.sponsor.display_name).toBe("metafactory");
+    expect(json.sponsor.tier).toBe("steward");
   });
 });


### PR DESCRIPTION
## Summary

- `arc info @scope/name` now resolves from metafactory API sources
- Builds manifest from API data (no tarball download needed)
- JSON output includes `versions`, `publisher` (tier, MFA, GitHub), `license`, `sponsor`
- Install hint shows `arc install @scope/name` for API packages
- Falls back to git-based registry if API lookup fails

## Changes

| File | Change |
|------|--------|
| `src/commands/info.ts` | `resolveMetafactoryInfo()`, `parsePackageRef` routing, `apiDetail` in InfoResult, install hint for scoped refs |
| `test/commands/info.test.ts` | 5 new tests with mocked API responses |
| `blueprint.yaml` | A-500 → done |
| `package.json` | 0.15.0 → 0.16.0 |

## Test plan

- [x] 472 tests passing (full suite), 5 new
- [x] `@scope/name` resolves from metafactory API source
- [x] Returns error when not found in any source
- [x] Formatted output shows publisher info and scoped install hint
- [x] JSON output includes versions array and publisher metadata
- [x] Existing git-based remote info still works (no regression)
- [ ] Code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)