### PR TITLE
feat(a-504): verify Ed25519 registry signature on install

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -135,10 +135,10 @@ features:
 
   - id: A-406
     name: SHA-256 registry verification
-    status: planned
+    status: done
     iteration: 5
     depends: [A-200]
-    description: "Verify sha256 field in REGISTRY.yaml entries against manifest content at install time"
+    description: "Verify sha256 field in registry version metadata against downloaded artifact at install time — implemented in src/lib/registry-install.ts verifyChecksum(), wired in src/cli.ts (non-bypassable)"
 
   - id: A-407
     name: Action artifact type
@@ -184,3 +184,10 @@ features:
     iteration: 6
     depends: [A-502, meta-factory:F5-500]
     description: "arc install fetches Sigstore bundle alongside artifact, calls cosign verify-blob --bundle --offline — blocks install on verification failure (DD-11, F-505)"
+
+  - id: A-504
+    name: arc install registry signature verification
+    status: done
+    iteration: 6
+    depends: [A-406, meta-factory:F-501]
+    description: "arc install fetches /.well-known/metafactory-signing-key from the registry and verifies the Ed25519 registry_signature bound to each version against manifest_canonical — blocks install on verification failure, no --force override. Unsigned/legacy versions emit a warning and proceed (matches meta-factory graceful degradation). Implemented in src/lib/registry-signing.ts + wired in src/cli.ts after SHA-256 check."

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ import {
   verifyChecksum,
   extractPackage,
 } from "./lib/registry-install.js";
+import { verifyVersionSignature } from "./lib/registry-signing.js";
 import { loadCatalog, saveCatalog, findEntry } from "./lib/catalog.js";
 import {
   loadSources,
@@ -166,6 +167,31 @@ program
         process.exit(1);
       }
       console.log(`SHA-256 verified`);
+
+      // A-504: verify registry-level Ed25519 signature over manifest bytes.
+      // Blocks install on any verified=false. verified=null means the
+      // version is unsigned (legacy / registry in degraded mode at publish
+      // time) — arc proceeds with a warning, consistent with meta-factory's
+      // own graceful degradation.
+      const sigResult = await verifyVersionSignature(
+        resolved.source,
+        {
+          registry_signature: resolved.registrySignature,
+          registry_key_id: resolved.registryKeyId,
+        },
+        resolved.manifestCanonical,
+      );
+      if (sigResult.verified === false) {
+        console.error(`Registry signature verification failed: ${sigResult.reason}`);
+        console.error(`This could indicate a compromised registry or a tampered manifest.`);
+        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        process.exit(1);
+      }
+      if (sigResult.verified === true) {
+        console.log(`Registry signature verified (${sigResult.reason})`);
+      } else {
+        console.warn(`Registry signature: ${sigResult.reason}`);
+      }
 
       // Extract
       const packageDir = `${resolved.scope}__${resolved.name}`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,8 +182,18 @@ program
         resolved.manifestCanonical,
       );
       if (sigResult.verified === false) {
+        // Distinguish infrastructure unavailability from a genuine
+        // signature mismatch. Both fail-closed, but the user-facing
+        // framing differs: "try again later" vs "investigate now".
+        const infraFailure = /public key unavailable|manifest_canonical missing/i.test(
+          sigResult.reason,
+        );
         console.error(`Registry signature verification failed: ${sigResult.reason}`);
-        console.error(`This could indicate a compromised registry or a tampered manifest.`);
+        if (infraFailure) {
+          console.error(`The registry may be temporarily unreachable or misconfigured. Try again later.`);
+        } else {
+          console.error(`This could indicate a compromised registry or a tampered manifest.`);
+        }
         await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
         process.exit(1);
       }

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -48,6 +48,12 @@ export interface ResolvedRegistryPackage {
   sha256: string;
   downloadUrl: string;
   source: RegistrySource;
+  /** F-501 registry signature — null for legacy/unsigned versions. */
+  registrySignature: string | null;
+  /** F-501 key identifier — null for legacy/unsigned versions. */
+  registryKeyId: string | null;
+  /** Exact manifest bytes as signed — required for A-504 verification. */
+  manifestCanonical: string | null;
 }
 
 /** Resolve a package from metafactory registry sources (anonymous — no auth required per DD-80) */
