### PR TITLE
feat: anonymous install and search — no auth for read ops (A-52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,9 +139,9 @@ program
 
       console.log(`Found ${formatPackageRef(pkgRef)} v${resolved.version} in ${resolved.source.name} [${resolved.source.tier}]`);
 
-      // Download
+      // Download (anonymous — no auth required per DD-80)
       console.log(`Downloading...`);
-      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir, resolved.source.token);
+      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir);
       if (!download.success || !download.tempPath) {
         console.error(`${download.error}`);
         process.exit(1);
@@ -697,7 +697,7 @@ source
 
 program
   .command("login")
-  .description("Authenticate with metafactory registry")
+  .description("Authenticate with metafactory registry (required for publishing only)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .option("-f, --force", "Re-authenticate even if already logged in")
   .action(async (opts: { source?: string; force?: boolean }) => {
@@ -716,7 +716,7 @@ program
 
 program
   .command("logout")
-  .description("Remove authentication from metafactory source")
+  .description("Remove authentication from metafactory source (only affects publishing)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .action(async (opts: { source?: string }) => {
     const paths = createPaths();

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -103,15 +103,14 @@ function debugLog(msg: string): void {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
-function buildHeaders(source: RegistrySource): Record<string, string> {
-  const headers: Record<string, string> = {
-    Accept: "application/json",
-  };
-  if (source.token) {
-    headers.Authorization = `Bearer ${source.token}`;
-  }
-  return headers;
+/** Build headers for read-only API requests (anonymous — no auth token). */
+function buildReadHeaders(): Record<string, string> {
+  return { Accept: "application/json" };
 }
+
+// NOTE: Authenticated headers (Bearer token) are only used by publish.ts,
+// which manages its own auth header construction.
+// All read operations (list, detail, search) are anonymous per DD-80.
 
 // ---------------------------------------------------------------------------
 // Convert API response to RegistryConfig
@@ -174,15 +173,15 @@ export async function fetchMetafactoryRegistry(
   try {
     while (page <= MAX_PAGES) {
       const url = `${source.url}/api/v1/packages?per_page=100&page=${page}`;
-      debugLog(`Fetching ${url} (token: ${source.token ? "***" : "none"})`);
+      debugLog(`Fetching ${url} (anonymous)`);
 
       const response = await fetch(url, {
-        headers: buildHeaders(source),
+        headers: buildReadHeaders(),
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
 
-      if (response.status === 401) {
-        process.stderr.write(`Token expired for ${source.name}. Run arc login to re-authenticate.\n`);
+      if (response.status === 401 || response.status === 403) {
+        process.stderr.write(`Access denied by ${source.name}. The registry may require authentication for this endpoint.\n`);
         return readCachedRegistry(cachePath, source);
       }
 
@@ -251,12 +250,12 @@ export async function fetchMetafactoryPackageDetail(
 
   try {
     const response = await fetch(url, {
-      headers: buildHeaders(source),
+      headers: buildReadHeaders(),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
-    if (response.status === 401) {
-      process.stderr.write(`Token expired for ${source.name}. Run arc login to re-authenticate.\n`);
+    if (response.status === 401 || response.status === 403) {
+      debugLog(`Access denied fetching package detail from ${source.name}`);
       return null;
     }
 

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -255,7 +255,7 @@ export async function fetchMetafactoryPackageDetail(
     });
 
     if (response.status === 401 || response.status === 403) {
-      debugLog(`Access denied fetching package detail from ${source.name}`);
+      process.stderr.write(`Access denied fetching package detail from ${source.name}. The package may require authentication.\n`);
       return null;
     }
 

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -50,7 +50,7 @@ export interface ResolvedRegistryPackage {
   source: RegistrySource;
 }
 
-/** Resolve a package from metafactory registry sources */
+/** Resolve a package from metafactory registry sources (anonymous — no auth required per DD-80) */
 export async function resolveFromRegistry(
   ref: PackageRef,
   sources: RegistrySource[],
@@ -66,11 +66,10 @@ export async function resolveFromRegistry(
     const targetVersion = ref.version ?? detail.latest_version;
     if (!targetVersion) continue;
 
-    // Fetch version detail to get SHA-256
+    // Fetch version detail to get SHA-256 (anonymous — no bearer token)
     const versionDetailUrl = `${source.url}/api/v1/packages/${encodeURIComponent(`@${ref.scope}`)}/${encodeURIComponent(ref.name)}/versions`;
     try {
       const headers: Record<string, string> = { Accept: "application/json" };
-      if (source.token) headers.Authorization = `Bearer ${source.token}`;
 
       const resp = await fetch(versionDetailUrl, {
         headers,
@@ -116,27 +115,22 @@ export interface DownloadResult {
   error?: string;
 }
 
-/** Download a package tarball from the storage endpoint */
+/** Download a package tarball from the storage endpoint (anonymous) */
 export async function downloadPackage(
   url: string,
   tempDir: string,
-  token?: string,
 ): Promise<DownloadResult> {
   const tempPath = join(tempDir, `arc-download-${Date.now()}.tar.gz`);
-
-  const headers: Record<string, string> = {};
-  if (token) headers.Authorization = `Bearer ${token}`;
 
   let lastError: string | undefined;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const response = await fetch(url, {
-        headers,
         signal: AbortSignal.timeout(60_000),
       });
 
       if (response.status === 401 || response.status === 403) {
-        return { success: false, error: "Access denied. Run \"arc login\" to authenticate." };
+        return { success: false, error: "Access denied by storage endpoint." };
       }
       if (response.status === 404) {
         return { success: false, error: "Package artifact not found at storage endpoint." };

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -66,13 +66,11 @@ export async function resolveFromRegistry(
     const targetVersion = ref.version ?? detail.latest_version;
     if (!targetVersion) continue;
 
-    // Fetch version detail to get SHA-256 (anonymous — no bearer token)
+    // Fetch version detail to get SHA-256 (anonymous — no bearer token per DD-80)
     const versionDetailUrl = `${source.url}/api/v1/packages/${encodeURIComponent(`@${ref.scope}`)}/${encodeURIComponent(ref.name)}/versions`;
     try {
-      const headers: Record<string, string> = { Accept: "application/json" };
-
       const resp = await fetch(versionDetailUrl, {
-        headers,
+        headers: { Accept: "application/json" },
         signal: AbortSignal.timeout(10_000),
       });
 

--- a/test/unit/metafactory-api.test.ts
+++ b/test/unit/metafactory-api.test.ts
@@ -134,7 +134,7 @@ describe("fetchMetafactoryRegistry", () => {
     }
   });
 
-  test("sends Authorization header when token present", async () => {
+  test("does not send Authorization header even when token configured (anonymous per DD-80)", async () => {
     const originalFetch = globalThis.fetch;
     let capturedHeaders: Headers | undefined;
     globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
@@ -144,22 +144,6 @@ describe("fetchMetafactoryRegistry", () => {
 
     try {
       await fetchMetafactoryRegistry(metafactorySource("my-secret-token"), env.paths.cachePath, true);
-      expect(capturedHeaders?.get("Authorization")).toBe("Bearer my-secret-token");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  test("does not send Authorization when no token", async () => {
-    const originalFetch = globalThis.fetch;
-    let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
-      capturedHeaders = new Headers(init?.headers);
-      return mockFetchResponse([]);
-    });
-
-    try {
-      await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
       expect(capturedHeaders?.get("Authorization")).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -249,11 +249,11 @@ describe("resolveFromRegistry", () => {
   test("does not send Authorization headers (anonymous per DD-80)", async () => {
     const originalFetch = globalThis.fetch;
     const capturedAuths: (string | null)[] = [];
-    globalThis.fetch = mockFetch(async (input: any) => {
+    globalThis.fetch = mockFetch(async (input: any, init?: any) => {
       const url = typeof input === "string" ? input : input.url;
-      // Capture Authorization header from the request
-      const req = new Request(url);
-      capturedAuths.push(req.headers.get("Authorization"));
+      // Capture Authorization header from init (not from a reconstructed Request)
+      const headers = new Headers(init?.headers);
+      capturedAuths.push(headers.get("Authorization"));
       if (url.includes("/versions")) {
         return new Response(JSON.stringify({
           versions: [{ version: "1.0.0", sha256: "abc" }],
@@ -320,9 +320,9 @@ describe("downloadPackage", () => {
   test("does not send Authorization header (anonymous download)", async () => {
     const originalFetch = globalThis.fetch;
     let capturedAuth: string | null = null;
-    globalThis.fetch = mockFetch(async (input: any) => {
-      const req = new Request(input);
-      capturedAuth = req.headers.get("Authorization");
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get("Authorization");
       return new Response(new ArrayBuffer(10), { status: 200 });
     });
 

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -246,6 +246,42 @@ describe("resolveFromRegistry", () => {
     }
   });
 
+  test("does not send Authorization headers (anonymous per DD-80)", async () => {
+    const originalFetch = globalThis.fetch;
+    const capturedAuths: (string | null)[] = [];
+    globalThis.fetch = mockFetch(async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      // Capture Authorization header from the request
+      const req = new Request(url);
+      capturedAuths.push(req.headers.get("Authorization"));
+      if (url.includes("/versions")) {
+        return new Response(JSON.stringify({
+          versions: [{ version: "1.0.0", sha256: "abc" }],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        namespace: "@test", name: "pkg",
+        display_name: null, description: "", type: "skill", license: "MIT",
+        latest_version: "1.0.0", versions: ["1.0.0"],
+        publisher: { display_name: "T", tier: "official", mfa_enabled: true, github_username: null },
+        sponsor: null, created_at: 0, updated_at: 0,
+      }), { status: 200 });
+    });
+
+    try {
+      await resolveFromRegistry(
+        { scope: "test", name: "pkg" },
+        [metafactorySource("should-not-be-sent")],
+      );
+      // No request should include an Authorization header
+      for (const auth of capturedAuths) {
+        expect(auth).toBeNull();
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("returns null when package not found", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch(async () => new Response("Not found", { status: 404 }));
@@ -281,17 +317,18 @@ describe("downloadPackage", () => {
     }
   });
 
-  test("sends Bearer token when provided", async () => {
+  test("does not send Authorization header (anonymous download)", async () => {
     const originalFetch = globalThis.fetch;
-    let capturedAuth: string | undefined;
-    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
-      capturedAuth = new Headers(init?.headers).get("Authorization") ?? undefined;
+    let capturedAuth: string | null = null;
+    globalThis.fetch = mockFetch(async (input: any) => {
+      const req = new Request(input);
+      capturedAuth = req.headers.get("Authorization");
       return new Response(new ArrayBuffer(10), { status: 200 });
     });
 
     try {
-      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir, "my-token");
-      expect(capturedAuth).toBe("Bearer my-token");
+      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(capturedAuth).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -304,7 +341,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
       expect(result.success).toBe(false);
-      expect(result.error).toContain("arc login");
+      expect(result.error).toContain("Access denied");
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- Strip bearer tokens from all read-only API paths (install, search, info) per DD-80
- Auth is now only required for `arc publish` — install/search work without `arc login`
- Update error messages: 401/403 no longer suggest login for read operations
- Update login/logout CLI descriptions to clarify publish-only scope

## Changes
| File | What changed |
|------|-------------|
| `src/lib/metafactory-api.ts` | `buildHeaders()` → `buildReadHeaders()` (no token); read functions anonymous |
| `src/lib/registry-install.ts` | `resolveFromRegistry()` and `downloadPackage()` no longer accept/send tokens |
| `src/cli.ts` | Remove `source.token` from download call; update login/logout descriptions |
| `test/unit/metafactory-api.test.ts` | Verify tokens NOT sent even when configured |
| `test/unit/registry-install.test.ts` | Add anonymous-header test; update 401 error expectation |

## Gate
`arc install @ns/name` resolves, downloads, and verifies SHA-256 without any bearer token or credential state on disk.

## Test plan
- [x] All 473 tests pass (0 failures)
- [x] `resolveFromRegistry` sends no Authorization header even with token configured
- [x] `downloadPackage` sends no Authorization header
- [x] `fetchMetafactoryRegistry` sends no Authorization header
- [x] 401 error message says "Access denied" (not "run arc login")
- [ ] Manual: `arc install @scope/name` works from fresh clone without `arc login`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)