### PR TITLE
feat: lazy auto-fetch cosign binary on first use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -108,14 +108,15 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
 
     const buffer = await response.arrayBuffer();
 
-    // Verify checksum
-    if (expectedHash) {
-      const hasher = new Bun.CryptoHasher("sha256");
-      hasher.update(buffer);
-      const actualHash = hasher.digest("hex");
-      if (actualHash !== expectedHash) {
-        return { error: `cosign checksum mismatch: expected ${expectedHash}, got ${actualHash}` };
-      }
+    // Verify checksum — hard fail if no checksum found
+    if (!expectedHash) {
+      return { error: `No checksum found for ${platform.binaryName} in cosign checksums — refusing to install unverified binary` };
+    }
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(buffer);
+    const actualHash = hasher.digest("hex");
+    if (actualHash !== expectedHash) {
+      return { error: `cosign checksum mismatch: expected ${expectedHash}, got ${actualHash}` };
     }
 
     // Write binary

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -97,6 +97,11 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
       }
     }
 
+    // Fail before downloading if no checksum available
+    if (!expectedHash) {
+      return { error: `No checksum found for ${platform.binaryName} in cosign checksums — refusing to install unverified binary` };
+    }
+
     // Download binary
     const response = await fetch(platform.downloadUrl, {
       signal: AbortSignal.timeout(120_000),
@@ -107,11 +112,6 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
     }
 
     const buffer = await response.arrayBuffer();
-
-    // Verify checksum — hard fail if no checksum found
-    if (!expectedHash) {
-      return { error: `No checksum found for ${platform.binaryName} in cosign checksums — refusing to install unverified binary` };
-    }
     const hasher = new Bun.CryptoHasher("sha256");
     hasher.update(buffer);
     const actualHash = hasher.digest("hex");

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -1,10 +1,19 @@
 /**
  * Thin wrapper around the bundled cosign binary.
  * Locates the correct platform binary and shells out for verification.
+ * Auto-fetches the binary on first use if not present.
  */
 
 import { join } from "path";
 import { existsSync } from "fs";
+import { writeFile, mkdir, chmod } from "fs/promises";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const COSIGN_VERSION = "v3.0.6";
+const CHECKSUMS_URL = `https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign_checksums.txt`;
 
 // ---------------------------------------------------------------------------
 // Platform detection
@@ -14,6 +23,7 @@ interface PlatformInfo {
   os: string;
   arch: string;
   binaryName: string;
+  downloadUrl: string;
 }
 
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
@@ -28,12 +38,18 @@ export function detectPlatform(): PlatformInfo {
   }
   const os = process.platform as string;
   const arch = process.arch === "arm64" ? "arm64" : "amd64";
-  return { os, arch, binaryName: `cosign-${os}-${arch}` };
+  const binaryName = `cosign-${os}-${arch}`;
+  const downloadUrl = `https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${binaryName}`;
+  return { os, arch, binaryName, downloadUrl };
 }
 
 // ---------------------------------------------------------------------------
 // Binary resolution
 // ---------------------------------------------------------------------------
