### PR TITLE
fix(hooks): substitute $HOME and ~/ upstream, drop ~/ in checker

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -8,6 +8,7 @@
 
 import { existsSync, readFileSync } from "fs";
 import { mkdir } from "fs/promises";
+import { homedir } from "os";
 import { dirname, join } from "path";
 import type { HooksDeclaration, InlineHook, HooksConfigRef } from "../types.js";
 
@@ -116,9 +117,15 @@ export function resolveHooksFromManifest(
 }
 
 /**
- * Replace $PKG_DIR / ${PKG_DIR}, $<NAME>_DIR / ${<NAME>_DIR}, and
- * (when provided) $PAI_DIR / ${PAI_DIR} in hook commands with the
- * corresponding absolute paths.
+ * Replace $PKG_DIR / ${PKG_DIR}, $<NAME>_DIR / ${<NAME>_DIR},
+ * (when provided) $PAI_DIR / ${PAI_DIR}, $HOME / ${HOME}, and a leading "~/"
+ * in hook commands with the corresponding absolute paths.
+ *
+ * $HOME and ~/ are substituted at install time so the missing-file gate
+ * (findMissingHookFiles) can stat the resolved absolute path, and so
+ * settings.json stores the same absolute path the runtime would resolve
+ * to — matching the existing $PKG_DIR / $PAI_DIR pattern. Without this,
+ * "$HOME/script.sh" was left literal and slipped past the gate (#90).
  */
 function resolveCommandPaths(
   hooks: InlineHook[],
@@ -128,6 +135,7 @@ function resolveCommandPaths(
 ): InlineHook[] {
   const nameUpper = packageName.toUpperCase().replace(/-/g, "_");
   const namePattern = new RegExp(`\\$\\{?${nameUpper}_DIR\\}?`, "g");
+  const home = process.env.HOME ?? homedir();
 
   return hooks.map((hook) => {
     let command = hook.command
@@ -136,6 +144,14 @@ function resolveCommandPaths(
     if (paiDir) {
       command = command.replace(/\$\{?PAI_DIR\}?/g, paiDir);
     }
+    // $HOME / ${HOME} → absolute home path
+    command = command.replace(/\$\{?HOME\}?/g, home);
+    // Leading "~/" or whitespace-preceded " ~/" → absolute home path. Bare "~"
+    // alone (without a trailing slash) is left as-is to avoid mangling tokens
+    // like "rsync@host:~" that legitimately use the literal character.
+    command = command
+      .replace(/^~\//, `${home}/`)
+      .replace(/(\s)~\//g, `$1${home}/`);
     return { ...hook, command };
   });
 }
@@ -146,14 +162,12 @@ function resolveCommandPaths(
  * file silently breaks every session (see issue #84), so install must refuse
  * to register such hooks.
  *
- * Heuristic: tokenize on whitespace, look at tokens starting with "/" or "~/".
- * Skip tokens that follow a shell redirect/pipe operator on the previous
- * token, since those are output sinks rather than required inputs.
- *
- * TODO: $HOME / ${HOME} (and other env-var references) are not substituted
- * upstream by resolveHooksFromManifest, so a hook using "$HOME/script.sh"
- * is left as the literal string and will not be inspected here. If/when the
- * resolver grows env-var substitution, drop the redundant ~/ branch below.
+ * Heuristic: tokenize on whitespace, look at tokens starting with "/" (any
+ * absolute path). $PKG_DIR / $<NAME>_DIR / $PAI_DIR / $HOME / leading "~/"
+ * are all substituted upstream by resolveCommandPaths, so by the time a
+ * hook command reaches this function the path-bearing tokens are already
+ * absolute. Skip tokens that follow a shell redirect/pipe operator on the
+ * previous token, since those are output sinks rather than required inputs.
  */
 export function findMissingHookFiles(
   hooks: InlineHook[],
@@ -170,16 +184,9 @@ export function findMissingHookFiles(
         continue;
       }
       const stripped = tokens[i].replace(/^['"]|['"]$/g, "");
-      if (!stripped) continue;
-      let path: string | null = null;
-      if (stripped.startsWith("/")) {
-        path = stripped;
-      } else if (stripped.startsWith("~/")) {
-        path = stripped.replace(/^~/, process.env.HOME ?? "");
-      }
-      if (!path) continue;
-      if (!existsSync(path)) {
-        issues.push({ event: hook.event, command: hook.command, missingPath: path });
+      if (!stripped || !stripped.startsWith("/")) continue;
+      if (!existsSync(stripped)) {
+        issues.push({ event: hook.event, command: hook.command, missingPath: stripped });
       }
     }
   }

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -474,6 +474,87 @@ describe("resolveHooksFromManifest $PAI_DIR substitution", () => {
   });
 });
 
+describe("resolveHooksFromManifest $HOME / ~ substitution", () => {
+  test("expands $HOME and ${HOME} to process.env.HOME", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/tmp/test-home";
+    try {
+      const hooks = [
+        { event: "Stop", command: "$HOME/scripts/cleanup.sh" },
+        { event: "Start", command: "${HOME}/init.sh" },
+      ];
+      const resolved = resolveHooksFromManifest(hooks, "/repo", "MyPkg");
+      expect(resolved).not.toBeNull();
+      expect(resolved![0].command).toBe("/tmp/test-home/scripts/cleanup.sh");
+      expect(resolved![1].command).toBe("/tmp/test-home/init.sh");
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  test("expands leading ~/ to home", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/tmp/test-home";
+    try {
+      const hooks = [{ event: "Stop", command: "~/bin/cleanup.sh" }];
+      const resolved = resolveHooksFromManifest(hooks, "/repo", "MyPkg");
+      expect(resolved![0].command).toBe("/tmp/test-home/bin/cleanup.sh");
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  test("expands whitespace-preceded ~/ inside a multi-token command", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/tmp/test-home";
+    try {
+      const hooks = [{ event: "Stop", command: "bun ~/bin/cleanup.sh --force" }];
+      const resolved = resolveHooksFromManifest(hooks, "/repo", "MyPkg");
+      expect(resolved![0].command).toBe("bun /tmp/test-home/bin/cleanup.sh --force");
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  test("does NOT mangle bare ~ characters that aren't a tilde-path", () => {
+    // Tokens like "rsync@host:~" use ~ literally. Only "~/" (tilde + slash)
+    // should be expanded.
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/tmp/test-home";
+    try {
+      const hooks = [{ event: "Stop", command: "rsync host:~ /tmp" }];
+      const resolved = resolveHooksFromManifest(hooks, "/repo", "MyPkg");
+      expect(resolved![0].command).toBe("rsync host:~ /tmp");
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+
+  test("$HOME / $PAI_DIR / $PKG_DIR all compose in one command", () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = "/tmp/test-home";
+    try {
+      const hooks = [
+        {
+          event: "Stop",
+          command: "${PKG_DIR}/run.sh ${PAI_DIR}/audit.log $HOME/.cache/x.json",
+        },
+      ];
+      const resolved = resolveHooksFromManifest(hooks, "/repo/install", "mypkg", "/Users/me/.claude");
+      expect(resolved![0].command).toBe(
+        "/repo/install/run.sh /Users/me/.claude/audit.log /tmp/test-home/.cache/x.json",
+      );
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+    }
+  });
+});
+
 describe("findMissingHookFiles", () => {
   test("flags command whose absolute path does not exist", () => {
     const issues = findMissingHookFiles([


### PR DESCRIPTION
## Summary

Closes #90.

\`\$HOME\` / \`\${HOME}\` (and a leading \`~/\`) were not substituted upstream by \`resolveHooksFromManifest\`. A hook command like \`"\$HOME/scripts/cleanup.sh"\` was written into \`settings.json\` verbatim. The runtime would still expand it at hook-fire time via shell, but the install-time gate (\`findMissingHookFiles\`, from #88) couldn't stat the target — both safeguards inherited the same substitution gap that #85 closed for \`\$PAI_DIR\`.

## Changes

- **\`src/lib/hooks.ts\` → \`resolveCommandPaths\`:** add substitutions for \`\$HOME\` / \`\${HOME}\` (using \`process.env.HOME ?? homedir()\`) and a leading \`~/\` (or whitespace-preceded \` ~/\`) → home path. Bare \`~\` alone (without a trailing slash) is left as-is so tokens like \`rsync host:~\` aren't mangled.
- **\`src/lib/hooks.ts\` → \`findMissingHookFiles\`:** drop the \`~/\` branch (Luna's earlier TODO). Now redundant — anything starting with \`~/\` is substituted to an absolute path upstream, so the checker only needs the absolute-path branch. The TODO comment is replaced with a paragraph explaining that \`\$PKG_DIR / \$<NAME>_DIR / \$PAI_DIR / \$HOME / leading "~/"\` are all substituted upstream.

## Tests (+5)

- \`\$HOME\` / \`\${HOME}\` → \`process.env.HOME\`
- Leading \`~/\` → home
- Whitespace-preceded \`~/\` inside a multi-token command (e.g. \`bun ~/bin/cleanup.sh --force\`)
- Bare \`~\` tokens (e.g. \`rsync host:~\`) are NOT mangled
- \`\$PKG_DIR / \$PAI_DIR / \$HOME\` compose correctly in a single command

Suite: 629/629 pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)