### PR TITLE
feat(A-503): client-side Sigstore/cosign verification on install

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -180,7 +180,7 @@ features:
 
   - id: A-503
     name: arc install cosign verification
-    status: planned
+    status: done
     iteration: 6
     depends: [A-502, meta-factory:F5-500]
     description: "arc install fetches Sigstore bundle alongside artifact, calls cosign verify-blob --bundle --offline — blocks install on verification failure (DD-11, F-505)"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import {
   extractPackage,
 } from "./lib/registry-install.js";
 import { verifyVersionSignature } from "./lib/registry-signing.js";
+import { verifyPackageSigstore } from "./lib/cosign-verify.js";
 import { loadCatalog, saveCatalog, findEntry } from "./lib/catalog.js";
 import {
   loadSources,
@@ -201,6 +202,31 @@ program
         console.log(`Registry signature verified (${sigResult.reason})`);
       } else {
         console.warn(`Registry signature: ${sigResult.reason}`);
+      }
+
+      // A-503: verify Sigstore bundle (cosign) when signature_bundle_key is
+      // present. Scope OQ-14: GitHub Actions OIDC only. verified=null means
+      // the version predates Sigstore signing — proceed with a warning.
+      const sigstoreResult = await verifyPackageSigstore({
+        source: resolved.source,
+        sha256: resolved.sha256,
+        signing: {
+          signature_bundle_key: resolved.signatureBundleKey,
+          signer_identity: resolved.signerIdentity,
+        },
+        artifactPath: download.tempPath,
+        tempDir: paths.reposDir,
+      });
+      if (sigstoreResult.verified === false) {
+        console.error(`Sigstore verification failed: ${sigstoreResult.reason}`);
+        console.error(`This could indicate a tampered artifact or an unexpected signer.`);
+        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        process.exit(1);
+      }
+      if (sigstoreResult.verified === true) {
+        console.log(`Sigstore signature verified (${sigstoreResult.reason})`);
+      } else {
+        console.warn(`Sigstore signature: ${sigstoreResult.reason}`);
       }
 
       // Extract

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -1,0 +1,113 @@
+/**
+ * A-503: Client-side Sigstore/cosign verification.
+ *
+ * Companion to meta-factory's F-008/F-009/F-010. When a version has a
+ * `signature_bundle_key` in its signing block, arc downloads the bundle from
+ * the registry's bundle endpoint and hands it to cosign (via the bundled
+ * binary wrapper) along with the expected signer identity and OIDC issuer.
+ *
+ * Scope (OQ-14): GitHub Actions OIDC only — other issuers are out of scope
+ * for phase 1. Anonymous bundle fetch (DD-80): no Authorization header.
+ */
+
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import type { RegistrySource } from "../types.js";
+import { verifySigstoreBundle, type VerifySigstoreResult } from "./cosign.js";
+
+const FETCH_TIMEOUT_MS = 30_000;
+
+/** OQ-14: phase 1 accepts only GitHub Actions OIDC as signer issuer. */
+export const TRUSTED_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
+
+export interface VersionSigstoreSigning {
+  signature_bundle_key: string | null;
+  signer_identity: string | null;
+}
+
+export interface SigstoreVerifyResult {
+  /** true = verified; false = verified-and-rejected; null = not-applicable (unsigned). */
+  verified: boolean | null;
+  reason: string;
+}
+
+export type SigstoreVerifier = (
+  artifactPath: string,
+  bundlePath: string,
+  expectedIdentity: string,
+  expectedIssuer: string,
+) => Promise<VerifySigstoreResult>;
+
+// ---------------------------------------------------------------------------
+// Bundle download
+// ---------------------------------------------------------------------------
+
+/**
+ * Download a Sigstore bundle to a temp file. Anonymous (no Authorization
+ * header) per DD-80 — bundles are public, the registry route is unauth'd.
+ * Never throws; returns `{error}` on any failure.
+ */
+export async function downloadSigstoreBundle(
+  url: string,
+  tempDir: string,
+): Promise<{ path?: string; error?: string }> {
+  try {
+    const resp = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!resp.ok) {
+      return { error: `bundle not found or unreachable (HTTP ${resp.status})` };
+    }
+    const body = await resp.text();
+    const path = join(tempDir, `arc-bundle-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.bundle`);
+    await writeFile(path, body);
+    return { path };
+  } catch (err: any) {
+    return { error: `bundle download failed: ${err?.message ?? err}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface VerifyPackageSigstoreOptions {
+  source: RegistrySource;
+  sha256: string;
+  signing: VersionSigstoreSigning;
+  artifactPath: string;
+  tempDir: string;
+  /** Injectable for tests; defaults to the bundled-cosign wrapper. */
+  verifier?: SigstoreVerifier;
+}
+
+export async function verifyPackageSigstore(
+  opts: VerifyPackageSigstoreOptions,
+): Promise<SigstoreVerifyResult> {
+  const { source, sha256, signing, artifactPath, tempDir } = opts;
+  const verifier: SigstoreVerifier = opts.verifier ?? verifySigstoreBundle;
+
+  if (!signing.signature_bundle_key) {
+    return { verified: null, reason: "version is not sigstore-signed (legacy or unsigned publish)" };
+  }
+
+  if (!signing.signer_identity) {
+    return {
+      verified: false,
+      reason: "signer_identity missing — cannot verify Sigstore bundle without expected identity",
+    };
+  }
+
+  const bundleUrl = `${source.url}/api/v1/storage/bundle/${sha256}`;
+  const dl = await downloadSigstoreBundle(bundleUrl, tempDir);
+  if (!dl.path) {
+    return { verified: false, reason: `bundle ${dl.error ?? "download failed"}` };
+  }
+
+  const result = await verifier(artifactPath, dl.path, signing.signer_identity, TRUSTED_OIDC_ISSUER);
+  if (result.valid) {
+    return { verified: true, reason: `Sigstore bundle verified for ${signing.signer_identity}` };
+  }
+  return { verified: false, reason: result.error ?? "cosign verification failed" };
+}

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -10,7 +10,7 @@
  * for phase 1. Anonymous bundle fetch (DD-80): no Authorization header.
  */
 
-import { writeFile } from "fs/promises";
+import { writeFile, unlink } from "fs/promises";
 import { join } from "path";
 import type { RegistrySource } from "../types.js";
 import { verifySigstoreBundle, type VerifySigstoreResult } from "./cosign.js";
@@ -105,9 +105,13 @@ export async function verifyPackageSigstore(
     return { verified: false, reason: `bundle ${dl.error ?? "download failed"}` };
   }
 
-  const result = await verifier(artifactPath, dl.path, signing.signer_identity, TRUSTED_OIDC_ISSUER);
-  if (result.valid) {
-    return { verified: true, reason: `Sigstore bundle verified for ${signing.signer_identity}` };
+  try {
+    const result = await verifier(artifactPath, dl.path, signing.signer_identity, TRUSTED_OIDC_ISSUER);
+    if (result.valid) {
+      return { verified: true, reason: `Sigstore bundle verified for ${signing.signer_identity}` };
+    }
+    return { verified: false, reason: result.error ?? "cosign verification failed" };
+  } finally {
+    await unlink(dl.path).catch(() => {});
   }
-  return { verified: false, reason: result.error ?? "cosign verification failed" };
 }

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -54,6 +54,12 @@ export interface ResolvedRegistryPackage {
   registryKeyId: string | null;
   /** Exact manifest bytes as signed — required for A-504 verification. */
   manifestCanonical: string | null;
+  /** F-009 Sigstore bundle R2 key — null if not sigstore-signed. */
+  signatureBundleKey: string | null;
+  /** F-008 expected signer identity (GitHub Actions workflow URI). */
+  signerIdentity: string | null;
+  /** Publish timestamp from the signing block (informational). */
+  signedAt: string | null;
 }
 
 /** Resolve a package from metafactory registry sources (anonymous — no auth required per DD-80) */
@@ -90,6 +96,9 @@ export async function resolveFromRegistry(
         signing?: {
           registry_signature: string | null;
           registry_key_id: string | null;
+          signature_bundle_key?: string | null;
+          signer_identity?: string | null;
+          signed_at?: string | null;
         };
       };
 
@@ -107,6 +116,9 @@ export async function resolveFromRegistry(
         registrySignature: body.signing?.registry_signature ?? null,
         registryKeyId: body.signing?.registry_key_id ?? null,
         manifestCanonical: body.manifest_canonical ?? null,
+        signatureBundleKey: body.signing?.signature_bundle_key ?? null,
+        signerIdentity: body.signing?.signer_identity ?? null,
+        signedAt: body.signing?.signed_at ?? null,
       };
     } catch (_err) {
       // Network error, try next source

--- a/test/unit/cosign-verify.test.ts
+++ b/test/unit/cosign-verify.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  downloadSigstoreBundle,
+  verifyPackageSigstore,
+  TRUSTED_OIDC_ISSUER,
+} from "../../src/lib/cosign-verify.js";
+import type { RegistrySource } from "../../src/types.js";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { writeFile } from "fs/promises";
+import { join } from "path";
+
+function mockFetch(handler: (input: any, init?: any) => Promise<Response>): typeof fetch {
+  const fn = handler as typeof fetch;
+  (fn as any).preconnect = () => {};
+  return fn;
+}
+
+function source(url = "https://reg.test"): RegistrySource {
+  return { name: "mf", url, tier: "official", enabled: true, type: "metafactory" };
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+let env: TestEnv;
+
+afterEach(async () => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (env) await env.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// downloadSigstoreBundle
+// ---------------------------------------------------------------------------
+
+describe("downloadSigstoreBundle", () => {
+  test("writes the bundle to temp and returns the path", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () =>
+      new Response('{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1"}', {
+        status: 200,
+      }),
+    );
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    expect(result.path).toBeDefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns error on 404", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () => new Response("not found", { status: 404 }));
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    expect(result.error).toMatch(/not found/i);
+    expect(result.path).toBeUndefined();
+  });
+
+  test("returns error on network failure (never throws)", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () => {
+      throw new Error("boom");
+    });
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    expect(result.error).toBeDefined();
+    expect(result.path).toBeUndefined();
+  });
+
+  test("does not send Authorization header (anonymous per DD-80)", async () => {
+    env = await createTestEnv();
+    let authSeen: string | null | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      authSeen = new Headers(init?.headers).get("Authorization");
+      return new Response("{}", { status: 200 });
+    });
+    await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    expect(authSeen).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyPackageSigstore — orchestrator, verifier injected for test isolation
+// ---------------------------------------------------------------------------
+
+describe("verifyPackageSigstore", () => {
+  test("verified=null when signature_bundle_key is null (legacy/unsigned)", async () => {
+    env = await createTestEnv();
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: { signature_bundle_key: null, signer_identity: null },
+      artifactPath: "/tmp/fake.tgz",
+      tempDir: env.paths.reposDir,
+    });
+    expect(result.verified).toBeNull();
+    expect(result.reason).toMatch(/not sigstore-signed/i);
+  });
+
+  test("verified=false when signature_bundle_key present but signer_identity missing", async () => {
+    env = await createTestEnv();
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: { signature_bundle_key: "packages/abc.bundle", signer_identity: null },
+      artifactPath: "/tmp/fake.tgz",
+      tempDir: env.paths.reposDir,
+    });
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/signer_identity/i);
+  });
+
+  test("verified=false when bundle download fails", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () => new Response("", { status: 503 }));
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: {
+        signature_bundle_key: "packages/abc.bundle",
+        signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
+      },
+      artifactPath: "/tmp/fake.tgz",
+      tempDir: env.paths.reposDir,
+    });
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/bundle/i);
+  });
+
+  test("verified=true when injected verifier returns valid", async () => {
+    env = await createTestEnv();
+    const bundleBody = '{"mediaType":"application/vnd.dev.sigstore.bundle+json"}';
+    globalThis.fetch = mockFetch(async () => new Response(bundleBody, { status: 200 }));
+
+    // Create a real artifact file so verifier receives a valid path
+    const artifactPath = join(env.paths.reposDir, "artifact.tgz");
+    await writeFile(artifactPath, "fake-contents");
+
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: {
+        signature_bundle_key: "packages/abc.bundle",
+        signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
+      },
+      artifactPath,
+      tempDir: env.paths.reposDir,
+      verifier: async (artifact: string, bundle: string, identity: string, issuer: string) => {
+        expect(artifact).toBe(artifactPath);
+        expect(bundle).toMatch(/\.bundle$/);
+        expect(identity).toContain("publish.yml");
+        expect(issuer).toBe(TRUSTED_OIDC_ISSUER);
+        return { valid: true, output: "ok" };
+      },
+    });
+    expect(result.verified).toBe(true);
+  });
+
+  test("verified=false when injected verifier returns invalid (tampered artifact)", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () =>
+      new Response('{"mediaType":"application/vnd.dev.sigstore.bundle+json"}', { status: 200 }),
+    );
+    const artifactPath = join(env.paths.reposDir, "artifact.tgz");
+    await writeFile(artifactPath, "fake");
+
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: {
+        signature_bundle_key: "packages/abc.bundle",
+        signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
+      },
+      artifactPath,
+      tempDir: env.paths.reposDir,
+      verifier: async () => ({ valid: false, error: "signature mismatch" }),
+    });
+    expect(result.verified).toBe(false);
+    expect(result.reason).toMatch(/signature mismatch/i);
+  });
+
+  test("TRUSTED_OIDC_ISSUER is GitHub Actions (OQ-14 scope)", () => {
+    expect(TRUSTED_OIDC_ISSUER).toBe("https://token.actions.githubusercontent.com");
+  });
+});


### PR DESCRIPTION
## Summary

Wires Sigstore bundle verification into the arc install pipeline, completing F-505's third verification gate alongside A-406 (SHA-256) and A-504 (registry Ed25519 signature).

- New `src/lib/cosign-verify.ts`: anonymous bundle fetch (DD-80) + orchestrator that shells out via the bundled cosign wrapper with the expected signer identity and the GitHub Actions OIDC issuer (OQ-14: phase-1 scope is GitHub Actions only).
- `ResolvedRegistryPackage` extended with `signatureBundleKey`, `signerIdentity`, `signedAt`; `resolveFromRegistry` reads them from the version-detail `signing` block (F-008/F-009/F-010).
- `cli.ts` runs the check after the registry-signature check: fail-closed on `verified=false` (no `--force`), warn-and-proceed on `verified=null` (legacy/unsigned) — matches the graceful-degradation pattern from A-504.
- Injectable `verifier` parameter on the orchestrator so tests don't need a real cosign binary or a signed fixture.

Install-time verification order is now:
1. SHA-256 content hash (A-406)
2. Registry Ed25519 signature over `manifest_canonical` (A-504)
3. Sigstore/cosign `verify-blob` against the GitHub Actions identity (A-503, this PR)

## Test plan

- [x] 10 new unit tests in `test/unit/cosign-verify.test.ts` — download success/404/network-error/anonymous, orchestrator null-legacy / missing-identity / bundle-fail / verified / tampered / OIDC-issuer constant
- [x] Full arc suite: 521/521 pass
- [ ] Manual end-to-end install against a sigstore-signed package on dev (blocked until a signed version is published through F-008/009/010)

Closes A-503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)