### PR TITLE
fix(bundle): expand defaults, warn on include trap, monorepo docs (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,18 +415,62 @@ The publish namespace is resolved in priority order:
 
 By default, these patterns are excluded from the tarball:
 
-`.git`, `node_modules`, `.env`, `.env.*`, `*.db`, `*.sqlite`, `.DS_Store`, `Thumbs.db`, `.specify`, `test`, `tests`, `dist`, `*.log`, `.wrangler`, `.claude`
+- **VCS / OS:** `.git`, `.DS_Store`, `Thumbs.db`
+- **Secrets:** `.env`, `.env.*`
+- **Databases / logs:** `*.db`, `*.sqlite`, `*.log`
+- **JS / TS build + cache:** `node_modules`, `dist`, `build`, `out`, `coverage`, `.nyc_output`, `.next`, `.turbo`, `.parcel-cache`, `.pnpm-store`
+- **Bun:** `.*.bun-build` (compiled-binary cache)
+- **Rust:** `target`
+- **Python:** `.venv`, `__pycache__`, `*.pyc`
+- **Prior bundle artefacts:** `*.tar.gz`, `*.tgz`
+- **arc / Cloudflare / Claude local state:** `.specify`, `.wrangler`, `.claude`
+- **Tests:** `test`, `tests` (override via `bundle.include` if your package ships tests)
 
-Override in `arc-manifest.yaml`:
+Extend or override in `arc-manifest.yaml`:
 
 ```yaml
 bundle:
   exclude:
     - "*.tmp"
-    - "coverage"
+    - "fixtures/large"
   include:
-    - "test"           # Override default exclusion
+    - "test"           # Cancels the default "test" exclusion
 ```
+
+#### `bundle.include` is not an allowlist
+
+`bundle.include` only **cancels** a matching default exclusion — an entry must appear verbatim in the default list above to have any effect. It does not filter the tarball down to a subset of files. Use `bundle.exclude` for that, or bundle a subdirectory directly (`arc bundle packages/my-pkg`). arc will warn when an `include` entry does not match any default.
+
+### Bundling a Monorepo
+
+If your repo is a monorepo with multiple publishable packages, there are two supported patterns:
+
+**1. Bundle one package at a time**
+
+Each package directory has its own `arc-manifest.yaml`. Run `arc bundle` against the subdirectory:
+
+```bash
+arc bundle packages/my-skill
+arc publish packages/my-skill
+```
+
+**2. Library root**
+
+Declare the repo root as a `library` with an `artifacts:` list. Each artifact is a subdirectory that contains its own `arc-manifest.yaml`.
+
+```yaml
+# /arc-manifest.yaml  (repo root)
+name: my-library
+version: 1.0.0
+type: library
+artifacts:
+  - path: packages/skill-a
+    description: Skill A
+  - path: packages/tool-b
+    description: Tool B
+```
+
+With the library pattern, `arc install` installs every artifact, and `arc bundle packages/skill-a` bundles only that subtree — ignoring the rest of the monorepo (including `node_modules`, build caches, sibling packages, etc.).
 
 ### Dry Run
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -813,7 +813,7 @@ program
 
 program
   .command("bundle [path]")
-  .description("Create a distributable tarball from a package directory")
+  .description("Create a distributable tarball from a package directory. For monorepos, pass a subdirectory (e.g. `arc bundle packages/my-pkg`) or use the library pattern at the repo root.")
   .option("-o, --output <path>", "Output path for the tarball")
   .action(async (path: string | undefined, opts: { output?: string }) => {
     const paths = createPaths();

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -188,11 +188,13 @@ export async function createBundle(
   const exclusions = getExclusionPatterns(manifest);
   const includePatterns = manifest.bundle?.include ?? [];
 
-  const orphanIncludes = includePatterns.filter((p) => !DEFAULT_EXCLUSIONS.includes(p));
+  // Warn when include entries don't cancel any exclusion (default OR user-defined).
+  // include only cancels matching exclusions — it is not a tar-level allowlist.
+  const orphanIncludes = includePatterns.filter((p) => !exclusions.includes(p));
   if (orphanIncludes.length > 0) {
     warnings.push(
       `bundle.include has no effect for [${orphanIncludes.join(", ")}] — ` +
-      `bundle.include only cancels matching default exclusions, it is not an allowlist. ` +
+      `bundle.include only cancels matching exclusions, it is not an allowlist. ` +
       `To filter the bundle, use bundle.exclude or pass a package subdirectory (e.g. arc bundle packages/my-pkg).`,
     );
   }

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -10,21 +10,46 @@ export const README_VARIANTS = ["README.md", "readme.md", "Readme.md"];
 // ── Constants ────────────────────────────────────────────────
 
 export const DEFAULT_EXCLUSIONS = [
+  // VCS / editor / OS
   ".git",
-  "node_modules",
-  ".env",
-  ".env.*",
-  "*.db",
-  "*.sqlite",
   ".DS_Store",
   "Thumbs.db",
-  ".specify",
-  "test",
-  "tests",
-  "dist",
+  // Secrets
+  ".env",
+  ".env.*",
+  // Databases / logs
+  "*.db",
+  "*.sqlite",
   "*.log",
+  // Node / JS / TS build + caches
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  ".nyc_output",
+  ".next",
+  ".turbo",
+  ".parcel-cache",
+  ".pnpm-store",
+  // Bun compiled-binary cache
+  ".*.bun-build",
+  // Rust
+  "target",
+  // Python
+  ".venv",
+  "__pycache__",
+  "*.pyc",
+  // Prior bundle artefacts
+  "*.tar.gz",
+  "*.tgz",
+  // arc / Cloudflare / Claude local state
+  ".specify",
   ".wrangler",
   ".claude",
+  // Test directories (override via bundle.include if your package ships tests)
+  "test",
+  "tests",
 ];
 
 const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50MB
@@ -162,6 +187,16 @@ export async function createBundle(
   const tarballName = outputPath ?? join(packageDir, `${manifest.name}-${manifest.version}.tar.gz`);
   const exclusions = getExclusionPatterns(manifest);
   const includePatterns = manifest.bundle?.include ?? [];
+
+  const orphanIncludes = includePatterns.filter((p) => !DEFAULT_EXCLUSIONS.includes(p));
+  if (orphanIncludes.length > 0) {
+    warnings.push(
+      `bundle.include has no effect for [${orphanIncludes.join(", ")}] — ` +
+      `bundle.include only cancels matching default exclusions, it is not an allowlist. ` +
+      `To filter the bundle, use bundle.exclude or pass a package subdirectory (e.g. arc bundle packages/my-pkg).`,
+    );
+  }
+
   const excludeArgs = buildTarArgs(exclusions, includePatterns);
 
   const result = Bun.spawnSync(
@@ -177,7 +212,21 @@ export async function createBundle(
 
   if (sizeBytes > MAX_PACKAGE_SIZE) {
     await rm(tarballName).catch(() => {});
-    return { success: false, tarballPath: tarballName, sha256, sizeBytes, fileCount, manifest, warnings, error: `Package tarball exceeds 50MB limit (${(sizeBytes / 1024 / 1024).toFixed(1)}MB)` };
+    const sizeMb = (sizeBytes / 1024 / 1024).toFixed(1);
+    const hint =
+      "If this is a monorepo, pass a package subdirectory (e.g. `arc bundle packages/my-pkg`), " +
+      "or use the library pattern (type: library with artifacts: at the repo root). " +
+      "Also check for large caches that should be added to bundle.exclude (e.g. .*.bun-build, target, .venv).";
+    return {
+      success: false,
+      tarballPath: tarballName,
+      sha256,
+      sizeBytes,
+      fileCount,
+      manifest,
+      warnings,
+      error: `Package tarball exceeds 50MB limit (${sizeMb}MB). ${hint}`,
+    };
   }
 
   if (sizeBytes > WARN_PACKAGE_SIZE) {

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -396,6 +396,28 @@ describe("createBundle", () => {
     await rm(result.tarballPath).catch(() => {});
   });
 
+  test("include that cancels a user-defined bundle.exclude produces no warning", async () => {
+    // Regression test for PR #81 review nit — include can cancel any exclusion
+    // in the merged set, not only DEFAULT_EXCLUSIONS. A user-defined exclude
+    // cancelled by include is a legitimate pattern, not an orphan.
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+      bundle: {
+        exclude: ["fixtures/large"],
+        include: ["fixtures/large"],
+      },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+    expect(result.warnings.some((w) => w.includes("bundle.include has no effect"))).toBe(false);
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
   test("warns when no README.md", async () => {
     const pkgDir = await createMockPackage(testDir, {
       name: "test-skill",

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -118,6 +118,33 @@ describe("getExclusionPatterns", () => {
   });
 });
 
+describe("DEFAULT_EXCLUSIONS", () => {
+  // Regression guard for https://github.com/the-metafactory/arc/issues/78 —
+  // these patterns are the common build/cache directories that caused 278MB
+  // bundles in monorepos. Each is confirmed to never belong in a published
+  // arc package.
+  const REQUIRED_PATTERNS = [
+    ".git", "node_modules", ".env", ".env.*",
+    "*.db", "*.sqlite", "*.log",
+    ".DS_Store", "Thumbs.db",
+    "dist", "build", "out",
+    "coverage", ".nyc_output",
+    ".next", ".turbo", ".parcel-cache", ".pnpm-store",
+    ".*.bun-build",
+    "target",
+    ".venv", "__pycache__", "*.pyc",
+    "*.tar.gz", "*.tgz",
+    ".specify", ".wrangler", ".claude",
+    "test", "tests",
+  ];
+
+  for (const pattern of REQUIRED_PATTERNS) {
+    test(`includes ${pattern}`, () => {
+      expect(DEFAULT_EXCLUSIONS).toContain(pattern);
+    });
+  }
+});
+
 // ── validateForPublish ───────────────────────────────────────
 
 describe("validateForPublish", () => {
@@ -245,6 +272,47 @@ describe("createBundle", () => {
     await rm(result.tarballPath).catch(() => {});
   });
 
+  test("excludes new build/cache defaults (bun, rust, python, frameworks)", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    }, {
+      extraFiles: {
+        ".cli.bun-build": "binary blob",         // .*.bun-build
+        "target/release/app": "rust binary",     // target
+        ".venv/bin/python": "venv",              // .venv
+        "__pycache__/mod.cpython.pyc": "pyc",    // __pycache__
+        "build/index.js": "build output",        // build
+        "out/index.html": "out output",          // out
+        "coverage/lcov.info": "coverage",        // coverage
+        ".next/build-manifest.json": "{}",       // .next
+        ".turbo/cache.json": "{}",               // .turbo
+        "prev-bundle-1.0.0.tar.gz": "prior",     // *.tar.gz
+      },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+
+    const listResult = Bun.spawnSync(["tar", "tzf", result.tarballPath], { stdout: "pipe" });
+    const contents = listResult.stdout.toString();
+
+    expect(contents).not.toContain(".cli.bun-build");
+    expect(contents).not.toContain("target/");
+    expect(contents).not.toContain(".venv/");
+    expect(contents).not.toContain("__pycache__/");
+    expect(contents).not.toContain("build/");
+    expect(contents).not.toContain("out/");
+    expect(contents).not.toContain("coverage/");
+    expect(contents).not.toContain(".next/");
+    expect(contents).not.toContain(".turbo/");
+    expect(contents).not.toContain("prev-bundle-1.0.0.tar.gz");
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
   test("bundle.include overrides exclusions", async () => {
     const pkgDir = await createMockPackage(testDir, {
       name: "test-skill",
@@ -265,6 +333,65 @@ describe("createBundle", () => {
     const listResult = Bun.spawnSync(["tar", "tzf", result.tarballPath], { stdout: "pipe" });
     const contents = listResult.stdout.toString();
     expect(contents).toContain("test/");
+
+    // Matching include should NOT produce the orphan-include warning
+    expect(result.warnings.some((w) => w.includes("bundle.include has no effect"))).toBe(false);
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("warns when bundle.include entries match no default exclusion", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+      bundle: { include: ["packages/specflow/**", "src/only"] },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+
+    const warning = result.warnings.find((w) => w.includes("bundle.include has no effect"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("packages/specflow/**");
+    expect(warning).toContain("src/only");
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("no orphan-include warning when bundle.include is empty or absent", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+    expect(result.warnings.some((w) => w.includes("bundle.include has no effect"))).toBe(false);
+
+    await rm(result.tarballPath).catch(() => {});
+  });
+
+  test("warns with mix of matching and orphan includes", async () => {
+    const pkgDir = await createMockPackage(testDir, {
+      name: "test-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "A test",
+      bundle: { include: ["test", "packages/foo"] },
+    });
+
+    const result = await createBundle(pkgDir);
+    expect(result.success).toBe(true);
+
+    const warning = result.warnings.find((w) => w.includes("bundle.include has no effect"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("packages/foo");
+    expect(warning).not.toContain("[test,");
+    expect(warning).not.toContain("[test ");
 
     await rm(result.tarballPath).catch(() => {});
   });

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -42,6 +42,8 @@ describe("findCosignBinary", () => {
 });
 
 describe("ensureCosignBinary", () => {
+  // First-run may download the binary (~100MB) from GitHub Releases; allow up
+  // to 60s so the smoke test gate is not flaky on a fresh worktree / CI cache.
   test("returns path or error", async () => {
     // Suppress stderr from potential download messages
     const originalWrite = process.stderr.write;
@@ -52,10 +54,13 @@ describe("ensureCosignBinary", () => {
     } finally {
       process.stderr.write = originalWrite;
     }
-  });
+  }, 60_000);
 });
 
 describe("verifySigstoreBundle", () => {
+  // Cosign verify-blob attempts network lookups (Rekor, Fulcio) before
+  // reporting the missing blob, so the negative-path case can take >5s on a
+  // slow network. Extend the timeout so the smoke test gate is stable.
   test("returns invalid for nonexistent artifact and bundle", async () => {
     // Suppress stderr from potential download messages
     const originalWrite = process.stderr.write;
@@ -73,7 +78,7 @@ describe("verifySigstoreBundle", () => {
     } finally {
       process.stderr.write = originalWrite;
     }
-  });
+  }, 60_000);
 });
 
 describe("detectPlatform - unsupported", () => {


### PR DESCRIPTION
Closes #78

## Summary

Three related DX issues caused `arc bundle` to produce enormous tarballs on monorepo roots (278MB) and monorepo package subdirs (252MB), before any user misconfiguration. Fixes all three.

### 1. Expanded `DEFAULT_EXCLUSIONS`

Added common build/cache patterns that nobody would intentionally ship:

- **JS / TS:** `build`, `out`, `coverage`, `.nyc_output`, `.next`, `.turbo`, `.parcel-cache`, `.pnpm-store`
- **Bun:** `.*.bun-build` (compiled-binary cache — the 689MB culprit in the filed issue)
- **Rust:** `target`
- **Python:** `.venv`, `__pycache__`, `*.pyc`
- **Prior bundles:** `*.tar.gz`, `*.tgz`

### 2. Warning for `bundle.include` trap

`bundle.include` looks like an allowlist but only **cancels** a matching default exclusion. Leaving the behavior intact for backward compat (specflow users rely on it) — now `createBundle` warns when `include` entries match no default, explaining the real semantics and pointing at `bundle.exclude` or a subdirectory path for filtering.

### 3. Monorepo / library pattern docs

The library pattern (`type: library` + `artifacts:` + per-artifact manifests) was fully implemented but undocumented. This PR:

- Adds a **Bundling a Monorepo** section to README with both patterns (subdir bundling + library root)
- Updates `arc bundle --help` to mention monorepo path + library pattern
- Enriches the size-rejection error with a concrete hint toward the library pattern and `bundle.exclude`

### Side fix: cosign test timeouts

Separate commit extends the 5s Bun default timeout on two cosign tests that do network I/O (Rekor/Fulcio verification, GitHub Release download). They were flaky on slow networks and in fresh CI/worktree environments. Pure test-harness change.

## Test plan

- [x] `bun test` — 577 pass, 0 fail
- [x] `bunx tsc --noEmit` clean
- [x] `bun src/cli.ts bundle --help` shows updated description
- [x] New unit tests:
  - `DEFAULT_EXCLUSIONS includes {pattern}` for each new default (30 assertions)
  - `excludes new build/cache defaults` — end-to-end tar output verification
  - `warns when bundle.include entries match no default exclusion`
  - `no orphan-include warning when bundle.include is empty or absent`
  - `warns with mix of matching and orphan includes`
  - `bundle.include overrides exclusions` — asserts no warning on matching include (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)