@@ -66,8 +72,9 @@ export async function resolveFromRegistry(
     const targetVersion = ref.version ?? detail.latest_version;
     if (!targetVersion) continue;
 
-    // Fetch version detail to get SHA-256 (anonymous — no bearer token per DD-80)
-    const versionDetailUrl = `${source.url}/api/v1/packages/${encodeURIComponent(`@${ref.scope}`)}/${encodeURIComponent(ref.name)}/versions`;
+    // Fetch per-version detail: returns sha256, signing (F-501), and
+    // manifest_canonical (exact bytes as signed, required for A-504).
+    const versionDetailUrl = `${source.url}/api/v1/packages/${encodeURIComponent(`@${ref.scope}`)}/${encodeURIComponent(ref.name)}@${encodeURIComponent(targetVersion)}`;
     try {
       const resp = await fetch(versionDetailUrl, {
         headers: { Accept: "application/json" },
@@ -77,21 +84,29 @@ export async function resolveFromRegistry(
       if (!resp.ok) continue;
 
       const body = (await resp.json()) as {
-        versions: Array<{ version: string; sha256: string }>;
+        version: string;
+        sha256: string;
+        manifest_canonical?: string;
+        signing?: {
+          registry_signature: string | null;
+          registry_key_id: string | null;
+        };
       };
 
-      const versionEntry = body.versions.find((v) => v.version === targetVersion);
-      if (!versionEntry) continue;
+      if (!body.sha256) continue;
 
-      const downloadUrl = `${source.url}/api/v1/storage/download/${versionEntry.sha256}`;
+      const downloadUrl = `${source.url}/api/v1/storage/download/${body.sha256}`;
 
       return {
         scope: ref.scope,
         name: ref.name,
         version: targetVersion,
-        sha256: versionEntry.sha256,
+        sha256: body.sha256,
         downloadUrl,
         source,
+        registrySignature: body.signing?.registry_signature ?? null,
+        registryKeyId: body.signing?.registry_key_id ?? null,
+        manifestCanonical: body.manifest_canonical ?? null,
       };
     } catch (_err) {
       // Network error, try next source

--- a/src/lib/registry-signing.ts
+++ b/src/lib/registry-signing.ts
@@ -1,0 +1,164 @@
+/**
+ * A-504: Client-side verification of registry-level Ed25519 signatures.
+ *
+ * Companion to meta-factory's F-501. The registry signs the exact manifest
+ * bytes stored in D1 at publish time; arc fetches the same bytes (via the
+ * `manifest_canonical` field on the version-detail endpoint) and verifies
+ * them against the `registry_signature` bound to the version using the
+ * public key served at `/.well-known/metafactory-signing-key`.
+ *
+ * Uses Bun's Web Crypto (Ed25519 support landed in 1.0+). No external deps.
+ */
+
+import type { RegistrySource } from "../types.js";
+
+const WELL_KNOWN_PATH = "/.well-known/metafactory-signing-key";
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface RegistryPublicKey {
+  algorithm: "Ed25519";
+  key_id: string;
+  public_key: string; // base64 raw 32-byte Ed25519 public key
+  created_at: number;
+}
+
+export interface VersionSigning {
+  registry_signature: string | null;
+  registry_key_id: string | null;
+}
+
+export interface SignatureVerifyResult {
+  /** true = verified; false = verified-and-rejected; null = not-applicable (unsigned). */
+  verified: boolean | null;
+  /** Short human-readable reason, suitable for stderr. */
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public-key fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the registry's signing public key. Returns null if the registry has
+ * not configured a key (503) or is unreachable. Anonymous — no auth header.
+ */
+export async function fetchRegistryPublicKey(
+  source: RegistrySource,
+): Promise<RegistryPublicKey | null> {
+  const url = `${source.url}${WELL_KNOWN_PATH}`;
+  try {
+    const resp = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (resp.status === 503) return null;
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as Partial<RegistryPublicKey>;
+    if (
+      body.algorithm !== "Ed25519" ||
+      typeof body.key_id !== "string" ||
+      typeof body.public_key !== "string"
+    ) {
+      return null;
+    }
+    return body as RegistryPublicKey;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Verify an Ed25519 registry signature against the exact manifest bytes.
+ * Returns false on any malformed input, wrong-length key/sig, or crypto
+ * error — never throws. Constant-time via crypto.subtle.verify (no `===`
+ * on bytes).
+ */
+export async function verifyRegistrySignature(
+  publicKeyBase64: string,
+  signatureBase64: string,
+  manifestCanonical: string,
+): Promise<boolean> {
+  try {
+    const pubBytes = base64ToBytes(publicKeyBase64);
+    const sigBytes = base64ToBytes(signatureBase64);
+    if (pubBytes.length !== 32) return false;
+    if (sigBytes.length !== 64) return false;
+
+    // Copy into fresh ArrayBuffers — lib.dom's BufferSource rejects the
+    // ArrayBufferLike union even though the runtime accepts it.
+    const pubBuf = pubBytes.buffer.slice(pubBytes.byteOffset, pubBytes.byteOffset + pubBytes.byteLength) as ArrayBuffer;
+    const sigBuf = sigBytes.buffer.slice(sigBytes.byteOffset, sigBytes.byteOffset + sigBytes.byteLength) as ArrayBuffer;
+    const msgBytes = new TextEncoder().encode(manifestCanonical);
+    const msgBuf = msgBytes.buffer.slice(msgBytes.byteOffset, msgBytes.byteOffset + msgBytes.byteLength) as ArrayBuffer;
+
+    const key = await crypto.subtle.importKey(
+      "raw",
+      pubBuf,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify({ name: "Ed25519" }, key, sigBuf, msgBuf);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — fetch key + verify, wrap in a human-readable result
+// ---------------------------------------------------------------------------
+
+export async function verifyVersionSignature(
+  source: RegistrySource,
+  signing: VersionSigning,
+  manifestCanonical: string | null | undefined,
+): Promise<SignatureVerifyResult> {
+  // Legacy / unsigned row: nothing to verify. The registry either predates
+  // F-501 or was in degraded mode when this version was published. Caller
+  // decides whether to warn or proceed.
+  if (!signing.registry_signature || !signing.registry_key_id) {
+    return { verified: null, reason: "version is unsigned (legacy or degraded publish)" };
+  }
+
+  if (!manifestCanonical) {
+    return {
+      verified: false,
+      reason: "manifest_canonical missing from registry response — cannot verify signature",
+    };
+  }
+
+  const key = await fetchRegistryPublicKey(source);
+  if (!key) {
+    return {
+      verified: false,
+      reason: `registry public key unavailable at ${source.url}${WELL_KNOWN_PATH}`,
+    };
+  }
+
+  if (key.key_id !== signing.registry_key_id) {
+    return {
+      verified: false,
+      reason: `key_id mismatch — version was signed with ${signing.registry_key_id}, registry currently serves ${key.key_id}`,
+    };
+  }
+
+  const ok = await verifyRegistrySignature(
+    key.public_key,
+    signing.registry_signature,
+    manifestCanonical,
+  );
+  return ok
+    ? { verified: true, reason: `verified with ${key.key_id}` }
+    : { verified: false, reason: "Ed25519 signature does not match manifest bytes" };
+}

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -179,9 +179,13 @@ describe("resolveFromRegistry", () => {
     globalThis.fetch = mockFetch(async (input: any) => {
       callCount++;
       const url = typeof input === "string" ? input : input.url;
-      if (url.includes("/versions")) {
+      // Per-version detail: /packages/@scope/name@version (F-501 + A-504 shape)
+      if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
         return new Response(JSON.stringify({
-          versions: [{ version: "1.2.0", sha256: "abc123" }, { version: "1.1.0", sha256: "def456" }],
+          version: "1.2.0",
+          sha256: "abc123",
+          manifest_canonical: '{"name":"@metafactory/grove","version":"1.2.0"}',
+          signing: { registry_signature: null, registry_key_id: null },
         }), { status: 200 });
       }
       // Package detail endpoint
@@ -220,9 +224,12 @@ describe("resolveFromRegistry", () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch(async (input: any) => {
       const url = typeof input === "string" ? input : input.url;
-      if (url.includes("/versions")) {
+      if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
         return new Response(JSON.stringify({
-          versions: [{ version: "1.2.0", sha256: "abc" }, { version: "1.1.0", sha256: "def" }],
+          version: "1.1.0",
+          sha256: "def",
+          manifest_canonical: '{"name":"@metafactory/grove","version":"1.1.0"}',
+          signing: { registry_signature: null, registry_key_id: null },
         }), { status: 200 });
       }
       return new Response(JSON.stringify({
@@ -254,9 +261,12 @@ describe("resolveFromRegistry", () => {
       // Capture Authorization header from init (not from a reconstructed Request)
       const headers = new Headers(init?.headers);
       capturedAuths.push(headers.get("Authorization"));
-      if (url.includes("/versions")) {
+      if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
         return new Response(JSON.stringify({
-          versions: [{ version: "1.0.0", sha256: "abc" }],
+          version: "1.0.0",
+          sha256: "abc",
+          manifest_canonical: "{}",
+          signing: { registry_signature: null, registry_key_id: null },
         }), { status: 200 });
       }
       return new Response(JSON.stringify({
@@ -277,6 +287,43 @@ describe("resolveFromRegistry", () => {
       for (const auth of capturedAuths) {
         expect(auth).toBeNull();
       }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("propagates F-501 signing fields from version detail response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
+        return new Response(JSON.stringify({
+          version: "1.0.0",
+          sha256: "deadbeef",
+          manifest_canonical: '{"name":"@a/b","version":"1.0.0"}',
+          signing: {
+            registry_signature: "S".repeat(88),
+            registry_key_id: "mf-reg-2026-04",
+          },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        namespace: "@a", name: "b",
+        display_name: null, description: "", type: "skill", license: "MIT",
+        latest_version: "1.0.0", versions: ["1.0.0"],
+        publisher: { display_name: "T", tier: "official", mfa_enabled: true, github_username: null },
+        sponsor: null, created_at: 0, updated_at: 0,
+      }), { status: 200 });
+    });
+
+    try {
+      const result = await resolveFromRegistry(
+        { scope: "a", name: "b" },
+        [metafactorySource()],
+      );
+      expect(result!.registrySignature).toBe("S".repeat(88));
+      expect(result!.registryKeyId).toBe("mf-reg-2026-04");
+      expect(result!.manifestCanonical).toBe('{"name":"@a/b","version":"1.0.0"}');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/test/unit/registry-signing.test.ts
+++ b/test/unit/registry-signing.test.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  fetchRegistryPublicKey,
+  verifyRegistrySignature,
+  verifyVersionSignature,
+} from "../../src/lib/registry-signing.js";
+import type { RegistrySource } from "../../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(handler: (input: any, init?: any) => Promise<Response>): typeof fetch {
+  const fn = handler as typeof fetch;
+  (fn as any).preconnect = () => {};
+  return fn;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+async function generateKeypair() {
+  const kp = (await crypto.subtle.generateKey(
+    { name: "Ed25519" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return { kp, rawPubBase64: bytesToBase64(new Uint8Array(raw)) };
+}
+
+async function signBytes(kp: CryptoKeyPair, text: string): Promise<string> {
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    kp.privateKey,
+    new TextEncoder().encode(text),
+  );
+  return bytesToBase64(new Uint8Array(sig));
+}
+
+function source(url = "https://reg.test"): RegistrySource {
+  return { name: "mf", url, tier: "official", enabled: true, type: "metafactory" };
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// verifyRegistrySignature — pure crypto
+// ---------------------------------------------------------------------------
+
+describe("verifyRegistrySignature", () => {
+  test("returns true for a valid signature over the exact bytes", async () => {
+    const { kp, rawPubBase64 } = await generateKeypair();
+    const manifest = '{"name":"@x/y","version":"1.0.0"}';
+    const sig = await signBytes(kp, manifest);
+    expect(await verifyRegistrySignature(rawPubBase64, sig, manifest)).toBe(true);
+  });
+
+  test("returns false when a single byte of the manifest is changed", async () => {
+    const { kp, rawPubBase64 } = await generateKeypair();
+    const manifest = '{"name":"@x/y","version":"1.0.0"}';
+    const sig = await signBytes(kp, manifest);
+    const tampered = manifest.replace('"1.0.0"', '"1.0.1"');
+    expect(await verifyRegistrySignature(rawPubBase64, sig, tampered)).toBe(false);
+  });
+
+  test("returns false for a signature made by a different key", async () => {
+    const a = await generateKeypair();
+    const b = await generateKeypair();
+    const manifest = "hello";
+    const sig = await signBytes(a.kp, manifest);
+    // verify with b's public key
+    expect(await verifyRegistrySignature(b.rawPubBase64, sig, manifest)).toBe(false);
+  });
+
+  test("returns false (never throws) for malformed base64", async () => {
+    expect(await verifyRegistrySignature("!!!not-base64!!!", "!!!", "x")).toBe(false);
+  });
+
+  test("returns false for wrong-length public key", async () => {
+    const shortKey = bytesToBase64(new Uint8Array(16));
+    const sig = bytesToBase64(new Uint8Array(64));
+    expect(await verifyRegistrySignature(shortKey, sig, "x")).toBe(false);
+  });
+
+  test("returns false for wrong-length signature", async () => {
+    const { rawPubBase64 } = await generateKeypair();
+    const shortSig = bytesToBase64(new Uint8Array(32));
+    expect(await verifyRegistrySignature(rawPubBase64, shortSig, "x")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRegistryPublicKey
+// ---------------------------------------------------------------------------
+
+describe("fetchRegistryPublicKey", () => {
+  test("returns the parsed body on 200", async () => {
+    const { rawPubBase64 } = await generateKeypair();
+    globalThis.fetch = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          algorithm: "Ed25519",
+          key_id: "mf-reg-2026-04",
+          public_key: rawPubBase64,
+          created_at: 1776124800,
+        }),
+        { status: 200 },
+      ),
+    );
+    const key = await fetchRegistryPublicKey(source());
+    expect(key).not.toBeNull();
+    expect(key!.key_id).toBe("mf-reg-2026-04");
+    expect(key!.public_key).toBe(rawPubBase64);
+  });
+
+  test("returns null on 503 (registry in degraded mode)", async () => {
+    globalThis.fetch = mockFetch(async () =>
+      new Response(JSON.stringify({ error: "signing_unconfigured" }), { status: 503 }),
+    );
+    expect(await fetchRegistryPublicKey(source())).toBeNull();
+  });
+
+  test("returns null on network error (never throws)", async () => {
+    globalThis.fetch = mockFetch(async () => {
+      throw new Error("boom");
+    });
+    expect(await fetchRegistryPublicKey(source())).toBeNull();
+  });
+
+  test("returns null on shape mismatch (wrong algorithm)", async () => {
+    globalThis.fetch = mockFetch(async () =>
+      new Response(
+        JSON.stringify({ algorithm: "RSA", key_id: "x", public_key: "y", created_at: 0 }),
+        { status: 200 },
+      ),
+    );
+    expect(await fetchRegistryPublicKey(source())).toBeNull();
+  });
+
+  test("does not send Authorization header (anonymous)", async () => {
+    let authSeen: string | null | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      authSeen = new Headers(init?.headers).get("Authorization");
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+    await fetchRegistryPublicKey(source());
+    expect(authSeen).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyVersionSignature — orchestration
+// ---------------------------------------------------------------------------
+
+describe("verifyVersionSignature", () => {
+  test("verified=true when signature matches manifest_canonical", async () => {
+    const { kp, rawPubBase64 } = await generateKeypair();
+    const manifest = '{"name":"@x/y","version":"1.0.0"}';
+    const sig = await signBytes(kp, manifest);
+
+    globalThis.fetch = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          algorithm: "Ed25519",
+          key_id: "mf-reg-2026-04",
+          public_key: rawPubBase64,
+          created_at: 0,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: sig, registry_key_id: "mf-reg-2026-04" },
+      manifest,
+    );
+    expect(result.verified).toBe(true);
+  });
+
+  test("verified=false when manifest_canonical is tampered", async () => {
+    const { kp, rawPubBase64 } = await generateKeypair();
+    const manifest = '{"name":"@x/y","version":"1.0.0"}';
+    const sig = await signBytes(kp, manifest);
+
+    globalThis.fetch = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          algorithm: "Ed25519",
+          key_id: "mf-reg-2026-04",
+          public_key: rawPubBase64,
+          created_at: 0,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: sig, registry_key_id: "mf-reg-2026-04" },
+      manifest.replace("1.0.0", "9.9.9"),
+    );
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/signature does not match/i);
+  });
+
+  test("verified=null when registry_signature is null (legacy/unsigned)", async () => {
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: null, registry_key_id: null },
+      "whatever",
+    );
+    expect(result.verified).toBeNull();
+  });
+
+  test("verified=false when well-known returns 503 but version claims to be signed", async () => {
+    globalThis.fetch = mockFetch(async () => new Response("", { status: 503 }));
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: "A".repeat(88), registry_key_id: "mf-reg-2026-04" },
+      "manifest-bytes",
+    );
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/public key unavailable/i);
+  });
+
+  test("verified=false when key_id on the version disagrees with the served key", async () => {
+    const { kp, rawPubBase64 } = await generateKeypair();
+    const sig = await signBytes(kp, "m");
+    globalThis.fetch = mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          algorithm: "Ed25519",
+          key_id: "mf-reg-CURRENT",
+          public_key: rawPubBase64,
+          created_at: 0,
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: sig, registry_key_id: "mf-reg-OLD" },
+      "m",
+    );
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/key_id mismatch/i);
+  });
+
+  test("verified=false when manifest_canonical is missing from registry response", async () => {
+    const result = await verifyVersionSignature(
+      source(),
+      { registry_signature: "sig", registry_key_id: "kid" },
+      null,
+    );
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/manifest_canonical missing/i);
+  });
+});


### PR DESCRIPTION
## Summary

Third client-side verification pass in the install pipeline — after SHA-256, before extract. Implements F-505 for the registry-level signing track (DD-12), consuming meta-factory's F-501 (shipped in #163) and the `manifest_canonical` field (shipped in #164).

## What

- **New:** `src/lib/registry-signing.ts`
  - `fetchRegistryPublicKey(source)` — hits `/.well-known/metafactory-signing-key`, returns null on 503/network-error/shape-mismatch.
  - `verifyRegistrySignature(pubB64, sigB64, bytes)` — Ed25519 verify via Web Crypto. Never throws, never uses `===` on bytes.
  - `verifyVersionSignature(source, signing, manifest_canonical)` — orchestrates fetch + key_id match + verify into a typed `{ verified, reason }` result.
- **Updated:** `src/lib/registry-install.ts`
  - `resolveFromRegistry` now calls `/packages/@scope/name@version` (returns sha256 + manifest_canonical + signing in one round-trip), replacing the older `/versions` list call.
  - `ResolvedRegistryPackage` carries `registrySignature`, `registryKeyId`, `manifestCanonical`.
- **Updated:** `src/cli.ts`
  - After SHA-256 passes, call `verifyVersionSignature`.
  - `verified === false` → exit 1 (no `--force` override, per DD-12/F-505).
  - `verified === null` → warn and proceed (legacy row or registry in degraded mode at publish time — mirrors meta-factory's graceful degradation).
- **Blueprint:** A-406 and A-504 marked `done`.

## Test plan

- [x] 17 new unit tests in `test/unit/registry-signing.test.ts`:
  - `verifyRegistrySignature`: round-trip, bit-flip (manifest), wrong key, malformed base64, wrong-length key (16 bytes), wrong-length sig (32 bytes).
  - `fetchRegistryPublicKey`: 200/503/network-error/shape-mismatch, anonymous (no Authorization header).
  - `verifyVersionSignature`: verified=true, verified=false on tamper, verified=null on unsigned, 503 while signed, key_id mismatch, missing manifest_canonical.
- [x] `registry-install.test.ts` mocks updated to the new per-version detail shape + one new test asserting signing fields propagate.
- [x] Full suite: 511/511 passing.
- [x] `bunx tsc --noEmit` clean.

## Dependencies satisfied

- meta-factory F-501 (PR #163) — registry signs, exposes signature
- meta-factory `manifest_canonical` (PR #164) — exposes exact signed bytes
- A-406 SHA-256 verify — already wired

## Not in this PR

A-503 (cosign/Sigstore verification) — separate track, depends on F-500 being wired end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)