### PR TITLE
fix(manifest): improve missing-capabilities error with example

### DIFF
--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -44,7 +44,7 @@ export async function readManifest(
         throw new Error(
           [
             `Invalid ${filename}: missing required field 'capabilities'`,
-            `Required for type: skill, tool, agent, prompt, pipeline, action, system (optional only for: component, rules).`,
+            `Required for type: skill, tool, agent, prompt, pipeline, system (optional only for: component, rules).`,
             ``,
             `Minimal example:`,
             ``,
@@ -59,7 +59,7 @@ export async function readManifest(
             `    allowed: false            # set true if the package shells out`,
             `  secrets: []                 # env vars or secret keys the package reads`,
             ``,
-            `See: https://github.com/the-metafactory/arc/blob/main/README.md#capabilities`,
+            `See: https://github.com/the-metafactory/arc/blob/main/README.md#capability-declarations`,
           ].join("\n"),
         );
       }

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -42,7 +42,25 @@ export async function readManifest(
       // capabilities optional for component and rules types, required for others
       if (!parsed.capabilities && parsed.type !== "component" && parsed.type !== "rules") {
         throw new Error(
-          `Invalid ${filename}: missing required field 'capabilities' (only optional for type: component)`
+          [
+            `Invalid ${filename}: missing required field 'capabilities'`,
+            `Required for type: skill, tool, agent, prompt, pipeline, action, system (optional only for: component, rules).`,
+            ``,
+            `Minimal example:`,
+            ``,
+            `capabilities:`,
+            `  filesystem:`,
+            `    read: []                  # paths the package reads from`,
+            `    write: []                 # paths the package writes to`,
+            `  network:`,
+            `    - domain: api.example.com`,
+            `      reason: <what calls this domain>`,
+            `  bash:`,
+            `    allowed: false            # set true if the package shells out`,
+            `  secrets: []                 # env vars or secret keys the package reads`,
+            ``,
+            `See: https://github.com/the-metafactory/arc/blob/main/README.md#capabilities`,
+          ].join("\n"),
         );
       }
 

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -162,14 +162,21 @@ author:
     // Lists the exempt types so a publisher can decide if they qualify.
     expect(msg).toContain("component");
     expect(msg).toContain("rules");
+    // Required-type list must NOT advertise "action" — it's not a member of
+    // the ArcManifest.type union, and recommending it would send users into
+    // a different validation failure later.
+    expect(msg).not.toContain("action");
     // Includes a copyable canonical block.
     expect(msg).toContain("filesystem:");
     expect(msg).toContain("network:");
     expect(msg).toContain("bash:");
     expect(msg).toContain("secrets:");
     expect(msg).toContain("reason:");
-    // Points at the schema doc.
-    expect(msg).toContain("README.md#capabilities");
+    // Points at the schema doc with the actual heading anchor on README.md
+    // (### Capability Declarations → #capability-declarations). A bare
+    // #capabilities anchor would render but scroll to top, defeating the
+    // affordance.
+    expect(msg).toContain("README.md#capability-declarations");
   });
 });
 

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -133,6 +133,44 @@ capabilities:
 
     await expect(readManifest(tempDir)).rejects.toThrow("missing required fields");
   });
+
+  // Issue #87: when capabilities is missing on a non-component/non-rules
+  // manifest, the error must guide first-time publishers — not just say
+  // "field missing". Surface the canonical block, list which types require
+  // it, and link to the README section.
+  test("missing capabilities error includes minimal example and exempt types", async () => {
+    await Bun.write(
+      join(tempDir, MANIFEST_FILENAME),
+      `name: example-tool
+version: 0.1.0
+type: tool
+author:
+  name: t
+  github: t
+`,
+    );
+
+    let err: Error | null = null;
+    try {
+      await readManifest(tempDir);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    const msg = err!.message;
+    expect(msg).toContain("missing required field 'capabilities'");
+    // Lists the exempt types so a publisher can decide if they qualify.
+    expect(msg).toContain("component");
+    expect(msg).toContain("rules");
+    // Includes a copyable canonical block.
+    expect(msg).toContain("filesystem:");
+    expect(msg).toContain("network:");
+    expect(msg).toContain("bash:");
+    expect(msg).toContain("secrets:");
+    expect(msg).toContain("reason:");
+    // Points at the schema doc.
+    expect(msg).toContain("README.md#capabilities");
+  });
 });
 
 describe("assessRisk", () => {


### PR DESCRIPTION
## Summary

Closes #87.

When \`capabilities\` is missing on a non-component/non-rules manifest, the previous error told a first-time publisher *what* was missing but not *what to write*. They had to grep the source or copy from sibling repos to discover the schema.

## Changes

**\`src/lib/manifest.ts\`** — replace the one-line error with a multi-line message:

\`\`\`
Invalid arc-manifest.yaml: missing required field 'capabilities'
Required for type: skill, tool, agent, prompt, pipeline, action, system (optional only for: component, rules).

Minimal example:

capabilities:
  filesystem:
    read: []                  # paths the package reads from
    write: []                 # paths the package writes to
  network:
    - domain: api.example.com
      reason: <what calls this domain>
  bash:
    allowed: false            # set true if the package shells out
  secrets: []                 # env vars or secret keys the package reads

See: https://github.com/the-metafactory/arc/blob/main/README.md#capabilities
\`\`\`

Also corrects the prior message which said \"only optional for type: component\" but \`rules\` was already exempt in the code.

## Tests (test/unit/manifest.test.ts, +1)

Asserts the error contains: \`'capabilities'\`, both exempt types (\`component\`, \`rules\`), the canonical block subkeys (\`filesystem\`, \`network\`, \`bash\`, \`secrets\`, \`reason\`), and the README link.

Suite: 622/622 pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)