### PR TITLE
fix(manifest): normalize network capability string shorthand (#79)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.21.0
+version: 0.21.1
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -46,6 +46,8 @@ export async function readManifest(
         );
       }
 
+      normalizeCapabilities(parsed, filename);
+
       return parsed;
     } catch (err: any) {
       if (err.code === "ENOENT") continue;
@@ -53,6 +55,65 @@ export async function readManifest(
     }
   }
   return null;
+}
+
+/**
+ * Normalize a single network-capability entry to object form.
+ * Accepts the legal `{domain, reason}` object shape and the string shorthand
+ * `"example.com"` (rewritten to `{domain: "example.com", reason: ""}`).
+ * Returns null for anything else so the caller can surface a clear error.
+ */
+export function normalizeNetworkEntry(
+  entry: unknown,
+): { domain: string; reason: string } | null {
+  if (typeof entry === "string") {
+    return { domain: entry, reason: "" };
+  }
+  if (entry && typeof entry === "object" && typeof (entry as any).domain === "string") {
+    const obj = entry as { domain: string; reason?: unknown };
+    return { domain: obj.domain, reason: typeof obj.reason === "string" ? obj.reason : "" };
+  }
+  return null;
+}
+
+/**
+ * Normalize `capabilities.network` in place. Rewrites string shorthand
+ * (`- example.com`) to `{domain, reason: ""}` and emits a one-shot stderr
+ * warning naming each shorthand entry so publishers can add a reason.
+ * No-op when capabilities or network are absent.
+ */
+export function normalizeCapabilities(manifest: ArcManifest, filename: string): void {
+  const caps = manifest.capabilities;
+  if (!caps || !Array.isArray(caps.network) || caps.network.length === 0) return;
+
+  const shorthand: string[] = [];
+  const invalid: unknown[] = [];
+  const normalized: Array<{ domain: string; reason: string }> = [];
+
+  for (const entry of caps.network as unknown[]) {
+    if (typeof entry === "string") shorthand.push(entry);
+    const result = normalizeNetworkEntry(entry);
+    if (result === null) {
+      invalid.push(entry);
+      continue;
+    }
+    normalized.push(result);
+  }
+
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid ${filename}: capabilities.network entries must be a string domain or {domain, reason} object; got ${JSON.stringify(invalid)}`,
+    );
+  }
+
+  caps.network = normalized;
+
+  if (shorthand.length > 0) {
+    process.stderr.write(
+      `warning: ${filename} capabilities.network uses string shorthand for [${shorthand.join(", ")}] — ` +
+      `add a reason for each domain in the form {domain: "${shorthand[0]}", reason: "why you need this"}.\n`,
+    );
+  }
 }
 
 /**

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -71,8 +71,15 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
     filesystem.push({ path: p, access: "write" });
   }
 
-  // Network: arc uses [{ domain, reason }], server uses [{ domain }]
-  const network = (caps.network ?? []).map((n) => ({ domain: n.domain }));
+  // Network: arc uses [{ domain, reason }] (string shorthand "example.com" is
+  // normalised at readManifest, but coerce defensively here in case a manifest
+  // was constructed in-memory without going through readManifest — issue #79).
+  // Server schema requires { domain }.
+  const network = (caps.network ?? []).flatMap((n): Array<{ domain: string }> => {
+    if (typeof n === "string") return [{ domain: n }];
+    if (n && typeof (n as any).domain === "string") return [{ domain: (n as any).domain }];
+    return [];
+  });
 
   // Bash → subprocess
   const subprocess: Array<{ command: string }> = [];

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -2,7 +2,15 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { readManifest, assessRisk, formatCapabilities, MANIFEST_FILENAME, LEGACY_MANIFEST_FILENAME } from "../../src/lib/manifest.js";
+import {
+  readManifest,
+  assessRisk,
+  formatCapabilities,
+  normalizeNetworkEntry,
+  normalizeCapabilities,
+  MANIFEST_FILENAME,
+  LEGACY_MANIFEST_FILENAME,
+} from "../../src/lib/manifest.js";
 import type { ArcManifest } from "../../src/types.js";
 
 let tempDir: string;
@@ -228,5 +236,185 @@ describe("formatCapabilities", () => {
     expect(lines.some((l) => l.includes("🔴") && l.includes("unrestricted"))).toBe(
       true
     );
+  });
+});
+
+// Regression tests for https://github.com/the-metafactory/arc/issues/79
+describe("normalizeNetworkEntry", () => {
+  test("string shorthand becomes object with empty reason", () => {
+    expect(normalizeNetworkEntry("github.com")).toEqual({
+      domain: "github.com",
+      reason: "",
+    });
+  });
+
+  test("object with domain + reason passes through", () => {
+    expect(normalizeNetworkEntry({ domain: "github.com", reason: "clone repos" })).toEqual({
+      domain: "github.com",
+      reason: "clone repos",
+    });
+  });
+
+  test("object missing reason gets empty reason", () => {
+    expect(normalizeNetworkEntry({ domain: "github.com" })).toEqual({
+      domain: "github.com",
+      reason: "",
+    });
+  });
+
+  test("object with non-string reason gets empty reason", () => {
+    expect(normalizeNetworkEntry({ domain: "github.com", reason: 42 })).toEqual({
+      domain: "github.com",
+      reason: "",
+    });
+  });
+
+  test("object missing domain rejected", () => {
+    expect(normalizeNetworkEntry({ reason: "no domain" })).toBeNull();
+  });
+
+  test("number rejected", () => {
+    expect(normalizeNetworkEntry(42)).toBeNull();
+  });
+
+  test("null rejected", () => {
+    expect(normalizeNetworkEntry(null)).toBeNull();
+  });
+});
+
+describe("normalizeCapabilities", () => {
+  test("mutates string shorthand into object form", () => {
+    const m: ArcManifest = {
+      name: "t",
+      version: "1.0.0",
+      type: "skill",
+      capabilities: { network: ["github.com", "agentskills.io"] as any },
+    };
+    normalizeCapabilities(m, "arc-manifest.yaml");
+    expect(m.capabilities!.network).toEqual([
+      { domain: "github.com", reason: "" },
+      { domain: "agentskills.io", reason: "" },
+    ]);
+  });
+
+  test("mixed string + object entries both land as objects", () => {
+    const m: ArcManifest = {
+      name: "t",
+      version: "1.0.0",
+      type: "skill",
+      capabilities: {
+        network: [
+          "github.com",
+          { domain: "api.example.com", reason: "telemetry" },
+        ] as any,
+      },
+    };
+    normalizeCapabilities(m, "arc-manifest.yaml");
+    expect(m.capabilities!.network).toEqual([
+      { domain: "github.com", reason: "" },
+      { domain: "api.example.com", reason: "telemetry" },
+    ]);
+  });
+
+  test("no-op when capabilities absent", () => {
+    const m: ArcManifest = { name: "t", version: "1.0.0", type: "skill" };
+    expect(() => normalizeCapabilities(m, "arc-manifest.yaml")).not.toThrow();
+  });
+
+  test("no-op when network absent or empty", () => {
+    const m: ArcManifest = {
+      name: "t",
+      version: "1.0.0",
+      type: "skill",
+      capabilities: { bash: { allowed: false } },
+    };
+    normalizeCapabilities(m, "arc-manifest.yaml");
+    expect(m.capabilities!.network).toBeUndefined();
+  });
+
+  test("throws on invalid entry type", () => {
+    const m: ArcManifest = {
+      name: "t",
+      version: "1.0.0",
+      type: "skill",
+      capabilities: { network: [42] as any },
+    };
+    expect(() => normalizeCapabilities(m, "arc-manifest.yaml")).toThrow(
+      /capabilities\.network entries must be/,
+    );
+  });
+
+  test("warns on stderr when string shorthand present", () => {
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: any) => {
+      captured.push(String(chunk));
+      return true;
+    }) as any;
+    try {
+      const m: ArcManifest = {
+        name: "t",
+        version: "1.0.0",
+        type: "skill",
+        capabilities: { network: ["github.com"] as any },
+      };
+      normalizeCapabilities(m, "arc-manifest.yaml");
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(captured.join("")).toContain("string shorthand");
+    expect(captured.join("")).toContain("github.com");
+  });
+
+  test("no warning when all entries are object form", () => {
+    const captured: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: any) => {
+      captured.push(String(chunk));
+      return true;
+    }) as any;
+    try {
+      const m: ArcManifest = {
+        name: "t",
+        version: "1.0.0",
+        type: "skill",
+        capabilities: {
+          network: [{ domain: "github.com", reason: "clone" }],
+        },
+      };
+      normalizeCapabilities(m, "arc-manifest.yaml");
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(captured.join("")).toBe("");
+  });
+});
+
+describe("readManifest — network shorthand (#79)", () => {
+  test("string-form network entries parse into object form", async () => {
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true) as any;
+    try {
+      await Bun.write(
+        join(tempDir, MANIFEST_FILENAME),
+        `schema: arc/v1
+name: shorthand-test
+version: 0.1.0
+type: skill
+capabilities:
+  network:
+    - github.com
+    - agentskills.io
+`,
+      );
+      const manifest = await readManifest(tempDir);
+      expect(manifest).not.toBeNull();
+      expect(manifest!.capabilities!.network).toEqual([
+        { domain: "github.com", reason: "" },
+        { domain: "agentskills.io", reason: "" },
+      ]);
+    } finally {
+      process.stderr.write = orig;
+    }
   });
 });

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -9,6 +9,7 @@ import {
   ensurePackageExists,
   registerVersion,
   combineError,
+  toServerManifest,
 } from "../../src/lib/publish.js";
 import { mockFetch } from "../helpers/mock-fetch.js";
 import type { ArcManifest, RegistrySource } from "../../src/types.js";
@@ -301,5 +302,64 @@ describe("combineError", () => {
   test("returns undefined for null/undefined", () => {
     expect(combineError(null)).toBeUndefined();
     expect(combineError(undefined)).toBeUndefined();
+  });
+});
+
+// Regression tests for https://github.com/the-metafactory/arc/issues/79
+describe("toServerManifest — network capability coercion", () => {
+  test("object form produces {domain}", () => {
+    const m = makeManifest({
+      capabilities: {
+        network: [
+          { domain: "github.com", reason: "clone repos" },
+          { domain: "api.example.com", reason: "telemetry" },
+        ],
+      },
+    });
+    const server = toServerManifest(m, "test");
+    expect(server.capabilities).toEqual({
+      network: [{ domain: "github.com" }, { domain: "api.example.com" }],
+    });
+  });
+
+  test("string shorthand produces {domain} (defensive path)", () => {
+    // Simulates a manifest that bypassed readManifest normalisation.
+    const m = makeManifest({
+      capabilities: {
+        network: ["github.com", "agentskills.io"] as unknown as Array<{ domain: string; reason: string }>,
+      },
+    });
+    const server = toServerManifest(m, "test");
+    expect(server.capabilities).toEqual({
+      network: [{ domain: "github.com" }, { domain: "agentskills.io" }],
+    });
+  });
+
+  test("never produces {domain: undefined} under any input shape", () => {
+    const m = makeManifest({
+      capabilities: {
+        network: [
+          "github.com",
+          { domain: "good.com", reason: "ok" },
+          { reason: "no domain" },
+          null,
+          undefined,
+          42,
+        ] as unknown as Array<{ domain: string; reason: string }>,
+      },
+    });
+    const server = toServerManifest(m, "test");
+    const netCaps = (server.capabilities as any).network as Array<{ domain: unknown }>;
+    for (const entry of netCaps) {
+      expect(typeof entry.domain).toBe("string");
+      expect(entry.domain).not.toBe("");
+    }
+    expect(netCaps).toEqual([{ domain: "github.com" }, { domain: "good.com" }]);
+  });
+
+  test("empty network array produces no network entry in server caps", () => {
+    const m = makeManifest({ capabilities: { network: [] } });
+    const server = toServerManifest(m, "test");
+    expect((server.capabilities as any).network).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #79

## Summary

`capabilities.network` YAML accepts string shorthand (`- github.com`) silently, even though `ArcManifest` types entries as `{domain, reason}`. All consumer sites deref `n.domain` → `undefined`. In `toServerManifest`, that sends `{domain: undefined}` to the registry, which D1 stores as `{}` and metafactory's validation pipeline rejects with `TypeError: canonicalJson: undefined is not allowed` — the submission hangs in `validating` forever while arc happily reports success.

## Fix

Normalize at the manifest boundary:

- **`readManifest`** runs `normalizeCapabilities`, which rewrites every string entry to `{domain, reason: ""}`, rejects malformed entries (non-string domain, null, number) with a useful error, and writes a stderr warning naming each shorthand entry so publishers can add a reason in the manifest.
- **`toServerManifest`** coerces defensively as well, so in-memory manifests that bypass `readManifest` (tests, programmatic callers) can never emit `{domain: undefined}`.

Downstream code (`formatCapabilities`, `db.ts`, `upgrade.ts`, `assessRisk`) keeps its typed assumption — no changes needed.

No behaviour change for manifests that already use object form.

## Test plan

- [x] `bun test` — 597 pass, 0 fail
- [x] `bunx tsc --noEmit` clean
- [x] `normalizeNetworkEntry` — 7 cases (string, object with/without reason, missing domain, number, null)
- [x] `normalizeCapabilities` — string rewrite, mixed shapes, no-op (no caps, no network, empty), invalid-entry throw, stderr warning emitted with correct content, no warning on pure object form
- [x] `readManifest` — string-form YAML parses to object form end-to-end
- [x] `toServerManifest` — object/string/mixed/undefined/null/number inputs all produce valid `{domain: string}` server entries; never emits `undefined`
- [x] Existing `manifest.test.ts` (object-form network) still passes
- [x] Existing `publish.test.ts` flow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)