### PR TITLE
fix(install): rollback symlinks AND unregister hooks on postinstall fail

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -5,7 +5,12 @@ import type { Database } from "bun:sqlite";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
 import { runScript } from "../lib/scripts.js";
-import { registerHooks, resolveHooksFromManifest, findMissingHookFiles } from "../lib/hooks.js";
+import {
+  registerHooks,
+  removeHooks,
+  resolveHooksFromManifest,
+  findMissingHookFiles,
+} from "../lib/hooks.js";
 import {
   createArtifactSymlinks,
   resolveArtifactSourceDir,
@@ -346,6 +351,14 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       quiet: opts.yes,
     });
     if (!postResult.success && !postResult.skipped) {
+      // #97: postinstall failure leaves the same partial-state shape as the
+      // hook-validation gate (#89) plus registered hooks pointing at a package
+      // the DB has no record of (recordInstall happens AFTER postinstall).
+      // Tear down hook registrations and symlinks before returning so the
+      // user gets a clean failure rather than orphans they have to clean up
+      // by hand.
+      await removeHooks(manifest.name, paths.settingsPath);
+      await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,
         error: `Postinstall script failed (exit ${postResult.exitCode})`,
@@ -608,6 +621,14 @@ export async function installSingleArtifact(
       quiet: opts.yes,
     });
     if (!postResult.success && !postResult.skipped) {
+      // #97: postinstall failure leaves the same partial-state shape as the
+      // hook-validation gate (#89) plus registered hooks pointing at a package
+      // the DB has no record of (recordInstall happens AFTER postinstall).
+      // Tear down hook registrations and symlinks before returning so the
+      // user gets a clean failure rather than orphans they have to clean up
+      // by hand.
+      await removeHooks(manifest.name, paths.settingsPath);
+      await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,
         error: `Postinstall script failed (exit ${postResult.exitCode})`,

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -261,11 +261,13 @@ export async function createArtifactSymlinks(opts: {
 /**
  * Roll back every symlink and shim recorded by createArtifactSymlinks.
  *
- * Currently called by install when the hook-validation gate fails — see
- * issue #89. Postinstall-script failure also leaves partial state (symlinks
- * + registered hooks pointing at a package the DB has no record of) but is
- * a strictly larger fix because it also requires unregistering hooks from
- * settings.json; tracked separately.
+ * Called by install on:
+ *   - Hook-validation gate failure (issue #89): symlinks placed but hooks
+ *     not yet registered. Caller only needs this helper.
+ *   - Postinstall-script failure (issue #97): symlinks AND hooks both placed
+ *     before the script ran, so the caller pairs this with removeHooks
+ *     before returning. recordInstall hasn't happened yet at that point,
+ *     so no DB row to clean up.
  *
  * Best-effort across all entries: an ENOENT on one path doesn't abort
  * cleanup of the others. Non-ENOENT errors (e.g. permission denied) are

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -355,6 +355,7 @@ describe("install provides.files (issue #84)", () => {
     providesFiles?: Array<{ source: string; target: string }>;
     providesHooks?: Array<{ event: string; command: string }>;
     providesCli?: Array<{ command: string; name: string }>;
+    postinstall?: { path: string; content: string };
   }): Promise<string> {
     const repoDir = join(env.root, `mock-${opts.name}`);
     const { mkdir, writeFile } = await import("fs/promises");
@@ -400,6 +401,14 @@ describe("install provides.files (issue #84)", () => {
         lines.push(`    - command: ${JSON.stringify(c.command)}`);
         lines.push(`      name: ${c.name}`);
       }
+    }
+    if (opts.postinstall) {
+      const scriptAbs = join(repoDir, opts.postinstall.path);
+      await mkdir(join(scriptAbs, ".."), { recursive: true });
+      await writeFile(scriptAbs, opts.postinstall.content);
+      Bun.spawnSync(["chmod", "+x", scriptAbs], { stdout: "pipe", stderr: "pipe" });
+      lines.push(`scripts:`);
+      lines.push(`  postinstall: ${JSON.stringify(opts.postinstall.path)}`);
     }
     lines.push(`capabilities:`);
     lines.push(`  filesystem: { read: [], write: [] }`);
@@ -603,6 +612,59 @@ describe("install provides.files (issue #84)", () => {
     // bin symlink + PATH shim for the declared CLI
     expect(existsSync(join(env.paths.binDir, "rollbackgate"))).toBe(false);
     expect(existsSync(join(env.paths.shimDir, "rollbackgate"))).toBe(false);
+  });
+
+  // Issue #97: postinstall script failure leaves the same partial-state shape
+  // as the hook-validation gate (#89) PLUS hooks already registered in
+  // settings.json (registerHooks runs before postinstall). Install must tear
+  // down both before returning.
+  test("postinstall failure rolls back symlinks AND unregisters hooks", async () => {
+    const filesTarget = join(env.paths.claudeRoot, "handlers", "Live.ts");
+    const repoUrl = await buildRepoWithProvides({
+      name: "PostinstallRollback",
+      extraFiles: { "handlers/Live.ts": "// live\n" },
+      providesFiles: [{ source: "handlers/Live.ts", target: filesTarget }],
+      providesCli: [{ command: "bun src/cli.ts", name: "postrollback" }],
+      providesHooks: [
+        { event: "Stop", command: "${PAI_DIR}/handlers/Live.ts" },
+      ],
+      postinstall: {
+        path: "scripts/postinstall.sh",
+        content: "#!/bin/bash\nexit 1\n",
+      },
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Postinstall script failed");
+
+    // Symlink rollback assertions (same shape as #89 hook-gate test).
+    expect(existsSync(join(env.paths.skillsDir, "PostinstallRollback"))).toBe(false);
+    expect(existsSync(filesTarget)).toBe(false);
+    expect(existsSync(join(env.paths.binDir, "postrollback"))).toBe(false);
+    expect(existsSync(join(env.paths.shimDir, "postrollback"))).toBe(false);
+
+    // Hook unregistration assertion: settings.json must NOT have a Stop entry
+    // tagged with this package name. (The file may exist from earlier
+    // registration but our package's group must be gone.)
+    if (existsSync(env.paths.settingsPath)) {
+      const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+      const stopHooks = settings.hooks?.Stop ?? [];
+      const ours = stopHooks.find(
+        (g: { _pai_pkg?: string }) => g._pai_pkg === "PostinstallRollback",
+      );
+      expect(ours).toBeUndefined();
+    }
+
+    // No DB row — recordInstall happens after postinstall.
+    const fromDb = getSkill(env.db, "PostinstallRollback");
+    expect(fromDb).toBeNull();
   });
 
   test("install succeeds when ${PAI_DIR} hook target is landed via provides.files", async () => {

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -650,17 +650,18 @@ describe("install provides.files (issue #84)", () => {
     expect(existsSync(join(env.paths.binDir, "postrollback"))).toBe(false);
     expect(existsSync(join(env.paths.shimDir, "postrollback"))).toBe(false);
 
-    // Hook unregistration assertion: settings.json must NOT have a Stop entry
-    // tagged with this package name. (The file may exist from earlier
-    // registration but our package's group must be gone.)
-    if (existsSync(env.paths.settingsPath)) {
-      const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
-      const stopHooks = settings.hooks?.Stop ?? [];
-      const ours = stopHooks.find(
-        (g: { _pai_pkg?: string }) => g._pai_pkg === "PostinstallRollback",
-      );
-      expect(ours).toBeUndefined();
-    }
+    // Hook unregistration assertion: settings.json was written by
+    // registerHooks earlier in the install flow, then the package's group
+    // was removed by removeHooks on postinstall failure. The file must
+    // exist (otherwise we'd be silently passing the assertion when
+    // registerHooks didn't run) AND not contain our group.
+    expect(existsSync(env.paths.settingsPath)).toBe(true);
+    const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    const stopHooks = settings.hooks?.Stop ?? [];
+    const ours = stopHooks.find(
+      (g: { _pai_pkg?: string }) => g._pai_pkg === "PostinstallRollback",
+    );
+    expect(ours).toBeUndefined();
 
     // No DB row — recordInstall happens after postinstall.
     const fromDb = getSkill(env.db, "PostinstallRollback");


### PR DESCRIPTION
## Summary

Closes #97.

Postinstall script failure left the same partial-state shape as the hook-validation gate (#89) **plus** hooks already registered in \`settings.json\` (\`registerHooks\` runs before postinstall). User got a cryptic \"Postinstall script failed\" return and a package whose:

- Per-type symlinks were placed.
- \`provides.files\` targets were placed.
- Hooks were registered in \`settings.json\`, pointing at the orphan.
- DB had no row (\`recordInstall\` happens AFTER postinstall).

## Changes

- **\`src/commands/install.ts\`** — at both postinstall-failure returns (\`install\` + \`installSingleArtifact\`), call \`removeHooks(name, settingsPath)\` followed by \`rollbackArtifactSymlinks(symlinkResult.record)\`. Order matters: settings.json stops referencing the symlinks first, then unlink. \`recordInstall\` hasn't happened yet at that point, so no DB cleanup needed.
- **\`src/lib/artifact-installer.ts\`** — extend the \`rollbackArtifactSymlinks\` JSDoc to document both call sites (hook gate vs. postinstall) and note that postinstall callers must pair the helper with \`removeHooks\`.

## Tests (test/commands/install.test.ts, +1)

\`buildRepoWithProvides\` extended with optional \`postinstall: {path, content}\`. New test installs a package whose postinstall exits 1, with full hook + \`provides.files\` + cli surface. Asserts:

- error contains \"Postinstall script failed\"
- skill dir, \`provides.files\` target, bin symlink, PATH shim all absent
- \`settings.json\` has no entry for the package
- no DB row

Strict superset of #89's hook-gate assertions.

Suite: 630/630 pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)