### PR TITLE
fix: fail loud on non-TTY stdin instead of silently half-installing (#46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,13 @@ program
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--pin <version>", "Pin to a specific version (git tag)")
   .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string }) => {
+    // Non-TTY guard: fail loud rather than silently half-installing
+    if (!opts.yes && !process.stdin.isTTY) {
+      console.error("Error: arc install requires an interactive terminal for capability confirmation.");
+      console.error("Pass --yes (-y) to approve non-interactively.");
+      process.exit(1);
+    }
+
     const paths = createPaths();
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -674,8 +674,12 @@ async function promptHookConsent(
 
 /**
  * Read a single line from stdin.
+ * Returns empty string immediately if stdin is not a TTY (defense in depth).
  */
 function readLine(): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return Promise.resolve("");
+  }
   return new Promise((resolve) => {
     const stdin = process.stdin;
     stdin.setEncoding("utf-8");

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -106,7 +106,7 @@ describe("fetchRemoteRegistry", () => {
 
   test("emits warning to stderr on HTTP error", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("Not Found", { status: 404, statusText: "Not Found" })) as typeof fetch;
+    globalThis.fetch = (async () => new Response("Not Found", { status: 404, statusText: "Not Found" })) as unknown as typeof fetch;
     (globalThis.fetch as any).preconnect = () => {};
 
     const stderrChunks: string[] = [];
@@ -134,7 +134,7 @@ describe("fetchRemoteRegistry", () => {
 
   test("emits warning with auth hint on 401", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" })) as typeof fetch;
+    globalThis.fetch = (async () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch;
     (globalThis.fetch as any).preconnect = () => {};
 
     const stderrChunks: string[] = [];
@@ -178,7 +178,7 @@ describe("fetchRemoteRegistry", () => {
 
     // Force refresh with network error
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as typeof fetch;
+    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
     (globalThis.fetch as any).preconnect = () => {};
 
     const stderrChunks: string[] = [];

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -106,8 +106,9 @@ describe("fetchRemoteRegistry", () => {
 
   test("emits warning to stderr on HTTP error", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("Not Found", { status: 404, statusText: "Not Found" })) as unknown as typeof fetch;
-    (globalThis.fetch as any).preconnect = () => {};
+    const mockFetch404 = async () => new Response("Not Found", { status: 404, statusText: "Not Found" });
+    (mockFetch404 as any).preconnect = () => {};
+    globalThis.fetch = mockFetch404 as any;
 
     const stderrChunks: string[] = [];
     const originalWrite = process.stderr.write;
@@ -134,8 +135,9 @@ describe("fetchRemoteRegistry", () => {
 
   test("emits warning with auth hint on 401", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch;
-    (globalThis.fetch as any).preconnect = () => {};
+    const mockFetch401 = async () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" });
+    (mockFetch401 as any).preconnect = () => {};
+    globalThis.fetch = mockFetch401 as any;
 
     const stderrChunks: string[] = [];
     const originalWrite = process.stderr.write;
@@ -178,8 +180,9 @@ describe("fetchRemoteRegistry", () => {
 
     // Force refresh with network error
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
-    (globalThis.fetch as any).preconnect = () => {};
+    const throwFetch = async () => { throw new Error("ECONNREFUSED"); };
+    (throwFetch as any).preconnect = () => {};
+    globalThis.fetch = throwFetch as any;
 
     const stderrChunks: string[] = [];
     const originalWrite = process.stderr.write;


### PR DESCRIPTION
## Summary
- `arc install` now exits with a clear error when stdin is non-TTY and `--yes` not passed
- Previously: silently skipped hook registration, exited 0 — half-applied install
- Now: prints actionable error message and exits non-zero
- Defense-in-depth: `readLine()` also returns empty immediately on non-TTY
- Fixes typecheck errors in remote-registry test mock casts (pre-existing)

## Before (non-TTY)
```
Allow? [y/N]    ← hangs 18s, then exits 0 with hooks not registered
```

## After (non-TTY)
```
Error: arc install requires an interactive terminal for capability confirmation.
Pass --yes (-y) to approve non-interactively.
```

## Test plan
- [x] 477 tests pass (all existing tests use `yes: true`)
- [x] Existing install/library tests unaffected (they pass `--yes`)
- [ ] Manual: `echo | arc install grove` fails with clear error
- [ ] Manual: `arc install grove --yes` still works

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)