+
+function vendorDir(): string {
+  return join(import.meta.dir, "..", "..", "vendor", "cosign");
+}
 
 /**
  * Locate the bundled cosign binary for the current platform.
@@ -41,12 +57,88 @@ export function detectPlatform(): PlatformInfo {
  */
 export function findCosignBinary(): string | null {
   const platform = detectPlatform();
-
-  // Resolve from arc's package root (two levels up from src/lib/)
-  const vendorPath = join(import.meta.dir, "..", "..", "vendor", "cosign", platform.binaryName);
+  const vendorPath = join(vendorDir(), platform.binaryName);
   if (existsSync(vendorPath)) return vendorPath;
-
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Download and verify the cosign binary for the current platform.
+ * Only fetches the single binary needed — not all platforms.
+ * Returns the path to the downloaded binary, or an error string.
+ */
+export async function fetchCosignBinary(): Promise<{ path?: string; error?: string }> {
+  const platform = detectPlatform();
+  const destDir = vendorDir();
+  const destPath = join(destDir, platform.binaryName);
+
+  // Already present
+  if (existsSync(destPath)) return { path: destPath };
+
+  process.stderr.write(`Downloading cosign ${COSIGN_VERSION} (${platform.binaryName})...\n`);
+
+  try {
+    // Fetch checksums
+    const checksumResp = await fetch(CHECKSUMS_URL, { signal: AbortSignal.timeout(30_000) });
+    if (!checksumResp.ok) {
+      return { error: `Failed to fetch cosign checksums: ${checksumResp.status}` };
+    }
+    const checksumText = await checksumResp.text();
+    let expectedHash: string | undefined;
+    for (const line of checksumText.split("\n")) {
+      const match = line.match(/^([a-f0-9]{64})\s+(.+)$/);
+      if (match && match[2].trim() === platform.binaryName) {
+        expectedHash = match[1];
+        break;
+      }
+    }
+
+    // Download binary
+    const response = await fetch(platform.downloadUrl, {
+      signal: AbortSignal.timeout(120_000),
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      return { error: `Failed to download cosign: ${response.status} ${response.statusText}` };
+    }
+
+    const buffer = await response.arrayBuffer();
+
+    // Verify checksum
+    if (expectedHash) {
+      const hasher = new Bun.CryptoHasher("sha256");
+      hasher.update(buffer);
+      const actualHash = hasher.digest("hex");
+      if (actualHash !== expectedHash) {
+        return { error: `cosign checksum mismatch: expected ${expectedHash}, got ${actualHash}` };
+      }
+    }
+
+    // Write binary
+    if (!existsSync(destDir)) {
+      await mkdir(destDir, { recursive: true });
+    }
+    await writeFile(destPath, Buffer.from(buffer));
+    await chmod(destPath, 0o755);
+
+    process.stderr.write(`cosign ${COSIGN_VERSION} downloaded and verified.\n`);
+    return { path: destPath };
+  } catch (err: any) {
+    return { error: `Failed to fetch cosign: ${err.message ?? err}` };
+  }
+}
+
+/**
+ * Get cosign binary path, auto-fetching if not present.
+ */
+export async function ensureCosignBinary(): Promise<{ path?: string; error?: string }> {
+  const existing = findCosignBinary();
+  if (existing) return { path: existing };
+  return fetchCosignBinary();
 }
 
 // ---------------------------------------------------------------------------
@@ -61,29 +153,27 @@ export interface VerifySigstoreResult {
 
 /**
  * Verify a Sigstore bundle for an artifact using cosign verify-blob.
+ * Auto-fetches cosign if not already present.
  *
  * @param artifactPath - Path to the artifact file (e.g., downloaded tarball)
  * @param bundlePath - Path to the Sigstore bundle (.sigstore.json)
  * @param expectedIdentity - Expected OIDC identity (e.g., GitHub Actions workflow URI)
  * @param expectedIssuer - Expected OIDC issuer (e.g., https://token.actions.githubusercontent.com)
  */
-export function verifySigstoreBundle(
+export async function verifySigstoreBundle(
   artifactPath: string,
   bundlePath: string,
   expectedIdentity: string,
   expectedIssuer: string,
-): VerifySigstoreResult {
-  const cosignPath = findCosignBinary();
-  if (!cosignPath) {
-    return {
-      valid: false,
-      error: `cosign binary not found for ${detectPlatform().binaryName}. Run: bun scripts/fetch-cosign.ts`,
-    };
+): Promise<VerifySigstoreResult> {
+  const cosign = await ensureCosignBinary();
+  if (!cosign.path) {
+    return { valid: false, error: cosign.error ?? "cosign binary unavailable" };
   }
 
   const result = Bun.spawnSync(
     [
-      cosignPath,
+      cosign.path,
       "verify-blob",
       "--bundle", bundlePath,
       "--certificate-identity", expectedIdentity,

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "bun:test";
-import { detectPlatform, findCosignBinary, verifySigstoreBundle } from "../../src/lib/cosign.js";
+import {
+  detectPlatform,
+  findCosignBinary,
+  ensureCosignBinary,
+  verifySigstoreBundle,
+} from "../../src/lib/cosign.js";
 
 describe("detectPlatform", () => {
   test("returns valid platform info", () => {
@@ -13,12 +18,17 @@ describe("detectPlatform", () => {
     const platform = detectPlatform();
     expect(platform.binaryName).toBe(`cosign-${platform.os}-${platform.arch}`);
   });
+
+  test("includes download URL", () => {
+    const platform = detectPlatform();
+    expect(platform.downloadUrl).toContain(platform.binaryName);
+    expect(platform.downloadUrl).toContain("github.com/sigstore/cosign");
+  });
 });
 
 describe("findCosignBinary", () => {
   test("returns string or null", () => {
     const result = findCosignBinary();
-    // Binary may or may not be present depending on whether fetch-cosign has run
     expect(result === null || typeof result === "string").toBe(true);
   });
 
@@ -31,18 +41,38 @@ describe("findCosignBinary", () => {
   });
 });
 
+describe("ensureCosignBinary", () => {
+  test("returns path or error", async () => {
+    // Suppress stderr from potential download messages
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const result = await ensureCosignBinary();
+      expect(result.path !== undefined || result.error !== undefined).toBe(true);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+});
+
 describe("verifySigstoreBundle", () => {
-  test("returns invalid for nonexistent artifact and bundle", () => {
-    const result = verifySigstoreBundle(
-      "/nonexistent/artifact.tar.gz",
-      "/nonexistent/bundle.sigstore.json",
-      "https://github.com/the-metafactory/meta-factory/.github/workflows/sign.yml@refs/heads/main",
-      "https://token.actions.githubusercontent.com",
-    );
-    expect(result.valid).toBe(false);
-    expect(result.error).toBeDefined();
-    // Either "binary not found" (no cosign) or cosign error (binary present, bad args)
-    expect(typeof result.error).toBe("string");
+  test("returns invalid for nonexistent artifact and bundle", async () => {
+    // Suppress stderr from potential download messages
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as any;
+    try {
+      const result = await verifySigstoreBundle(
+        "/nonexistent/artifact.tar.gz",
+        "/nonexistent/bundle.sigstore.json",
+        "https://github.com/the-metafactory/meta-factory/.github/workflows/sign.yml@refs/heads/main",
+        "https://token.actions.githubusercontent.com",
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe("string");
+    } finally {
+      process.stderr.write = originalWrite;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- `verifySigstoreBundle()` now auto-downloads cosign for the current platform if not present
- Downloads only the single binary needed (not all three platforms)
- SHA-256 verified against published checksums before writing
- `ensureCosignBinary()` exported for explicit pre-fetch
- `verifySigstoreBundle()` is now async (breaking change from #70)
- Download progress goes to stderr

## Before
```
cosign binary not found for cosign-darwin-arm64. Run: bun scripts/fetch-cosign.ts
```

## After
```
Downloading cosign v3.0.6 (cosign-darwin-arm64)...
cosign v3.0.6 downloaded and verified.
```

## Test plan
- [x] 485 tests pass (8 cosign tests)
- [x] `ensureCosignBinary()` returns path or error
- [x] `verifySigstoreBundle()` returns invalid for bad artifacts (with auto-fetch)
- [x] Platform detection includes download URL
- [ ] Manual: delete `vendor/cosign/cosign-*`, run verify — should auto-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)