### PR TITLE
fix: surface registry fetch failures instead of swallowing them (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -64,7 +64,8 @@ export async function fetchRemoteRegistry(
       parsed.registry.components ??= [];
       parsed.registry.rules ??= [];
       return parsed;
-    } catch {
+    } catch (err: any) {
+      process.stderr.write(`Warning: failed to read local source "${source.name}": ${filePath}: ${err.message ?? err}\n`);
       return null;
     }
   }
@@ -112,7 +113,18 @@ export async function fetchRemoteRegistry(
       headers,
     });
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      const hint = (response.status === 401 || response.status === 404)
+        ? `\n   hint: check that GITHUB_TOKEN has 'Contents: Read' on the source repo`
+        : "";
+      process.stderr.write(
+        `Warning: failed to fetch source "${source.name}" (${response.status} ${response.statusText}): ${fetchUrl}` +
+        (body ? `\n   ${body.slice(0, 200)}` : "") +
+        hint + "\n",
+      );
+      return null;
+    }
 
     const text = await response.text();
     const parsed = YAML.parse(text) as RegistryConfig;
@@ -132,15 +144,21 @@ export async function fetchRemoteRegistry(
     await writeFile(cached, text, "utf-8");
 
     return parsed;
-  } catch {
-    // Network failure — try stale cache
+  } catch (err: any) {
+    // Network failure — warn and try stale cache
+    process.stderr.write(
+      `Warning: network error fetching source "${source.name}": ${err.message ?? err}\n`,
+    );
     if (existsSync(cached)) {
       try {
         const content = await readFile(cached, "utf-8");
         const parsed = YAML.parse(content) as RegistryConfig;
-        if (parsed?.registry) return parsed;
+        if (parsed?.registry) {
+          process.stderr.write(`   Using stale cache for "${source.name}"\n`);
+          return parsed;
+        }
       } catch {
-        // Nothing we can do
+        // Stale cache also corrupt — fall through to null
       }
     }
     return null;

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -199,11 +199,18 @@ describe("searchAcrossSources", () => {
         { name: "missing", url: "file:///nonexistent/path.yaml", tier: "community", enabled: true },
       ],
     };
-    const result = await searchAcrossSources(config, env.paths.cachePath);
-    expect(result.warnings.length).toBe(1);
-    expect(result.warnings[0].sourceName).toBe("missing");
-    expect(result.warnings[0].reason).toBe("unreachable");
-    expect(result.successfulSources).toBe(0);
+    // Suppress stderr from fetchRemoteRegistry warnings
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const result = await searchAcrossSources(config, env.paths.cachePath);
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0].sourceName).toBe("missing");
+      expect(result.warnings[0].reason).toBe("unreachable");
+      expect(result.successfulSources).toBe(0);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
   });
 
   test("healthy sources work when another fails", async () => {
@@ -220,10 +227,17 @@ describe("searchAcrossSources", () => {
       ],
     };
 
-    const result = await searchAcrossSources(config, env.paths.cachePath);
-    expect(result.results.length).toBe(1);
-    expect(result.successfulSources).toBe(1);
-    expect(result.warnings.length).toBe(1);
+    // Suppress stderr from fetchRemoteRegistry warnings
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const result = await searchAcrossSources(config, env.paths.cachePath);
+      expect(result.results.length).toBe(1);
+      expect(result.successfulSources).toBe(1);
+      expect(result.warnings.length).toBe(1);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
   });
 
   test("disabled sources are ignored", async () => {

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -73,6 +73,102 @@ describe("fetchRemoteRegistry", () => {
     const result = await fetchRemoteRegistry(source, env.paths.cachePath);
     expect(result).toBeNull();
   });
+
+  test("emits warning to stderr on HTTP error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("Not Found", { status: 404, statusText: "Not Found" })) as typeof fetch;
+    (globalThis.fetch as any).preconnect = () => {};
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
+
+    const source: RegistrySource = {
+      name: "broken-hub",
+      url: "https://example.com/missing.yaml",
+      tier: "community",
+      enabled: true,
+    };
+
+    try {
+      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      expect(result).toBeNull();
+      const output = stderrChunks.join("");
+      expect(output).toContain("broken-hub");
+      expect(output).toContain("404");
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  test("emits warning with auth hint on 401", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" })) as typeof fetch;
+    (globalThis.fetch as any).preconnect = () => {};
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
+
+    const source: RegistrySource = {
+      name: "private-hub",
+      url: "https://example.com/private.yaml",
+      tier: "community",
+      enabled: true,
+    };
+
+    try {
+      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      expect(result).toBeNull();
+      const output = stderrChunks.join("");
+      expect(output).toContain("private-hub");
+      expect(output).toContain("401");
+      expect(output).toContain("GITHUB_TOKEN");
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  test("emits warning on network error and falls back to stale cache", async () => {
+    const source: RegistrySource = {
+      name: "flaky-hub",
+      url: "https://example.com/flaky.yaml",
+      tier: "community",
+      enabled: true,
+    };
+
+    // Pre-populate stale cache
+    await mkdir(env.paths.cachePath, { recursive: true });
+    await writeFile(
+      join(env.paths.cachePath, "flaky-hub.yaml"),
+      YAML.stringify(sampleRemoteRegistry()),
+    );
+
+    // Force refresh with network error
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as typeof fetch;
+    (globalThis.fetch as any).preconnect = () => {};
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
+
+    try {
+      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      // Should fall back to stale cache
+      expect(result).not.toBeNull();
+      expect(result!.registry.skills[0].name).toBe("RemoteSkill");
+      const output = stderrChunks.join("");
+      expect(output).toContain("flaky-hub");
+      expect(output).toContain("ECONNREFUSED");
+      expect(output).toContain("stale cache");
+    } finally {
+      globalThis.fetch = originalFetch;
+      process.stderr.write = originalWrite;
+    }
+  });
 });
 
 describe("searchAllSources", () => {

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -70,8 +70,38 @@ describe("fetchRemoteRegistry", () => {
       enabled: true,
     };
 
-    const result = await fetchRemoteRegistry(source, env.paths.cachePath);
-    expect(result).toBeNull();
+    // Capture stderr to keep test output clean
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const result = await fetchRemoteRegistry(source, env.paths.cachePath);
+      expect(result).toBeNull();
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  test("emits warning on local file read error", async () => {
+    const source: RegistrySource = {
+      name: "missing-local",
+      url: "file:///nonexistent/registry.yaml",
+      tier: "community",
+      enabled: true,
+    };
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
+
+    try {
+      const result = await fetchRemoteRegistry(source, env.paths.cachePath);
+      expect(result).toBeNull();
+      const output = stderrChunks.join("");
+      expect(output).toContain("missing-local");
+      expect(output).toContain("/nonexistent/registry.yaml");
+    } finally {
+      process.stderr.write = originalWrite;
+    }
   });
 
   test("emits warning to stderr on HTTP error", async () => {
@@ -184,13 +214,19 @@ describe("searchAllSources", () => {
       ],
     };
 
-    const results = await searchAllSources(
-      sources,
-      "anything",
-      env.paths.cachePath
-    );
-
-    expect(results).toHaveLength(0);
+    // Suppress stderr warnings from failed fetches
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const results = await searchAllSources(
+        sources,
+        "anything",
+        env.paths.cachePath
+      );
+      expect(results).toHaveLength(0);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
   });
 
   test("aggregates from cached sources", async () => {


### PR DESCRIPTION
## Summary
- Emit warnings to stderr when registry fetch fails (HTTP error, network failure, local file error)
- Include source name, URL, HTTP status, and response body snippet in warning
- Add auth hint for 401/404: "check that GITHUB_TOKEN has 'Contents: Read' on the source repo"
- Note stale cache fallback when network error + stale cache exists
- Keep `return null` behavior so commands still try remaining sources

## Before
```
❌ "grove" not found in any source. Try: arc search <keyword>
```

## After
```
Warning: failed to fetch source "metafactory-registry" (404 Not Found): https://api.github.com/repos/...
   {"message":"Not Found","documentation_url":"..."}
   hint: check that GITHUB_TOKEN has 'Contents: Read' on the source repo
❌ "grove" not found in any source. Try: arc search <keyword>
```

## Test plan
- [x] 476 tests pass (3 new tests added)
- [x] HTTP error test: verifies source name and status code in warning
- [x] Auth hint test: verifies 401 includes GITHUB_TOKEN hint
- [x] Network error + stale cache test: verifies fallback with warning

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)