### PR TITLE
fix(install): honor provides.files across all types, gate hooks

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -277,7 +277,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   );
   if (resolvedHooks?.length) {
     // Refuse to register hooks whose command points at a file that does not
-    // exist \u2014 silent registration of broken hooks was the original symptom of
+    // exist — silent registration of broken hooks was the original symptom of
     // issue #84.
     const missingHookFiles = findMissingHookFiles(resolvedHooks);
     if (missingHookFiles.length) {
@@ -543,7 +543,7 @@ export async function installSingleArtifact(
   );
   if (resolvedHooks?.length) {
     // Refuse to register hooks whose command points at a file that does not
-    // exist \u2014 silent registration of broken hooks was the original symptom of
+    // exist — silent registration of broken hooks was the original symptom of
     // issue #84.
     const missingHookFiles = findMissingHookFiles(resolvedHooks);
     if (missingHookFiles.length) {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -5,7 +5,7 @@ import type { Database } from "bun:sqlite";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
 import { runScript } from "../lib/scripts.js";
-import { registerHooks, resolveHooksFromManifest } from "../lib/hooks.js";
+import { registerHooks, resolveHooksFromManifest, findMissingHookFiles } from "../lib/hooks.js";
 import { createArtifactSymlinks, resolveArtifactSourceDir, installNodeDependencies } from "../lib/artifact-installer.js";
 import { wireExtensions } from "../lib/extensions.js";
 import { extractRepoName } from "../lib/repo-name.js";
@@ -250,7 +250,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   }
 
   // 4. Create symlinks based on artifact type
-  await createArtifactSymlinks({
+  const symlinkResult = await createArtifactSymlinks({
     type: manifest.type,
     manifest,
     paths,
@@ -258,6 +258,16 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     consumerDir: opts.consumerDir,
     quiet: opts.yes,
   });
+  if (symlinkResult.filesMissingSource.length) {
+    const detail = symlinkResult.filesMissingSource
+      .map((f) => `  - ${f.source} -> ${f.target}`)
+      .join("\n");
+    return {
+      success: false,
+      error:
+        `Manifest declares provides.files entries whose source does not exist in the package:\n${detail}`,
+    };
+  }
 
   // 5b. Register hooks (if declared, with consent gating)
   const resolvedHooks = resolveHooksFromManifest(
@@ -266,6 +276,21 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     manifest.name,
   );
   if (resolvedHooks?.length) {
+    // Refuse to register hooks whose command points at a file that does not
+    // exist \u2014 silent registration of broken hooks was the original symptom of
+    // issue #84.
+    const missingHookFiles = findMissingHookFiles(resolvedHooks);
+    if (missingHookFiles.length) {
+      const detail = missingHookFiles
+        .map((m) => `  - ${m.event}: ${m.command}\n      missing: ${m.missingPath}`)
+        .join("\n");
+      return {
+        success: false,
+        error:
+          `Manifest declares hooks whose command references a file that was not installed:\n${detail}\n` +
+          `Add the file to provides.files (or fix the command path) and reinstall.`,
+      };
+    }
     const tier = opts.sourceTier ?? manifest.tier ?? "custom";
     const approved = await promptHookConsent(
       manifest.name,
@@ -491,7 +516,7 @@ export async function installSingleArtifact(
   // Create symlinks based on artifact type
   const artifactType = manifest.type as ArtifactType;
 
-  await createArtifactSymlinks({
+  const symlinkResult = await createArtifactSymlinks({
     type: artifactType,
     manifest,
     paths,
@@ -499,6 +524,16 @@ export async function installSingleArtifact(
     consumerDir: opts.consumerDir,
     quiet: opts.yes,
   });
+  if (symlinkResult.filesMissingSource.length) {
+    const detail = symlinkResult.filesMissingSource
+      .map((f) => `  - ${f.source} -> ${f.target}`)
+      .join("\n");
+    return {
+      success: false,
+      error:
+        `Manifest declares provides.files entries whose source does not exist in the package:\n${detail}`,
+    };
+  }
 
   // Register hooks (with consent gating — same as standalone install)
   const resolvedHooks = resolveHooksFromManifest(
@@ -507,6 +542,21 @@ export async function installSingleArtifact(
     manifest.name,
   );
   if (resolvedHooks?.length) {
+    // Refuse to register hooks whose command points at a file that does not
+    // exist \u2014 silent registration of broken hooks was the original symptom of
+    // issue #84.
+    const missingHookFiles = findMissingHookFiles(resolvedHooks);
+    if (missingHookFiles.length) {
+      const detail = missingHookFiles
+        .map((m) => `  - ${m.event}: ${m.command}\n      missing: ${m.missingPath}`)
+        .join("\n");
+      return {
+        success: false,
+        error:
+          `Manifest declares hooks whose command references a file that was not installed:\n${detail}\n` +
+          `Add the file to provides.files (or fix the command path) and reinstall.`,
+      };
+    }
     const tier = opts.sourceTier ?? manifest.tier ?? "custom";
     const approved = await promptHookConsent(
       manifest.name,

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -55,7 +55,10 @@ export async function createArtifactSymlinks(opts: {
   installDir: string;
   consumerDir?: string;
   quiet?: boolean;
-}): Promise<void> {
+}): Promise<{
+  filesCreated: Array<{ source: string; target: string }>;
+  filesMissingSource: Array<{ source: string; target: string }>;
+}> {
   const { type, manifest, paths, installDir, quiet } = opts;
 
   switch (type) {
@@ -105,14 +108,8 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "component": {
-      // Components: symlink each provides.files entry from repo source to expanded target
-      const files = manifest.provides?.files ?? [];
-      for (const file of files) {
-        const sourcePath = join(installDir, file.source);
-        const targetPath = file.target.replace(/^~/, homedir());
-        await mkdir(dirname(targetPath), { recursive: true });
-        await createSymlink(sourcePath, targetPath);
-      }
+      // Components have no per-type primary layout — provides.files is honored
+      // by the type-agnostic pass below.
       break;
     }
 
@@ -192,6 +189,28 @@ export async function createArtifactSymlinks(opts: {
       break;
     }
   }
+
+  // Type-agnostic provides.files pass.
+  // Every artifact type honors provides.files entries — used to ship auxiliary
+  // files (hook handlers, helpers, shared libs) alongside the primary layout.
+  // Previously only `component` honored this, which silently broke any
+  // multi-artifact package using a different primary type. See issue #84.
+  const declaredFiles = manifest.provides?.files ?? [];
+  const filesCreated: Array<{ source: string; target: string }> = [];
+  const filesMissingSource: Array<{ source: string; target: string }> = [];
+  for (const file of declaredFiles) {
+    const sourcePath = join(installDir, file.source);
+    const targetPath = file.target.replace(/^~/, homedir());
+    if (!existsSync(sourcePath)) {
+      filesMissingSource.push({ source: sourcePath, target: targetPath });
+      continue;
+    }
+    await mkdir(dirname(targetPath), { recursive: true });
+    await createSymlink(sourcePath, targetPath);
+    filesCreated.push({ source: sourcePath, target: targetPath });
+  }
+
+  return { filesCreated, filesMissingSource };
 }
 
 /**

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -128,6 +128,39 @@ function resolveCommandPaths(
 }
 
 /**
+ * Inspect resolved hook commands and return any that reference an absolute
+ * file path that does not exist on disk. A hook that points at a missing
+ * file silently breaks every session (see issue #84), so install must refuse
+ * to register such hooks.
+ *
+ * Heuristic: split each command on whitespace, look at tokens starting with
+ * "/" (absolute paths) or "~" (home-relative). Tokens may be quoted; strip
+ * outer single/double quotes before checking. Non-path tokens are ignored.
+ */
+export function findMissingHookFiles(
+  hooks: InlineHook[],
+): Array<{ event: string; command: string; missingPath: string }> {
+  const issues: Array<{ event: string; command: string; missingPath: string }> = [];
+  for (const hook of hooks) {
+    for (const token of hook.command.split(/\s+/)) {
+      const stripped = token.replace(/^['"]|['"]$/g, "");
+      if (!stripped) continue;
+      let path: string | null = null;
+      if (stripped.startsWith("/")) {
+        path = stripped;
+      } else if (stripped.startsWith("~/")) {
+        path = stripped.replace(/^~/, process.env.HOME ?? "");
+      }
+      if (!path) continue;
+      if (!existsSync(path)) {
+        issues.push({ event: hook.event, command: hook.command, missingPath: path });
+      }
+    }
+  }
+  return issues;
+}
+
+/**
  * Check whether a manifest has any hooks declared (either format).
  */
 export function hasHooks(hooks: HooksDeclaration | undefined): boolean {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -133,17 +133,30 @@ function resolveCommandPaths(
  * file silently breaks every session (see issue #84), so install must refuse
  * to register such hooks.
  *
- * Heuristic: split each command on whitespace, look at tokens starting with
- * "/" (absolute paths) or "~" (home-relative). Tokens may be quoted; strip
- * outer single/double quotes before checking. Non-path tokens are ignored.
+ * Heuristic: tokenize on whitespace, look at tokens starting with "/" or "~/".
+ * Skip tokens that follow a shell redirect/pipe operator on the previous
+ * token, since those are output sinks rather than required inputs.
+ *
+ * TODO: $HOME / ${HOME} (and other env-var references) are not substituted
+ * upstream by resolveHooksFromManifest, so a hook using "$HOME/script.sh"
+ * is left as the literal string and will not be inspected here. If/when the
+ * resolver grows env-var substitution, drop the redundant ~/ branch below.
  */
 export function findMissingHookFiles(
   hooks: InlineHook[],
 ): Array<{ event: string; command: string; missingPath: string }> {
   const issues: Array<{ event: string; command: string; missingPath: string }> = [];
+  // Tokens that direct shell I/O — the next path-like token is an output
+  // destination, not a required file. ">>" / "<<" are caught by .startsWith.
+  const REDIRECT_OPS = new Set([">", ">>", "<", "<<", "|", "&>", "2>", "2>>", "1>"]);
   for (const hook of hooks) {
-    for (const token of hook.command.split(/\s+/)) {
-      const stripped = token.replace(/^['"]|['"]$/g, "");
+    const tokens = hook.command.split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      const prev = i > 0 ? tokens[i - 1] : "";
+      if (REDIRECT_OPS.has(prev) || prev.startsWith(">") || prev.startsWith("2>")) {
+        continue;
+      }
+      const stripped = tokens[i].replace(/^['"]|['"]$/g, "");
       if (!stripped) continue;
       let path: string | null = null;
       if (stripped.startsWith("/")) {

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -343,6 +343,166 @@ describe("install command", () => {
   });
 });
 
+describe("install provides.files (issue #84)", () => {
+  /**
+   * Build a skill repo whose arc-manifest.yaml declares provides.files and/or
+   * provides.hooks. Used to exercise the type-agnostic provides.files pass and
+   * the hook-target validation gate.
+   */
+  async function buildRepoWithProvides(opts: {
+    name: string;
+    extraFiles?: Record<string, string>;
+    providesFiles?: Array<{ source: string; target: string }>;
+    providesHooks?: Array<{ event: string; command: string }>;
+  }): Promise<string> {
+    const repoDir = join(env.root, `mock-${opts.name}`);
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(join(repoDir, "skill"), { recursive: true });
+    await writeFile(
+      join(repoDir, "skill", "SKILL.md"),
+      `---\nname: ${opts.name}\ndescription: Test\n---\n# ${opts.name}\n`,
+    );
+    for (const [path, content] of Object.entries(opts.extraFiles ?? {})) {
+      const abs = join(repoDir, path);
+      await mkdir(join(abs, ".."), { recursive: true });
+      await writeFile(abs, content);
+    }
+    const lines: string[] = [
+      `name: ${opts.name}`,
+      `version: 1.0.0`,
+      `type: skill`,
+      `tier: custom`,
+      `author:`,
+      `  name: testuser`,
+      `  github: testuser`,
+      `provides:`,
+      `  skill:`,
+      `    - trigger: ${opts.name.toLowerCase()}`,
+    ];
+    if (opts.providesFiles?.length) {
+      lines.push(`  files:`);
+      for (const f of opts.providesFiles) {
+        lines.push(`    - source: ${JSON.stringify(f.source)}`);
+        lines.push(`      target: ${JSON.stringify(f.target)}`);
+      }
+    }
+    if (opts.providesHooks?.length) {
+      lines.push(`  hooks:`);
+      for (const h of opts.providesHooks) {
+        lines.push(`    - event: ${h.event}`);
+        lines.push(`      command: ${JSON.stringify(h.command)}`);
+      }
+    }
+    lines.push(`capabilities:`);
+    lines.push(`  filesystem: { read: [], write: [] }`);
+    lines.push(`  network: []`);
+    lines.push(`  bash: { allowed: false }`);
+    lines.push(`  secrets: []`);
+    await writeFile(join(repoDir, "arc-manifest.yaml"), lines.join("\n") + "\n");
+    Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=t@t.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+    return repoDir;
+  }
+
+  test("honors provides.files entries on a skill-type package", async () => {
+    const targetPath = join(env.root, "out", "handler.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "FileSkill",
+      extraFiles: { "src/handler.ts": "// handler\n" },
+      providesFiles: [{ source: "src/handler.ts", target: targetPath }],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(targetPath)).toBe(true);
+    expect(lstatSync(targetPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(targetPath)).toContain("src/handler.ts");
+  });
+
+  test("fails install when provides.files source is missing from package", async () => {
+    const targetPath = join(env.root, "out", "missing.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "MissingSourceSkill",
+      providesFiles: [{ source: "src/missing.ts", target: targetPath }],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("provides.files");
+    expect(result.error).toContain("src/missing.ts");
+    expect(existsSync(targetPath)).toBe(false);
+  });
+
+  test("fails install when provides.hooks command points at non-existent file", async () => {
+    const missingHandler = join(env.root, "ghost", "handler.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "GhostHookSkill",
+      providesHooks: [
+        { event: "Stop", command: missingHandler },
+      ],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hooks");
+    expect(result.error).toContain(missingHandler);
+    // settings.json must not have been written with the broken hook
+    if (existsSync(env.paths.settingsPath)) {
+      const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+      const stopHooks = settings.hooks?.Stop ?? [];
+      const ghostFound = stopHooks.some((g: { _pai_pkg?: string }) => g._pai_pkg === "GhostHookSkill");
+      expect(ghostFound).toBe(false);
+    }
+  });
+
+  test("provides.hooks with $PKG_DIR resolves to installed file and registers", async () => {
+    const repoUrl = await buildRepoWithProvides({
+      name: "GoodHookSkill",
+      extraFiles: { "hooks/Stop.ts": "// stop\n" },
+      providesHooks: [
+        { event: "Stop", command: "${PKG_DIR}/hooks/Stop.ts" },
+      ],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    const stopHooks = settings.hooks?.Stop ?? [];
+    const ours = stopHooks.find((g: { _pai_pkg?: string }) => g._pai_pkg === "GoodHookSkill");
+    expect(ours).toBeDefined();
+    expect(ours.hooks[0].command).toContain("hooks/Stop.ts");
+    expect(ours.hooks[0].command).not.toContain("${PKG_DIR}");
+  });
+});
+
 describe("parseNameVersion", () => {
   test("parses name@version", () => {
     expect(parseNameVersion("MySkill@1.2.0")).toEqual({ name: "MySkill", version: "1.2.0" });

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -2,12 +2,14 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
+import { writeFile } from "fs/promises";
 import {
   registerHooks,
   removeHooks,
   listPackageHooks,
   resolveHooksFromManifest,
   hasHooks,
+  findMissingHookFiles,
 } from "../../src/lib/hooks.js";
 
 let tmpDir: string;
@@ -439,5 +441,55 @@ describe("hasHooks", () => {
 
   test("returns false for empty config-file reference", () => {
     expect(hasHooks({ claude_code: { config: "" } } as any)).toBe(false);
+  });
+});
+
+describe("findMissingHookFiles", () => {
+  test("flags command whose absolute path does not exist", () => {
+    const issues = findMissingHookFiles([
+      { event: "Stop", command: "/nonexistent/path/to/handler.ts" },
+    ]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].event).toBe("Stop");
+    expect(issues[0].missingPath).toBe("/nonexistent/path/to/handler.ts");
+  });
+
+  test("returns empty when command path exists", async () => {
+    const path = join(tmpDir, "handler.ts");
+    await writeFile(path, "// ok\n");
+    const issues = findMissingHookFiles([
+      { event: "Stop", command: path },
+    ]);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("ignores non-path tokens like flags and bare commands", () => {
+    const issues = findMissingHookFiles([
+      { event: "Stop", command: "echo done" },
+      { event: "Stop", command: "bun run --silent" },
+    ]);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("does not false-positive on shell redirect targets", async () => {
+    // The redirect target /tmp/output.log may or may not exist; either way it
+    // is an output sink, not a required input file. Validation must skip it.
+    const handler = join(tmpDir, "ok.ts");
+    await writeFile(handler, "// ok\n");
+    const missingSink = "/tmp/arc-test-redirect-" + Date.now() + ".log";
+    const issues = findMissingHookFiles([
+      { event: "Stop", command: `${handler} > ${missingSink}` },
+      { event: "Stop", command: `${handler} 2> ${missingSink}` },
+      { event: "Stop", command: `${handler} >> ${missingSink}` },
+    ]);
+    expect(issues).toHaveLength(0);
+  });
+
+  test("strips surrounding quotes before resolving", () => {
+    const issues = findMissingHookFiles([
+      { event: "Stop", command: `'/nonexistent/quoted.ts'` },
+      { event: "Stop", command: `"/nonexistent/dquoted.ts"` },
+    ]);
+    expect(issues).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes #84. Refs #85, #86.

`arc install` previously honored `provides.files` only for `type: component` and silently dropped it for every other artifact type. Hook registration ran unconditionally, so packages declaring a `skill` (or `tool` / `agent` / …) plus `provides.files` plus `provides.hooks` looked like they installed cleanly but failed at runtime — `settings.json` pointed at files that were never placed. Caduceus is the canonical example.

## Changes

- **`src/lib/artifact-installer.ts`** — lift the `provides.files` symlink loop out of `case "component"` into a type-agnostic post-pass that runs after the per-type switch for every artifact type. Return `{ filesCreated, filesMissingSource }` so the caller can fail loudly when a declared source does not exist in the package.
- **`src/lib/hooks.ts`** — new `findMissingHookFiles()` helper that scans resolved hook commands (after `${PKG_DIR}` substitution) for absolute path tokens that don't exist on disk.
- **`src/commands/install.ts`** — wire both gates into the standalone install path and the library-artifact install path. Either gate failing returns `{ success: false, error: … }` with a precise diagnostic, never silently registering broken hooks.

## Tests

`test/commands/install.test.ts` (4 new):

- Skill-type package with `provides.files` → symlink created at target.
- Skill-type package with `provides.files` source missing → install fails with a clear error.
- Skill-type package with `provides.hooks` command pointing at a non-existent file → install fails, `settings.json` not mutated.
- Skill-type package with `provides.hooks` using `${PKG_DIR}` that resolves to an installed file → install succeeds and the hook is registered with the substituted path.

Full suite: 601/601 pass.

## Test plan

- [x] `bun test test/commands/install.test.ts` (25 pass)
- [x] `bun test` (601 pass)
- [x] `bunx tsc --noEmit` clean
- [ ] Manual smoke: `arc install <caduceus-shaped-manifest>` either succeeds with all targets in place or fails with the new diagnostic — tested via the new install tests against an isolated `createTestEnv()` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)