### PR TITLE
feat(review): arc review CLI for sponsor/steward triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.21.0
+
+### Added
+- `arc review` command family for sponsor / steward submission triage while the metafactory reviewer UI ([the-metafactory/meta-factory#114](https://github.com/the-metafactory/meta-factory/issues/114)) is still spec-only:
+  - `arc review list` — pending submissions assigned to you (paginated, `--per-page` capped at 100 client-side, `--json` for scripting)
+  - `arc review show <id>` — full submission detail; pretty-prints nested `validation_result` JSON
+  - `arc review approve <id>` — advance submission to `approved` (first approval promotes package `draft` → `active`)
+  - `arc review reject <id> -r <reason>` — reject with reason shown to publisher
+  - `arc review request-changes <id> -m <message>` — request changes with comment to publisher
+- All action commands accept `--json` for machine output.
+- Reuses existing `arc login` bearer-token auth; `-s, --source <name>` selects a metafactory source. Server enforces tier-gating (`trusted+`), sponsor-only queue scoping, and DD-9 self-review prevention.
+
 ## 0.19.3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ arc login --source <name>     # Authenticate with a specific source
 arc logout                    # Remove authentication token
 ```
 
+### Review (sponsor/steward)
+
+Triage the submission queue for packages where you are the assigned sponsor — or, as a steward, any submission. Requires `trusted+` tier server-side. DD-9 blocks reviewing your own submissions.
+
+```bash
+arc review list                          # Pending submissions assigned to you
+arc review list --per-page 50 --json     # Scripting-friendly, capped at 100
+arc review show <id>                     # Full detail incl. validation_result
+arc review approve <id>                  # Approve and advance to 'approved'
+arc review reject <id> -r "reason"       # Reject (reason shown to publisher)
+arc review request-changes <id> -m "..." # Request changes (comment to publisher)
+```
+
+Every `review` subcommand accepts `-s, --source <name>` to pick a metafactory source and (on `list`, `show`, and all action commands) `--json` for machine output. The first approval on a package promotes it from `draft` → `active`, making it visible on browse and the package page.
+
 ---
 
 ## How It Works
@@ -456,6 +471,55 @@ Re-running `arc publish` with the same version returns a clear error: *"Version 
 - Valid `arc-manifest.yaml` with `name` (lowercase alphanumeric), `version` (semver), and `type`
 - A `README.md` is recommended but not required
 - All capabilities must be honestly declared
+
+---
+
+## Reviewing Submissions
+
+Every published version goes through human review before becoming visible (metafactory DD-6 — no automated approval at any tier). If you are listed as a package's sponsor, or you hold the `steward` tier, `arc review` lets you triage the queue from the terminal while the dedicated reviewer UI is still under construction.
+
+### Quick Review
+
+```bash
+arc review list                 # Submissions awaiting your action
+arc review show <submission-id> # Full detail (validation output, capability diff, reviewer comment)
+```
+
+### Actions
+
+```bash
+arc review approve <id>                   # Advance submission to 'approved'
+arc review reject <id> -r "reason"        # Reject; reason is shown to the publisher
+arc review request-changes <id> -m "..."  # Send the submission back with a comment
+```
+
+### How Reviewing Works
+
+1. Publisher runs `arc publish`, version lands in state `pending_review` with an assigned sponsor.
+2. Sponsor (or any steward) pulls the queue with `arc review list`, inspects with `arc review show`, and chooses one of the three actions.
+3. On `approve`, the package transitions from `draft` to `active` on its first approval, becoming visible on browse and its package page. Subsequent approvals just promote new versions.
+4. `reject` / `request-changes` store your text on the submission so the publisher sees why and what to change.
+
+### Server-Side Guarantees
+
+- `trusted+` tier required for every `review` subcommand (enforced server-side).
+- `list` only returns submissions where `sponsor_id = you` — you never see other sponsors' queues.
+- DD-9: you cannot approve, reject, or request changes on your own submissions. The server returns 403 with a clear message.
+- `reject` and `request-changes` require non-empty text; both the client (arc) and the server enforce this.
+
+### Scripting
+
+`arc review list`, `show`, and all action commands accept `--json` for machine output. Example:
+
+```bash
+arc review list --json | jq '.submissions[] | {id, status, submitted_by}'
+```
+
+### Requirements
+
+- Authenticated with `arc login`
+- Assigned as sponsor for the package, or tier `steward`
+- Tier `trusted` or higher (server enforces)
 
 ---
 

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.20.1
+version: 0.21.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,16 @@ import { logout } from "./commands/logout.js";
 import { bundle, formatBundle } from "./commands/bundle.js";
 import { publish, formatPublish } from "./commands/publish.js";
 import {
+  reviewList,
+  reviewShow,
+  reviewApprove,
+  reviewReject,
+  reviewRequestChanges,
+  formatReviewList,
+  formatReviewShow,
+  formatReviewAction,
+} from "./commands/review.js";
+import {
   searchAcrossSources,
   formatSearch,
   formatSearchJson,
@@ -836,6 +846,89 @@ program
     });
 
     console.log(formatPublish(result));
+    if (!result.success) process.exit(1);
+  });
+
+// ── Review commands (sponsor/steward triage) ────────────────
+
+const review = program
+  .command("review")
+  .description("Review pending package submissions (sponsor/steward)");
+
+review
+  .command("list")
+  .description("List pending submissions assigned to you")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .option("-p, --page <number>", "Page number", "1")
+  .option("--per-page <number>", "Items per page (max 100)", "20")
+  .option("--json", "Output raw JSON")
+  .action(async (opts: { source?: string; page: string; perPage: string; json?: boolean }) => {
+    const paths = createPaths();
+    const result = await reviewList({
+      paths,
+      sourceName: opts.source,
+      page: parseInt(opts.page, 10) || 1,
+      perPage: parseInt(opts.perPage, 10) || 20,
+      json: opts.json,
+    });
+    console.log(formatReviewList(result));
+    if (!result.success) process.exit(1);
+  });
+
+review
+  .command("show <id>")
+  .description("Show submission detail")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .option("--json", "Output raw JSON")
+  .action(async (id: string, opts: { source?: string; json?: boolean }) => {
+    const paths = createPaths();
+    const result = await reviewShow({ paths, sourceName: opts.source, id, json: opts.json });
+    console.log(formatReviewShow(result));
+    if (!result.success) process.exit(1);
+  });
+
+review
+  .command("approve <id>")
+  .description("Approve a submission")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .action(async (id: string, opts: { source?: string }) => {
+    const paths = createPaths();
+    const result = await reviewApprove({ paths, sourceName: opts.source, id });
+    console.log(formatReviewAction(result));
+    if (!result.success) process.exit(1);
+  });
+
+review
+  .command("reject <id>")
+  .description("Reject a submission (requires --reason)")
+  .requiredOption("-r, --reason <text>", "Rejection reason (shown to publisher)")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .action(async (id: string, opts: { source?: string; reason: string }) => {
+    const paths = createPaths();
+    const result = await reviewReject({
+      paths,
+      sourceName: opts.source,
+      id,
+      reason: opts.reason,
+    });
+    console.log(formatReviewAction(result));
+    if (!result.success) process.exit(1);
+  });
+
+review
+  .command("request-changes <id>")
+  .description("Request changes from publisher (requires --message)")
+  .requiredOption("-m, --message <text>", "Change request comment (shown to publisher)")
+  .option("-s, --source <name>", "Use a specific metafactory source")
+  .action(async (id: string, opts: { source?: string; message: string }) => {
+    const paths = createPaths();
+    const result = await reviewRequestChanges({
+      paths,
+      sourceName: opts.source,
+      id,
+      comment: opts.message,
+    });
+    console.log(formatReviewAction(result));
     if (!result.success) process.exit(1);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -891,9 +891,10 @@ review
   .command("approve <id>")
   .description("Approve a submission")
   .option("-s, --source <name>", "Use a specific metafactory source")
-  .action(async (id: string, opts: { source?: string }) => {
+  .option("--json", "Output raw JSON")
+  .action(async (id: string, opts: { source?: string; json?: boolean }) => {
     const paths = createPaths();
-    const result = await reviewApprove({ paths, sourceName: opts.source, id });
+    const result = await reviewApprove({ paths, sourceName: opts.source, id, json: opts.json });
     console.log(formatReviewAction(result));
     if (!result.success) process.exit(1);
   });
@@ -903,13 +904,15 @@ review
   .description("Reject a submission (requires --reason)")
   .requiredOption("-r, --reason <text>", "Rejection reason (shown to publisher)")
   .option("-s, --source <name>", "Use a specific metafactory source")
-  .action(async (id: string, opts: { source?: string; reason: string }) => {
+  .option("--json", "Output raw JSON")
+  .action(async (id: string, opts: { source?: string; reason: string; json?: boolean }) => {
     const paths = createPaths();
     const result = await reviewReject({
       paths,
       sourceName: opts.source,
       id,
       reason: opts.reason,
+      json: opts.json,
     });
     console.log(formatReviewAction(result));
     if (!result.success) process.exit(1);
@@ -920,13 +923,15 @@ review
   .description("Request changes from publisher (requires --message)")
   .requiredOption("-m, --message <text>", "Change request comment (shown to publisher)")
   .option("-s, --source <name>", "Use a specific metafactory source")
-  .action(async (id: string, opts: { source?: string; message: string }) => {
+  .option("--json", "Output raw JSON")
+  .action(async (id: string, opts: { source?: string; message: string; json?: boolean }) => {
     const paths = createPaths();
     const result = await reviewRequestChanges({
       paths,
       sourceName: opts.source,
       id,
       comment: opts.message,
+      json: opts.json,
     });
     console.log(formatReviewAction(result));
     if (!result.success) process.exit(1);

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -40,10 +40,18 @@ async function resolveSource(
   return { source: src };
 }
 
+const MAX_PER_PAGE = 100;
+
 export async function reviewList(opts: ReviewListOptions): Promise<ReviewListResult> {
   const resolved = await resolveSource(opts.paths, opts.sourceName);
   if ("error" in resolved) return { success: false, error: resolved.error };
-  const r = await listPending(resolved.source, opts.page ?? 1, opts.perPage ?? 20);
+  // Server clamps to 100 silently; cap client-side so callers see the capped
+  // value in the output and aren't surprised by a partial page.
+  const perPage = Math.min(MAX_PER_PAGE, Math.max(1, opts.perPage ?? 20));
+  if (opts.perPage && opts.perPage > MAX_PER_PAGE) {
+    console.warn(`Note: --per-page clamped to ${MAX_PER_PAGE} (server maximum).`);
+  }
+  const r = await listPending(resolved.source, opts.page ?? 1, perPage);
   if (!r.success) return { success: false, error: r.error };
   return {
     success: true,
@@ -83,6 +91,7 @@ export interface ReviewActionOptions {
   id: string;
   reason?: string;
   comment?: string;
+  json?: boolean;
 }
 
 export interface ReviewActionCommandResult {
@@ -90,39 +99,40 @@ export interface ReviewActionCommandResult {
   action: "approve" | "reject" | "request-changes";
   submission?: SubmissionDetail;
   error?: string;
+  json?: boolean;
 }
 
 export async function reviewApprove(
   opts: ReviewActionOptions,
 ): Promise<ReviewActionCommandResult> {
   const resolved = await resolveSource(opts.paths, opts.sourceName);
-  if ("error" in resolved) return { success: false, action: "approve", error: resolved.error };
+  if ("error" in resolved) return { success: false, action: "approve", error: resolved.error, json: opts.json };
   const r = await approveSubmission(resolved.source, opts.id);
-  return { success: r.success, action: "approve", submission: r.submission, error: r.error };
+  return { success: r.success, action: "approve", submission: r.submission, error: r.error, json: opts.json };
 }
 
 export async function reviewReject(
   opts: ReviewActionOptions,
 ): Promise<ReviewActionCommandResult> {
   if (!opts.reason || opts.reason.trim().length === 0) {
-    return { success: false, action: "reject", error: "--reason is required" };
+    return { success: false, action: "reject", error: "--reason is required", json: opts.json };
   }
   const resolved = await resolveSource(opts.paths, opts.sourceName);
-  if ("error" in resolved) return { success: false, action: "reject", error: resolved.error };
+  if ("error" in resolved) return { success: false, action: "reject", error: resolved.error, json: opts.json };
   const r = await rejectSubmission(resolved.source, opts.id, opts.reason.trim());
-  return { success: r.success, action: "reject", submission: r.submission, error: r.error };
+  return { success: r.success, action: "reject", submission: r.submission, error: r.error, json: opts.json };
 }
 
 export async function reviewRequestChanges(
   opts: ReviewActionOptions,
 ): Promise<ReviewActionCommandResult> {
   if (!opts.comment || opts.comment.trim().length === 0) {
-    return { success: false, action: "request-changes", error: "--message is required" };
+    return { success: false, action: "request-changes", error: "--message is required", json: opts.json };
   }
   const resolved = await resolveSource(opts.paths, opts.sourceName);
-  if ("error" in resolved) return { success: false, action: "request-changes", error: resolved.error };
+  if ("error" in resolved) return { success: false, action: "request-changes", error: resolved.error, json: opts.json };
   const r = await requestChanges(resolved.source, opts.id, opts.comment.trim());
-  return { success: r.success, action: "request-changes", submission: r.submission, error: r.error };
+  return { success: r.success, action: "request-changes", submission: r.submission, error: r.error, json: opts.json };
 }
 
 // ── Formatters ───────────────────────────────────────────────
@@ -156,6 +166,23 @@ export function formatReviewList(r: ReviewListResult): string {
   return header + rows.join("\n\n");
 }
 
+function renderValidationResult(raw: unknown): string {
+  // Server stores validation_result as a JSON string. Unwrap it and
+  // pretty-print so stewards can skim nested findings/discrepancies.
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  }
+  if (typeof parsed === "string") return parsed;
+  const pretty = JSON.stringify(parsed, null, 2);
+  // Indent every line by 4 so the block aligns under `validation_result:`.
+  return pretty.split("\n").map((line) => `    ${line}`).join("\n");
+}
+
 export function formatReviewShow(r: ReviewShowResult): string {
   if (!r.success) return `Error: ${r.error}`;
   if (r.json) return JSON.stringify(r.submission, null, 2);
@@ -175,12 +202,21 @@ export function formatReviewShow(r: ReviewShowResult): string {
   if (s.review_comment) lines.push(`  review_comment:  ${s.review_comment}`);
   if (s.validation_result) {
     lines.push(`  validation_result:`);
-    lines.push(`    ${typeof s.validation_result === "string" ? s.validation_result : JSON.stringify(s.validation_result)}`);
+    lines.push(renderValidationResult(s.validation_result));
   }
   return lines.join("\n");
 }
 
 export function formatReviewAction(r: ReviewActionCommandResult): string {
+  if (r.json) {
+    return JSON.stringify(
+      r.success
+        ? { action: r.action, submission: r.submission }
+        : { action: r.action, error: r.error },
+      null,
+      2,
+    );
+  }
   if (!r.success) return `Error: ${r.error}`;
   const verbMap = { approve: "approved", reject: "rejected", "request-changes": "changes requested" };
   const verb = verbMap[r.action];

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,189 @@
+import { loadSources, findMetafactorySource } from "../lib/sources.js";
+import {
+  listPending,
+  getSubmission,
+  approveSubmission,
+  rejectSubmission,
+  requestChanges,
+  type PendingSubmission,
+  type SubmissionDetail,
+} from "../lib/review.js";
+import type { PaiPaths } from "../types.js";
+
+export interface ReviewListOptions {
+  paths: PaiPaths;
+  sourceName?: string;
+  page?: number;
+  perPage?: number;
+  json?: boolean;
+}
+
+export interface ReviewListResult {
+  success: boolean;
+  submissions?: PendingSubmission[];
+  total?: number;
+  page?: number;
+  per_page?: number;
+  json?: boolean;
+  error?: string;
+}
+
+async function resolveSource(
+  paths: PaiPaths,
+  sourceName?: string,
+): Promise<{ source: import("../types.js").RegistrySource } | { error: string }> {
+  const sourcesConfig = await loadSources(paths.sourcesPath);
+  const sourceResult = findMetafactorySource(sourcesConfig, sourceName);
+  if ("error" in sourceResult) return { error: sourceResult.error };
+  const src = sourceResult.source;
+  if (!src.token) return { error: 'Not authenticated. Run "arc login" first.' };
+  return { source: src };
+}
+
+export async function reviewList(opts: ReviewListOptions): Promise<ReviewListResult> {
+  const resolved = await resolveSource(opts.paths, opts.sourceName);
+  if ("error" in resolved) return { success: false, error: resolved.error };
+  const r = await listPending(resolved.source, opts.page ?? 1, opts.perPage ?? 20);
+  if (!r.success) return { success: false, error: r.error };
+  return {
+    success: true,
+    submissions: r.submissions,
+    total: r.total,
+    page: r.page,
+    per_page: r.per_page,
+    json: opts.json,
+  };
+}
+
+export interface ReviewShowOptions {
+  paths: PaiPaths;
+  sourceName?: string;
+  id: string;
+  json?: boolean;
+}
+
+export interface ReviewShowResult {
+  success: boolean;
+  submission?: SubmissionDetail;
+  json?: boolean;
+  error?: string;
+}
+
+export async function reviewShow(opts: ReviewShowOptions): Promise<ReviewShowResult> {
+  const resolved = await resolveSource(opts.paths, opts.sourceName);
+  if ("error" in resolved) return { success: false, error: resolved.error };
+  const r = await getSubmission(resolved.source, opts.id);
+  if (!r.success) return { success: false, error: r.error };
+  return { success: true, submission: r.submission, json: opts.json };
+}
+
+export interface ReviewActionOptions {
+  paths: PaiPaths;
+  sourceName?: string;
+  id: string;
+  reason?: string;
+  comment?: string;
+}
+
+export interface ReviewActionCommandResult {
+  success: boolean;
+  action: "approve" | "reject" | "request-changes";
+  submission?: SubmissionDetail;
+  error?: string;
+}
+
+export async function reviewApprove(
+  opts: ReviewActionOptions,
+): Promise<ReviewActionCommandResult> {
+  const resolved = await resolveSource(opts.paths, opts.sourceName);
+  if ("error" in resolved) return { success: false, action: "approve", error: resolved.error };
+  const r = await approveSubmission(resolved.source, opts.id);
+  return { success: r.success, action: "approve", submission: r.submission, error: r.error };
+}
+
+export async function reviewReject(
+  opts: ReviewActionOptions,
+): Promise<ReviewActionCommandResult> {
+  if (!opts.reason || opts.reason.trim().length === 0) {
+    return { success: false, action: "reject", error: "--reason is required" };
+  }
+  const resolved = await resolveSource(opts.paths, opts.sourceName);
+  if ("error" in resolved) return { success: false, action: "reject", error: resolved.error };
+  const r = await rejectSubmission(resolved.source, opts.id, opts.reason.trim());
+  return { success: r.success, action: "reject", submission: r.submission, error: r.error };
+}
+
+export async function reviewRequestChanges(
+  opts: ReviewActionOptions,
+): Promise<ReviewActionCommandResult> {
+  if (!opts.comment || opts.comment.trim().length === 0) {
+    return { success: false, action: "request-changes", error: "--message is required" };
+  }
+  const resolved = await resolveSource(opts.paths, opts.sourceName);
+  if ("error" in resolved) return { success: false, action: "request-changes", error: resolved.error };
+  const r = await requestChanges(resolved.source, opts.id, opts.comment.trim());
+  return { success: r.success, action: "request-changes", submission: r.submission, error: r.error };
+}
+
+// ── Formatters ───────────────────────────────────────────────
+
+function fmtTime(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString();
+}
+
+export function formatReviewList(r: ReviewListResult): string {
+  if (!r.success) return `Error: ${r.error}`;
+  if (r.json) {
+    return JSON.stringify(
+      { submissions: r.submissions, total: r.total, page: r.page, per_page: r.per_page },
+      null,
+      2,
+    );
+  }
+  const subs = r.submissions ?? [];
+  if (subs.length === 0) return "No pending submissions assigned to you.";
+  const header = `${subs.length} of ${r.total} pending submission(s) (page ${r.page}):\n`;
+  const rows = subs.map((s) => {
+    const capFlag = s.capability_change ? " [caps changed]" : "";
+    return [
+      `  ${s.id}`,
+      `    status:       ${s.status}${capFlag}`,
+      `    version_id:   ${s.package_version_id}`,
+      `    submitted_by: ${s.submitted_by}`,
+      `    created:      ${fmtTime(s.created_at)}`,
+    ].join("\n");
+  });
+  return header + rows.join("\n\n");
+}
+
+export function formatReviewShow(r: ReviewShowResult): string {
+  if (!r.success) return `Error: ${r.error}`;
+  if (r.json) return JSON.stringify(r.submission, null, 2);
+  const s = r.submission;
+  if (!s) return "No submission found.";
+  const lines = [
+    `Submission ${s.id}`,
+    `  status:          ${s.status}`,
+    `  version_id:      ${s.package_version_id}`,
+    `  submitted_by:    ${s.submitted_by}`,
+    `  sponsor_id:      ${s.sponsor_id ?? "(none)"}`,
+    `  capability_change: ${s.capability_change ? "yes" : "no"}`,
+    `  created:         ${fmtTime(s.created_at)}`,
+    `  updated:         ${fmtTime(s.updated_at)}`,
+    `  reviewed:        ${s.reviewed_at ? fmtTime(s.reviewed_at) : "(not yet)"}`,
+  ];
+  if (s.review_comment) lines.push(`  review_comment:  ${s.review_comment}`);
+  if (s.validation_result) {
+    lines.push(`  validation_result:`);
+    lines.push(`    ${typeof s.validation_result === "string" ? s.validation_result : JSON.stringify(s.validation_result)}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatReviewAction(r: ReviewActionCommandResult): string {
+  if (!r.success) return `Error: ${r.error}`;
+  const verbMap = { approve: "approved", reject: "rejected", "request-changes": "changes requested" };
+  const verb = verbMap[r.action];
+  if (!r.submission) return `Submission ${verb}.`;
+  return `Submission ${r.submission.id} — ${verb}. Status: ${r.submission.status}.`;
+}

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -1,0 +1,172 @@
+import type { RegistrySource } from "../types.js";
+import { combineError } from "./publish.js";
+
+const API_TIMEOUT_MS = 30_000;
+
+function authHeaders(source: RegistrySource): Record<string, string> {
+  return { Authorization: `Bearer ${source.token}` };
+}
+
+export interface PendingSubmission {
+  id: string;
+  package_version_id: string;
+  submitted_by: string;
+  sponsor_id: string;
+  status: string;
+  capability_change: boolean;
+  hold_until: number | null;
+  review_comment: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface PendingListResult {
+  success: boolean;
+  submissions?: PendingSubmission[];
+  total?: number;
+  page?: number;
+  per_page?: number;
+  error?: string;
+}
+
+export async function listPending(
+  source: RegistrySource,
+  page = 1,
+  perPage = 20,
+): Promise<PendingListResult> {
+  try {
+    const resp = await fetch(
+      `${source.url}/api/v1/review/pending?page=${page}&per_page=${perPage}`,
+      { headers: authHeaders(source), signal: AbortSignal.timeout(API_TIMEOUT_MS) },
+    );
+    const body = (await resp.json().catch(() => ({}))) as {
+      submissions?: PendingSubmission[];
+      total?: number;
+      page?: number;
+      per_page?: number;
+      error?: unknown;
+      message?: unknown;
+    };
+    if (!resp.ok) {
+      return { success: false, error: combineError(body) ?? `HTTP ${resp.status}` };
+    }
+    return {
+      success: true,
+      submissions: body.submissions ?? [],
+      total: body.total ?? 0,
+      page: body.page ?? page,
+      per_page: body.per_page ?? perPage,
+    };
+  } catch (err) {
+    return { success: false, error: `Network error: ${(err as Error).message}` };
+  }
+}
+
+export interface SubmissionDetail {
+  id: string;
+  package_version_id: string;
+  submitted_by: string;
+  sponsor_id: string | null;
+  status: string;
+  validation_result: unknown;
+  audit_result: unknown;
+  capability_change: boolean;
+  hold_until: number | null;
+  review_comment: string | null;
+  reviewed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ShowResult {
+  success: boolean;
+  submission?: SubmissionDetail;
+  error?: string;
+}
+
+export async function getSubmission(
+  source: RegistrySource,
+  id: string,
+): Promise<ShowResult> {
+  try {
+    const resp = await fetch(`${source.url}/api/v1/review/${encodeURIComponent(id)}`, {
+      headers: authHeaders(source),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    const body = (await resp.json().catch(() => ({}))) as {
+      submission?: SubmissionDetail;
+      error?: unknown;
+      message?: unknown;
+    };
+    if (!resp.ok) {
+      return { success: false, error: combineError(body) ?? `HTTP ${resp.status}` };
+    }
+    return { success: true, submission: body.submission };
+  } catch (err) {
+    return { success: false, error: `Network error: ${(err as Error).message}` };
+  }
+}
+
+export interface ReviewActionResult {
+  success: boolean;
+  submission?: SubmissionDetail;
+  error?: string;
+  statusCode?: number;
+}
+
+async function postAction(
+  source: RegistrySource,
+  id: string,
+  action: "approve" | "reject" | "request-changes",
+  payload: Record<string, unknown>,
+): Promise<ReviewActionResult> {
+  try {
+    const resp = await fetch(
+      `${source.url}/api/v1/review/${encodeURIComponent(id)}/${action}`,
+      {
+        method: "POST",
+        headers: { ...authHeaders(source), "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      },
+    );
+    const body = (await resp.json().catch(() => ({}))) as {
+      submission?: SubmissionDetail;
+      error?: unknown;
+      message?: unknown;
+    };
+    if (!resp.ok) {
+      return {
+        success: false,
+        error: combineError(body) ?? `HTTP ${resp.status}`,
+        statusCode: resp.status,
+      };
+    }
+    return { success: true, submission: body.submission, statusCode: resp.status };
+  } catch (err) {
+    return { success: false, error: `Network error: ${(err as Error).message}` };
+  }
+}
+
+export function approveSubmission(
+  source: RegistrySource,
+  id: string,
+): Promise<ReviewActionResult> {
+  return postAction(source, id, "approve", {});
+}
+
+export function rejectSubmission(
+  source: RegistrySource,
+  id: string,
+  reason: string,
+): Promise<ReviewActionResult> {
+  return postAction(source, id, "reject", { reason });
+}
+
+export function requestChanges(
+  source: RegistrySource,
+  id: string,
+  comment: string,
+): Promise<ReviewActionResult> {
+  return postAction(source, id, "request-changes", { comment });
+}

--- a/test/commands/review.test.ts
+++ b/test/commands/review.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { mockFetch } from "../helpers/mock-fetch.js";
+import {
+  reviewList,
+  reviewShow,
+  reviewApprove,
+  reviewReject,
+  reviewRequestChanges,
+  formatReviewList,
+  formatReviewShow,
+  formatReviewAction,
+} from "../../src/commands/review.js";
+import { saveSources } from "../../src/lib/sources.js";
+import type { SourcesConfig } from "../../src/types.js";
+
+let env: TestEnv;
+let savedFetch: typeof fetch;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  savedFetch = globalThis.fetch;
+});
+
+afterEach(async () => {
+  globalThis.fetch = savedFetch;
+  await env.cleanup();
+});
+
+function mfSource(): SourcesConfig {
+  return {
+    sources: [{
+      name: "mf-test",
+      url: "https://meta-factory.test",
+      tier: "official",
+      enabled: true,
+      type: "metafactory",
+      token: "test-token",
+    }],
+  };
+}
+
+function mfSourceNoToken(): SourcesConfig {
+  return {
+    sources: [{
+      name: "mf-test",
+      url: "https://meta-factory.test",
+      tier: "official",
+      enabled: true,
+      type: "metafactory",
+    }],
+  };
+}
+
+const submissionFixture = {
+  id: "sub-1",
+  package_version_id: "pv-1",
+  submitted_by: "acc-submitter",
+  sponsor_id: "acc-sponsor",
+  status: "pending_review",
+  validation_result: null,
+  audit_result: null,
+  capability_change: false,
+  hold_until: null,
+  review_comment: null,
+  reviewed_at: null,
+  created_at: 1_700_000_000,
+  updated_at: 1_700_000_000,
+};
+
+// ── reviewList ────────────────────────────────────────────────
+
+describe("arc review list", () => {
+  test("fails without metafactory source", async () => {
+    await saveSources(env.paths.sourcesPath, { sources: [] });
+    const r = await reviewList({ paths: env.paths });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/metafactory/i);
+  });
+
+  test("fails without authentication", async () => {
+    await saveSources(env.paths.sourcesPath, mfSourceNoToken());
+    const r = await reviewList({ paths: env.paths });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/login/);
+  });
+
+  test("returns submissions from server", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    mockFetch(async (url: any) => {
+      expect(String(url)).toContain("/api/v1/review/pending");
+      return new Response(
+        JSON.stringify({ submissions: [submissionFixture], total: 1, page: 1, per_page: 20 }),
+        { status: 200 },
+      );
+    });
+    const r = await reviewList({ paths: env.paths });
+    expect(r.success).toBe(true);
+    expect(r.submissions?.length).toBe(1);
+    expect(r.total).toBe(1);
+  });
+
+  test("surfaces server error message on 403", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    mockFetch(async () =>
+      new Response(JSON.stringify({ error: "Forbidden", message: "Not authorised" }), { status: 403 }),
+    );
+    const r = await reviewList({ paths: env.paths });
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("Not authorised");
+  });
+
+  test("clamps --per-page client-side above 100", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    let capturedUrl = "";
+    mockFetch(async (url: any) => {
+      capturedUrl = String(url);
+      return new Response(
+        JSON.stringify({ submissions: [], total: 0, page: 1, per_page: 100 }),
+        { status: 200 },
+      );
+    });
+    const r = await reviewList({ paths: env.paths, perPage: 500 });
+    expect(r.success).toBe(true);
+    expect(capturedUrl).toContain("per_page=100");
+  });
+
+  test("--json formatter emits raw JSON", () => {
+    const out = formatReviewList({
+      success: true,
+      submissions: [submissionFixture],
+      total: 1,
+      page: 1,
+      per_page: 20,
+      json: true,
+    });
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+});
+
+// ── reviewShow ────────────────────────────────────────────────
+
+describe("arc review show", () => {
+  test("returns detail for a known id", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    mockFetch(async (url: any) => {
+      expect(String(url)).toContain("/api/v1/review/sub-1");
+      return new Response(JSON.stringify({ submission: submissionFixture }), { status: 200 });
+    });
+    const r = await reviewShow({ paths: env.paths, id: "sub-1" });
+    expect(r.success).toBe(true);
+    expect(r.submission?.id).toBe("sub-1");
+  });
+
+  test("404 surfaces server error", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    mockFetch(async () => new Response(JSON.stringify({ error: "Not found" }), { status: 404 }));
+    const r = await reviewShow({ paths: env.paths, id: "nope" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/Not found|HTTP 404/);
+  });
+
+  test("pretty-prints stringified validation_result", () => {
+    const vr = JSON.stringify({ risk_level: "low", summary: "ok" });
+    const out = formatReviewShow({
+      success: true,
+      submission: { ...submissionFixture, validation_result: vr },
+    });
+    expect(out).toContain("validation_result:");
+    // Pretty-printed — each key on its own line with indentation
+    expect(out).toContain(`"risk_level": "low"`);
+    expect(out).toContain(`"summary": "ok"`);
+  });
+});
+
+// ── action commands ──────────────────────────────────────────
+
+describe("arc review approve", () => {
+  test("posts to /approve and surfaces submission", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    let posted = false;
+    mockFetch(async (url: any, init: any) => {
+      posted = true;
+      expect(String(url)).toContain("/api/v1/review/sub-1/approve");
+      expect(init?.method).toBe("POST");
+      return new Response(
+        JSON.stringify({ submission: { ...submissionFixture, status: "approved" } }),
+        { status: 200 },
+      );
+    });
+    const r = await reviewApprove({ paths: env.paths, id: "sub-1" });
+    expect(posted).toBe(true);
+    expect(r.success).toBe(true);
+    expect(r.submission?.status).toBe("approved");
+  });
+
+  test("DD-9 self-review 403 surfaces server message", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({ error: "Forbidden", message: "Cannot review your own submission (DD-9)" }),
+        { status: 403 },
+      ),
+    );
+    const r = await reviewApprove({ paths: env.paths, id: "sub-1" });
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/DD-9/);
+  });
+
+  test("--json formatter emits action JSON on success", () => {
+    const out = formatReviewAction({
+      success: true,
+      action: "approve",
+      submission: { ...submissionFixture, status: "approved" },
+      json: true,
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.action).toBe("approve");
+    expect(parsed.submission.status).toBe("approved");
+  });
+});
+
+describe("arc review reject", () => {
+  test("rejects without --reason client-side", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    const r = await reviewReject({ paths: env.paths, id: "sub-1" });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("--reason");
+  });
+
+  test("rejects with whitespace-only reason", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    const r = await reviewReject({ paths: env.paths, id: "sub-1", reason: "   " });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("--reason");
+  });
+
+  test("sends trimmed reason in POST body", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    let body = "";
+    mockFetch(async (_url: any, init: any) => {
+      body = init?.body ?? "";
+      return new Response(
+        JSON.stringify({ submission: { ...submissionFixture, status: "rejected" } }),
+        { status: 200 },
+      );
+    });
+    const r = await reviewReject({ paths: env.paths, id: "sub-1", reason: "  breaks convention  " });
+    expect(r.success).toBe(true);
+    expect(JSON.parse(body)).toEqual({ reason: "breaks convention" });
+  });
+});
+
+describe("arc review request-changes", () => {
+  test("rejects without --message", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    const r = await reviewRequestChanges({ paths: env.paths, id: "sub-1" });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("--message");
+  });
+
+  test("sends comment in POST body", async () => {
+    await saveSources(env.paths.sourcesPath, mfSource());
+    let body = "";
+    mockFetch(async (url: any, init: any) => {
+      expect(String(url)).toContain("/request-changes");
+      body = init?.body ?? "";
+      return new Response(
+        JSON.stringify({ submission: { ...submissionFixture, status: "changes_requested" } }),
+        { status: 200 },
+      );
+    });
+    const r = await reviewRequestChanges({ paths: env.paths, id: "sub-1", comment: "tweak manifest" });
+    expect(r.success).toBe(true);
+    expect(JSON.parse(body)).toEqual({ comment: "tweak manifest" });
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`arc review\` subcommand family so sponsors and stewards can triage the submission queue from the terminal. Unblocks reviewers while the metafactory D-ADMIN reviewer UI ([the-metafactory/meta-factory#114](https://github.com/the-metafactory/meta-factory/issues/114)) is still spec-only — today approvers would have to log in via browser, copy the \`session\` cookie out of DevTools, and hand-craft curl calls.

## New commands

\`\`\`
arc review list                       List pending submissions assigned to you
arc review show <id>                  Show submission detail (validation_result, etc.)
arc review approve <id>               Approve a submission
arc review reject <id> -r <reason>    Reject a submission (reason shown to publisher)
arc review request-changes <id> -m    Request changes (comment shown to publisher)
\`\`\`

All commands accept \`-s, --source <name>\` to pick a registry. \`list\` and \`show\` accept \`--json\` for scripting.

## Auth & scope

Reuses the existing \`RegistrySource.token\` (populated by \`arc login\`) and sends \`Authorization: Bearer <token>\`. Same pattern as \`arc publish\`. No new config keys.

Server-side gating (unchanged on meta-factory):
- \`requireAuth + requireMinTier('trusted')\` on every endpoint
- \`list\` is scoped by \`sponsor_id = caller.id\` — you only see what's assigned to you
- DD-9 self-review block applies (can't approve your own submission)

## Test plan

- [ ] \`arc review --help\` renders the subtree
- [ ] \`arc review list -s dev\` against real dev returns pending submissions
- [ ] \`arc review approve <id> -s dev\` advances a \`pending_review\` submission to \`approved\`
- [ ] \`arc review reject <id> -r "..." -s dev\` returns 400 without \`-r\`
- [ ] \`arc review request-changes <id> -m "..." -s dev\` writes the comment into the submission
- [x] \`bunx tsc --noEmit\` clean

## Related

- meta-factory#114 — D-ADMIN reviewer UI (this PR is the stop-gap)
- meta-factory#300 — publisher-side feedback on rejections (separate track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)