### PR TITLE
fix(install): send Bearer token to auth-gated storage endpoints

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,9 +158,11 @@ program
 
       console.log(`Found ${formatPackageRef(pkgRef)} v${resolved.version} in ${resolved.source.name} [${resolved.source.tier}]`);
 
-      // Download (anonymous — no auth required per DD-80)
+      // Download. Anonymous by default (DD-80); the resolved source is passed
+      // through so an auth-gated metafactory storage endpoint receives the
+      // bearer token from `arc login` (issue #83).
       console.log(`Downloading...`);
-      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir);
+      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir, resolved.source);
       if (!download.success || !download.tempPath) {
         console.error(`${download.error}`);
         process.exit(1);

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -140,17 +140,32 @@ export interface DownloadResult {
   error?: string;
 }
 
-/** Download a package tarball from the storage endpoint (anonymous) */
+/**
+ * Download a package tarball from the storage endpoint.
+ *
+ * When `source` is provided and is a metafactory source with a stored bearer
+ * token, attaches `Authorization: Bearer <token>` so the request can pass
+ * through an auth-gated storage endpoint (issue #83). For sources without a
+ * token, or registry-type sources, the request stays anonymous (DD-80) so
+ * public unauthenticated installs continue to work.
+ */
 export async function downloadPackage(
   url: string,
   tempDir: string,
+  source?: RegistrySource,
 ): Promise<DownloadResult> {
   const tempPath = join(tempDir, `arc-download-${Date.now()}.tar.gz`);
+
+  const headers: Record<string, string> = {};
+  if (source && source.token && getSourceType(source) === "metafactory") {
+    headers.Authorization = `Bearer ${source.token}`;
+  }
 
   let lastError: string | undefined;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const response = await fetch(url, {
+        headers,
         signal: AbortSignal.timeout(60_000),
       });
 

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -140,6 +140,7 @@ export interface DownloadResult {
   error?: string;
 }
 
+/** Maximum number of HTTP redirects to follow on a single download. */
 const MAX_REDIRECTS = 5;
 
 /**
@@ -151,6 +152,10 @@ const MAX_REDIRECTS = 5;
  * WHATWG `fetch` spec already mandates this, but pinning the contract
  * here protects against runtime changes and makes the intent observable
  * in tests. Same-origin redirects keep the header.
+ *
+ * After MAX_REDIRECTS hops without reaching a non-3xx response, throw —
+ * never fall back to default fetch redirect-following, which would void
+ * the no-leak contract this function exists to enforce.
  */
 async function fetchFollowingRedirects(
   url: string,
@@ -158,7 +163,7 @@ async function fetchFollowingRedirects(
 ): Promise<Response> {
   let currentUrl = url;
   let currentHeaders = { ...init.headers };
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+  for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
     const response = await fetch(currentUrl, {
       headers: currentHeaders,
       signal: init.signal,
@@ -180,10 +185,7 @@ async function fetchFollowingRedirects(
       currentHeaders = rest;
     }
   }
-  return fetch(currentUrl, {
-    headers: currentHeaders,
-    signal: init.signal,
-  });
+  throw new Error(`Too many redirects (>${MAX_REDIRECTS}) following ${url}`);
 }
 
 /**

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -140,6 +140,52 @@ export interface DownloadResult {
   error?: string;
 }
 
+const MAX_REDIRECTS = 5;
+
+/**
+ * Fetch with explicit cross-origin Authorization stripping.
+ *
+ * If an auth'd request is redirected to a different origin (e.g. storage
+ * 302s to a presigned R2/S3 URL), drop the Authorization header on the
+ * next hop so the bearer token never reaches the redirect target. The
+ * WHATWG `fetch` spec already mandates this, but pinning the contract
+ * here protects against runtime changes and makes the intent observable
+ * in tests. Same-origin redirects keep the header.
+ */
+async function fetchFollowingRedirects(
+  url: string,
+  init: { headers: Record<string, string>; signal: AbortSignal },
+): Promise<Response> {
+  let currentUrl = url;
+  let currentHeaders = { ...init.headers };
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const response = await fetch(currentUrl, {
+      headers: currentHeaders,
+      signal: init.signal,
+      redirect: "manual",
+    });
+    const status = response.status;
+    if (status < 300 || status >= 400) {
+      return response;
+    }
+    const location = response.headers.get("location");
+    if (!location) {
+      return response;
+    }
+    const nextUrl = new URL(location, currentUrl).toString();
+    const sameOrigin = new URL(nextUrl).origin === new URL(currentUrl).origin;
+    currentUrl = nextUrl;
+    if (!sameOrigin && currentHeaders.Authorization) {
+      const { Authorization: _drop, ...rest } = currentHeaders;
+      currentHeaders = rest;
+    }
+  }
+  return fetch(currentUrl, {
+    headers: currentHeaders,
+    signal: init.signal,
+  });
+}
+
 /**
  * Download a package tarball from the storage endpoint.
  *
@@ -148,6 +194,10 @@ export interface DownloadResult {
  * through an auth-gated storage endpoint (issue #83). For sources without a
  * token, or registry-type sources, the request stays anonymous (DD-80) so
  * public unauthenticated installs continue to work.
+ *
+ * Redirects are followed manually: on a cross-origin redirect (e.g. 302 to
+ * a presigned R2/S3 URL), the Authorization header is stripped before the
+ * next hop so the bearer never leaks to a third-party storage origin.
  */
 export async function downloadPackage(
   url: string,
@@ -164,7 +214,7 @@ export async function downloadPackage(
   let lastError: string | undefined;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const response = await fetch(url, {
+      const response = await fetchFollowingRedirects(url, {
         headers,
         signal: AbortSignal.timeout(60_000),
       });

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -520,6 +520,77 @@ describe("downloadPackage", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  // Defense-in-depth: if storage 302s to a presigned URL on a different
+  // origin (R2/S3/CDN), the bearer token must not reach the redirect target.
+  test("strips Authorization on cross-origin redirect", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; auth: string | null }> = [];
+    globalThis.fetch = mockFetch(async (input: any, init?: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      const headers = new Headers(init?.headers);
+      requests.push({ url, auth: headers.get("Authorization") });
+      if (url.startsWith("https://meta-factory.test/")) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "https://r2.cloudflarestorage.com/bucket/pkg.tar.gz" },
+        });
+      }
+      return new Response(new ArrayBuffer(64), { status: 200 });
+    });
+
+    try {
+      const result = await downloadPackage(
+        "https://meta-factory.test/api/v1/storage/download/abc",
+        env.paths.reposDir,
+        metafactorySource("super-secret-token"),
+      );
+      expect(result.success).toBe(true);
+      expect(requests).toHaveLength(2);
+      // First hop (origin server) gets the bearer.
+      expect(requests[0].url).toContain("meta-factory.test");
+      expect(requests[0].auth).toBe("Bearer super-secret-token");
+      // Second hop (cross-origin storage) MUST NOT see the bearer.
+      expect(requests[1].url).toContain("r2.cloudflarestorage.com");
+      expect(requests[1].auth).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("preserves Authorization on same-origin redirect", async () => {
+    // Internal redirect (e.g. /v1/storage/download/abc → /v2/storage/download/abc
+    // on the same origin) is part of the auth surface; strip would break installs.
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; auth: string | null }> = [];
+    globalThis.fetch = mockFetch(async (input: any, init?: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      const headers = new Headers(init?.headers);
+      requests.push({ url, auth: headers.get("Authorization") });
+      if (url.endsWith("/v1/storage/download/abc")) {
+        return new Response(null, {
+          status: 307,
+          headers: { Location: "/v2/storage/download/abc" },
+        });
+      }
+      return new Response(new ArrayBuffer(64), { status: 200 });
+    });
+
+    try {
+      const result = await downloadPackage(
+        "https://meta-factory.test/v1/storage/download/abc",
+        env.paths.reposDir,
+        metafactorySource("super-secret-token"),
+      );
+      expect(result.success).toBe(true);
+      expect(requests).toHaveLength(2);
+      expect(requests[0].auth).toBe("Bearer super-secret-token");
+      expect(requests[1].auth).toBe("Bearer super-secret-token");
+      expect(requests[1].url).toContain("/v2/storage/download/abc");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -558,6 +558,40 @@ describe("downloadPackage", () => {
     }
   });
 
+  test("aborts after too many redirects rather than auto-following", async () => {
+    // If a server keeps issuing 3xx responses, we must NOT silently fall
+    // back to the runtime's default redirect-following — that would void
+    // the cross-origin auth-strip contract for any hop past the cap.
+    const originalFetch = globalThis.fetch;
+    let attempts = 0;
+    globalThis.fetch = mockFetch(async (_input: any) => {
+      attempts++;
+      // Bounce through a chain of cross-origin hosts forever.
+      const next = `https://hop-${attempts}.example.com/x`;
+      return new Response(null, {
+        status: 302,
+        headers: { Location: next },
+      });
+    });
+
+    try {
+      const result = await downloadPackage(
+        "https://meta-factory.test/api/v1/storage/download/abc",
+        env.paths.reposDir,
+        metafactorySource("super-secret-token"),
+      );
+      // downloadPackage's retry loop catches the thrown "too many redirects"
+      // as a generic network error after both attempts. The important part
+      // is that no auto-followed fetch ever happens beyond the cap.
+      expect(result.success).toBe(false);
+      // Two retries × MAX_REDIRECTS hops each = 10 attempts at most.
+      expect(attempts).toBeLessThanOrEqual(10);
+      expect(attempts).toBeGreaterThanOrEqual(5);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("preserves Authorization on same-origin redirect", async () => {
     // Internal redirect (e.g. /v1/storage/download/abc → /v2/storage/download/abc
     // on the same origin) is part of the auth surface; strip would break installs.

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -424,6 +424,102 @@ describe("downloadPackage", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  // Issue #83: auth-gated metafactory storage endpoints (e.g. dev.meta-factory.ai)
+  // require Bearer auth on /api/v1/storage/download. Anonymous installs against
+  // unauthenticated registries must continue to work.
+  test("sends Bearer token when source is metafactory with token", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedAuth: string | null = null;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get("Authorization");
+      return new Response(new ArrayBuffer(10), { status: 200 });
+    });
+
+    try {
+      const result = await downloadPackage(
+        "https://example.com/pkg.tar.gz",
+        env.paths.reposDir,
+        metafactorySource("test-token-abc"),
+      );
+      expect(result.success).toBe(true);
+      expect(capturedAuth as string | null).toBe("Bearer test-token-abc");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("omits Authorization header when source has no token", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedAuth: string | null = null;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get("Authorization");
+      return new Response(new ArrayBuffer(10), { status: 200 });
+    });
+
+    try {
+      await downloadPackage(
+        "https://example.com/pkg.tar.gz",
+        env.paths.reposDir,
+        metafactorySource(),
+      );
+      expect(capturedAuth).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("omits Authorization header for non-metafactory source even with token", async () => {
+    // A registry-type source should never receive the bearer; tokens belong
+    // to the metafactory API surface.
+    const originalFetch = globalThis.fetch;
+    let capturedAuth: string | null = null;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get("Authorization");
+      return new Response(new ArrayBuffer(10), { status: 200 });
+    });
+
+    try {
+      const registrySource: RegistrySource = {
+        name: "registry-test",
+        url: "https://example.com",
+        tier: "official",
+        enabled: true,
+        type: "registry",
+        token: "should-not-be-sent",
+      };
+      await downloadPackage(
+        "https://example.com/pkg.tar.gz",
+        env.paths.reposDir,
+        registrySource,
+      );
+      expect(capturedAuth).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("auth-gated 401 still surfaces Access denied error", async () => {
+    // Even with a token in hand, the server can reject (expired/invalid).
+    // Caller-facing error message stays the same.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("Unauthorized", { status: 401 }));
+
+    try {
+      const result = await downloadPackage(
+        "https://example.com/pkg.tar.gz",
+        env.paths.reposDir,
+        metafactorySource("expired-token"),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Access denied");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #83.

\`arc install\` could not download from a metafactory source whose \`/api/v1/storage/download/<sha256>\` endpoint requires auth (e.g. dev.meta-factory.ai). The download path was hardcoded anonymous and never attached the bearer token even after \`arc login\`, so install failed with \"Access denied by storage endpoint.\" The package detail endpoint already worked anonymously, so the token was sitting on the resolved source unused.

Verified by direct probes (per issue body): anonymous \`/api/v1/packages/...\` returns 200, anonymous \`/api/v1/storage/download/<sha256>\` returns 401, the same request with \`Authorization: Bearer <token>\` returns 200.

## Changes

- **\`src/lib/registry-install.ts\`** — extend \`downloadPackage(url, tempDir, source?)\` with an optional \`source\` param. When \`source.token\` is set and the source is metafactory-type, attach \`Authorization: Bearer <token>\`. Otherwise (no token, or registry-type source) the request stays anonymous so DD-80 public installs keep working.
- **\`src/cli.ts\`** — pass \`resolved.source\` through at the single call site.

Backwards-compatible: existing tests that call \`downloadPackage(url, tempDir)\` without a source argument keep their anonymous behaviour.

## Tests (test/unit/registry-install.test.ts, +4)

- Bearer token attached when source is metafactory with a token.
- Authorization header omitted when source has no token.
- Authorization header omitted for registry-type sources, even if they carry a token.
- 401 response still surfaces \"Access denied\" to the caller (e.g. expired/invalid token).

Full suite: 610/610 pass.

## Test plan

- [x] \`bun test test/unit/registry-install.test.ts\` (37 pass, 4 new)
- [x] \`bun test\` (610 pass)
- [x] \`bunx tsc --noEmit\` clean
- [ ] Manual smoke against dev.meta-factory.ai once merged: \`arc login --source metafactory-dev && arc install @jcfischer/caduceus -y\` should succeed where it currently fails with the access-denied error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)