### PR TITLE
fix(install): pre-validate provides.files + rollback on hook gate fail

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -6,7 +6,12 @@ import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } fr
 import { recordInstall, getSkill } from "../lib/db.js";
 import { runScript } from "../lib/scripts.js";
 import { registerHooks, resolveHooksFromManifest, findMissingHookFiles } from "../lib/hooks.js";
-import { createArtifactSymlinks, resolveArtifactSourceDir, installNodeDependencies } from "../lib/artifact-installer.js";
+import {
+  createArtifactSymlinks,
+  resolveArtifactSourceDir,
+  installNodeDependencies,
+  rollbackArtifactSymlinks,
+} from "../lib/artifact-installer.js";
 import { wireExtensions } from "../lib/extensions.js";
 import { extractRepoName } from "../lib/repo-name.js";
 
@@ -288,6 +293,10 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       const detail = missingHookFiles
         .map((m) => `  - ${m.event}: ${m.command}\n      missing: ${m.missingPath}`)
         .join("\n");
+      // #89: roll back any symlinks/shims createArtifactSymlinks placed before
+      // we hit this gate, so the install fails clean rather than leaving
+      // orphan entries under ~/.claude/{skills,bin,...} for the user to clean.
+      await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,
         error:
@@ -556,6 +565,10 @@ export async function installSingleArtifact(
       const detail = missingHookFiles
         .map((m) => `  - ${m.event}: ${m.command}\n      missing: ${m.missingPath}`)
         .join("\n");
+      // #89: roll back any symlinks/shims createArtifactSymlinks placed before
+      // we hit this gate, so the install fails clean rather than leaving
+      // orphan entries under ~/.claude/{skills,bin,...} for the user to clean.
+      await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,
         error:

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -260,16 +260,36 @@ export async function createArtifactSymlinks(opts: {
 
 /**
  * Roll back every symlink and shim recorded by createArtifactSymlinks.
- * Used by install when a downstream gate (hook validation, postinstall
- * script) fails — see issue #89. Best-effort: individual unlink errors
- * are swallowed so cleanup can proceed across all entries.
+ *
+ * Currently called by install when the hook-validation gate fails — see
+ * issue #89. Postinstall-script failure also leaves partial state (symlinks
+ * + registered hooks pointing at a package the DB has no record of) but is
+ * a strictly larger fix because it also requires unregistering hooks from
+ * settings.json; tracked separately.
+ *
+ * Best-effort across all entries: an ENOENT on one path doesn't abort
+ * cleanup of the others. Non-ENOENT errors (e.g. permission denied) are
+ * surfaced via console.warn so the user sees orphans they need to inspect
+ * manually rather than failing silently.
  */
 export async function rollbackArtifactSymlinks(record: ArtifactSymlinkRecord): Promise<void> {
   for (const link of record.symlinks) {
-    await removeSymlink(link).catch(() => {});
+    try {
+      await removeSymlink(link);
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        console.warn(`  ⚠ rollback: failed to remove symlink ${link}: ${err?.message ?? err}`);
+      }
+    }
   }
   for (const name of record.shims.names) {
-    await removeCliShim(record.shims.dir, name).catch(() => {});
+    try {
+      await removeCliShim(record.shims.dir, name);
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        console.warn(`  ⚠ rollback: failed to remove shim ${name}: ${err?.message ?? err}`);
+      }
+    }
   }
 }
 

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -3,7 +3,13 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import type { ArtifactType, ArcManifest, PaiPaths } from "../types.js";
-import { createSymlink, createCliShim, extractAllCliInfo } from "./symlinks.js";
+import {
+  createSymlink,
+  createCliShim,
+  extractAllCliInfo,
+  removeSymlink,
+  removeCliShim,
+} from "./symlinks.js";
 import { generateRules } from "./rules.js";
 
 /**
@@ -48,6 +54,18 @@ export function resolveArtifactSourceDir(type: ArtifactType | "rules" | "system"
  * tool, agent, prompt, and skill. Extracted from install() to allow reuse
  * across install, catalog use, and single-artifact install flows.
  */
+/**
+ * Aggregate of every filesystem artifact a single createArtifactSymlinks call
+ * created. Captured so a downstream failure (hook gate, post-install script,
+ * etc.) can roll back the partial state — see issue #89.
+ */
+export interface ArtifactSymlinkRecord {
+  /** Absolute paths of symlinks created (any directory). */
+  symlinks: string[];
+  /** CLI shim files created via createCliShim (need removeCliShim, not unlink). */
+  shims: { dir: string; names: string[] };
+}
+
 export async function createArtifactSymlinks(opts: {
   type: ArtifactType | "rules" | "system";
   manifest: ArcManifest;
@@ -58,14 +76,45 @@ export async function createArtifactSymlinks(opts: {
 }): Promise<{
   filesCreated: Array<{ source: string; target: string }>;
   filesMissingSource: Array<{ source: string; target: string }>;
+  record: ArtifactSymlinkRecord;
 }> {
   const { type, manifest, paths, installDir, quiet } = opts;
+  const record: ArtifactSymlinkRecord = { symlinks: [], shims: { dir: paths.shimDir, names: [] } };
+
+  // Helper that wraps createSymlink + tracks the target for rollback (#89).
+  const linkTracked = async (source: string, target: string) => {
+    await createSymlink(source, target);
+    record.symlinks.push(target);
+  };
+  const shimTracked = async () => {
+    const created = await createCliShim(paths.shimDir, paths.binDir, manifest);
+    record.shims.names.push(...created);
+  };
+
+  // Pre-validation pass (#89): assert every provides.files source exists in
+  // the package before we create ANY symlinks. The most common failure mode
+  // (manifest typo, repo drift) is now stopped with zero filesystem mutation,
+  // so install can return cleanly without producing orphan symlinks.
+  const declaredFiles = manifest.provides?.files ?? [];
+  const filesMissingSource: Array<{ source: string; target: string }> = [];
+  for (const file of declaredFiles) {
+    const sourcePath = join(installDir, file.source);
+    if (!existsSync(sourcePath)) {
+      filesMissingSource.push({
+        source: sourcePath,
+        target: file.target.replace(/^~/, homedir()),
+      });
+    }
+  }
+  if (filesMissingSource.length) {
+    return { filesCreated: [], filesMissingSource, record };
+  }
 
   switch (type) {
     case "action": {
       // Actions: symlink action directory into actionsDir
       const actionLinkPath = join(paths.actionsDir, manifest.name);
-      await createSymlink(installDir, actionLinkPath);
+      await linkTracked(installDir, actionLinkPath);
       break;
     }
 
@@ -93,16 +142,16 @@ export async function createArtifactSymlinks(opts: {
       const pipelineSourceDir = join(installDir, "pipeline");
       const sourceDir = existsSync(pipelineSourceDir) ? pipelineSourceDir : installDir;
       const pipelineLinkPath = join(paths.pipelinesDir, manifest.name);
-      await createSymlink(sourceDir, pipelineLinkPath);
+      await linkTracked(sourceDir, pipelineLinkPath);
 
       // If the manifest declares CLI entries, also create shims
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
         const binLinkPath = join(paths.binDir, entry.binName);
-        await createSymlink(installDir, binLinkPath);
+        await linkTracked(installDir, binLinkPath);
       }
       if (cliEntries.length) {
-        await createCliShim(paths.shimDir, paths.binDir, manifest);
+        await shimTracked();
       }
       break;
     }
@@ -118,15 +167,15 @@ export async function createArtifactSymlinks(opts: {
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
         const binLinkPath = join(paths.binDir, entry.binName);
-        await createSymlink(installDir, binLinkPath);
+        await linkTracked(installDir, binLinkPath);
       }
       if (!cliEntries.length) {
         // Fallback: symlink under manifest name if no CLI declared
-        await createSymlink(installDir, join(paths.binDir, manifest.name));
+        await linkTracked(installDir, join(paths.binDir, manifest.name));
       }
 
       // Create PATH-accessible shims for all CLI entries
-      await createCliShim(paths.shimDir, paths.binDir, manifest);
+      await shimTracked();
       break;
     }
 
@@ -139,10 +188,10 @@ export async function createArtifactSymlinks(opts: {
       const linkPath = join(paths.agentsDir, mdFile);
 
       if (existsSync(sourcePath)) {
-        await createSymlink(sourcePath, linkPath);
+        await linkTracked(sourcePath, linkPath);
       } else {
         // Fallback: symlink directory if .md file not found by convention name
-        await createSymlink(sourceDir, join(paths.agentsDir, manifest.name));
+        await linkTracked(sourceDir, join(paths.agentsDir, manifest.name));
       }
       break;
     }
@@ -156,10 +205,10 @@ export async function createArtifactSymlinks(opts: {
       const linkPath = join(paths.promptsDir, mdFile);
 
       if (existsSync(sourcePath)) {
-        await createSymlink(sourcePath, linkPath);
+        await linkTracked(sourcePath, linkPath);
       } else {
         // Fallback: symlink directory if .md file not found by convention name
-        await createSymlink(sourceDir, join(paths.promptsDir, manifest.name));
+        await linkTracked(sourceDir, join(paths.promptsDir, manifest.name));
       }
       break;
     }
@@ -172,19 +221,19 @@ export async function createArtifactSymlinks(opts: {
       const skillLinkPath = join(paths.skillsDir, manifest.name);
 
       if (existsSync(skillSourceDir)) {
-        await createSymlink(skillSourceDir, skillLinkPath);
+        await linkTracked(skillSourceDir, skillLinkPath);
       } else {
-        await createSymlink(installDir, skillLinkPath);
+        await linkTracked(installDir, skillLinkPath);
       }
 
       // Create bin symlinks and shims for all CLI entries (skills with CLI)
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
         const binLinkPath = join(paths.binDir, entry.binName);
-        await createSymlink(installDir, binLinkPath);
+        await linkTracked(installDir, binLinkPath);
       }
       if (cliEntries.length) {
-        await createCliShim(paths.shimDir, paths.binDir, manifest);
+        await shimTracked();
       }
       break;
     }
@@ -195,22 +244,33 @@ export async function createArtifactSymlinks(opts: {
   // files (hook handlers, helpers, shared libs) alongside the primary layout.
   // Previously only `component` honored this, which silently broke any
   // multi-artifact package using a different primary type. See issue #84.
-  const declaredFiles = manifest.provides?.files ?? [];
+  // The pre-validation pass above guarantees every source exists by the time
+  // we get here, so we can fearlessly create symlinks without partial-state risk.
   const filesCreated: Array<{ source: string; target: string }> = [];
-  const filesMissingSource: Array<{ source: string; target: string }> = [];
   for (const file of declaredFiles) {
     const sourcePath = join(installDir, file.source);
     const targetPath = file.target.replace(/^~/, homedir());
-    if (!existsSync(sourcePath)) {
-      filesMissingSource.push({ source: sourcePath, target: targetPath });
-      continue;
-    }
     await mkdir(dirname(targetPath), { recursive: true });
-    await createSymlink(sourcePath, targetPath);
+    await linkTracked(sourcePath, targetPath);
     filesCreated.push({ source: sourcePath, target: targetPath });
   }
 
-  return { filesCreated, filesMissingSource };
+  return { filesCreated, filesMissingSource: [], record };
+}
+
+/**
+ * Roll back every symlink and shim recorded by createArtifactSymlinks.
+ * Used by install when a downstream gate (hook validation, postinstall
+ * script) fails — see issue #89. Best-effort: individual unlink errors
+ * are swallowed so cleanup can proceed across all entries.
+ */
+export async function rollbackArtifactSymlinks(record: ArtifactSymlinkRecord): Promise<void> {
+  for (const link of record.symlinks) {
+    await removeSymlink(link).catch(() => {});
+  }
+  for (const name of record.shims.names) {
+    await removeCliShim(record.shims.dir, name).catch(() => {});
+  }
 }
 
 /**

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -528,6 +528,68 @@ describe("install provides.files (issue #84)", () => {
     expect(result.error).toContain("SkillNudge.ts");
   });
 
+  // Issue #89: rollback partial state on install failure.
+  test("missing provides.files source: zero symlinks created (pre-validation)", async () => {
+    const presentTarget = join(env.root, "out", "present.ts");
+    const missingTarget = join(env.root, "out", "missing.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "RollbackPreValidate",
+      extraFiles: { "src/present.ts": "// present\n" },
+      providesFiles: [
+        { source: "src/present.ts", target: presentTarget },
+        { source: "src/missing.ts", target: missingTarget },
+      ],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("provides.files");
+    // Pre-validation kicked in BEFORE per-type symlinks: nothing landed
+    // anywhere — neither the partial provides.files entry nor the skill dir.
+    expect(existsSync(presentTarget)).toBe(false);
+    expect(existsSync(missingTarget)).toBe(false);
+    expect(existsSync(join(env.paths.skillsDir, "RollbackPreValidate"))).toBe(false);
+  });
+
+  test("hook gate failure rolls back per-type symlinks + provides.files targets", async () => {
+    // Pre-validation passes (provides.files source exists), per-type primary
+    // symlinks get created, provides.files target gets created. Then the hook
+    // gate trips on a separate ${PAI_DIR}/missing.ts entry. Install must fail
+    // AND clean up the symlinks already placed.
+    const filesTarget = join(env.paths.claudeRoot, "handlers", "Live.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "RollbackOnHookGate",
+      extraFiles: { "handlers/Live.ts": "// live\n" },
+      providesFiles: [{ source: "handlers/Live.ts", target: filesTarget }],
+      providesHooks: [
+        // Live.ts will be landed by provides.files — fine.
+        { event: "Stop", command: "${PAI_DIR}/handlers/Live.ts" },
+        // Ghost.ts is NOT landed by anything — hook gate must reject.
+        { event: "Stop", command: "${PAI_DIR}/handlers/Ghost.ts" },
+      ],
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hooks");
+    // Skill dir symlink, bin shim, and provides.files target must all be gone
+    // — install rolled them back when the hook gate tripped.
+    expect(existsSync(join(env.paths.skillsDir, "RollbackOnHookGate"))).toBe(false);
+    expect(existsSync(filesTarget)).toBe(false);
+  });
+
   test("install succeeds when ${PAI_DIR} hook target is landed via provides.files", async () => {
     const targetPath = join(env.paths.claudeRoot, "hooks", "handlers", "Live.ts");
     const repoUrl = await buildRepoWithProvides({

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -354,6 +354,7 @@ describe("install provides.files (issue #84)", () => {
     extraFiles?: Record<string, string>;
     providesFiles?: Array<{ source: string; target: string }>;
     providesHooks?: Array<{ event: string; command: string }>;
+    providesCli?: Array<{ command: string; name: string }>;
   }): Promise<string> {
     const repoDir = join(env.root, `mock-${opts.name}`);
     const { mkdir, writeFile } = await import("fs/promises");
@@ -391,6 +392,13 @@ describe("install provides.files (issue #84)", () => {
       for (const h of opts.providesHooks) {
         lines.push(`    - event: ${h.event}`);
         lines.push(`      command: ${JSON.stringify(h.command)}`);
+      }
+    }
+    if (opts.providesCli?.length) {
+      lines.push(`  cli:`);
+      for (const c of opts.providesCli) {
+        lines.push(`    - command: ${JSON.stringify(c.command)}`);
+        lines.push(`      name: ${c.name}`);
       }
     }
     lines.push(`capabilities:`);
@@ -557,16 +565,21 @@ describe("install provides.files (issue #84)", () => {
     expect(existsSync(join(env.paths.skillsDir, "RollbackPreValidate"))).toBe(false);
   });
 
-  test("hook gate failure rolls back per-type symlinks + provides.files targets", async () => {
+  test("hook gate failure rolls back per-type symlinks + provides.files targets + CLI shims", async () => {
     // Pre-validation passes (provides.files source exists), per-type primary
-    // symlinks get created, provides.files target gets created. Then the hook
-    // gate trips on a separate ${PAI_DIR}/missing.ts entry. Install must fail
-    // AND clean up the symlinks already placed.
+    // symlinks get created, CLI shim gets created, provides.files target
+    // gets created. Then the hook gate trips on a separate
+    // ${PAI_DIR}/Ghost.ts entry. Install must fail AND clean up everything
+    // that was placed before the gate ran.
     const filesTarget = join(env.paths.claudeRoot, "handlers", "Live.ts");
     const repoUrl = await buildRepoWithProvides({
       name: "RollbackOnHookGate",
-      extraFiles: { "handlers/Live.ts": "// live\n" },
+      extraFiles: {
+        "handlers/Live.ts": "// live\n",
+        "src/cli.ts": "#!/usr/bin/env bun\nconsole.log('hi');\n",
+      },
       providesFiles: [{ source: "handlers/Live.ts", target: filesTarget }],
+      providesCli: [{ command: "bun src/cli.ts", name: "rollbackgate" }],
       providesHooks: [
         // Live.ts will be landed by provides.files — fine.
         { event: "Stop", command: "${PAI_DIR}/handlers/Live.ts" },
@@ -584,10 +597,12 @@ describe("install provides.files (issue #84)", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("hooks");
-    // Skill dir symlink, bin shim, and provides.files target must all be gone
-    // — install rolled them back when the hook gate tripped.
+    // Every artifact placed before the gate must be gone.
     expect(existsSync(join(env.paths.skillsDir, "RollbackOnHookGate"))).toBe(false);
     expect(existsSync(filesTarget)).toBe(false);
+    // bin symlink + PATH shim for the declared CLI
+    expect(existsSync(join(env.paths.binDir, "rollbackgate"))).toBe(false);
+    expect(existsSync(join(env.paths.shimDir, "rollbackgate"))).toBe(false);
   });
 
   test("install succeeds when ${PAI_DIR} hook target is landed via provides.files", async () => {


### PR DESCRIPTION
## Summary

Closes #89.

\`install\` previously left orphan symlinks under \`~/.claude/{skills,agents,bin,...}\` when validation failed mid-flow. Two distinct partial-state shapes:

1. \`provides.files\` entry N's source missing → entries 1..N-1 already linked, per-type primary symlinks already in place.
2. Hook gate trips after symlinks landed → symlinks orphaned, \`settings.json\` untouched, DB unaware.

User had no clean recovery path: \`arc remove\` couldn't drive cleanup (no DB entry), so manual rm was the only option.

## Changes

- **\`src/lib/artifact-installer.ts\`** — implement both fixes from the issue:
  1. **Pre-pass validation (option 1).** Before the per-type switch, walk every \`provides.files\` entry and assert each \`source\` exists in the package. If any missing, return immediately with \`filesMissingSource\` populated and **zero filesystem mutations**.
  2. **Rollback tracking (option 2).** Every symlink (per-type primary, CLI bins, \`provides.files\` target) and shim now goes through \`linkTracked\` / \`shimTracked\` helpers that record the path on an \`ArtifactSymlinkRecord\`. New \`rollbackArtifactSymlinks()\` helper unlinks them best-effort.

- **\`src/commands/install.ts\`** — call \`rollbackArtifactSymlinks(symlinkResult.record)\` on the hook-gate failure path. Missing hook target now tears down everything that was placed before the gate ran.

## Tests (test/commands/install.test.ts, +2)

- **Pre-validation:** manifest with two \`provides.files\`, second source missing. Install fails with \`provides.files\` diagnostic. The FIRST entry's target is also absent (pre-validation prevented it being created), and the per-type skill symlink is absent.
- **Hook-gate rollback:** \`provides.files\` succeeds but a separate hook command references an unlanded file. Install fails with hook diagnostic. Skill symlink AND \`provides.files\` target both rolled back.

Suite: 624/624 pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)