### PR TITLE
feat(arc-100): PackageBuilder § 12 - persona-driven agents + PublishBundle + AuthorPersonaAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.22.0
+
+### Added
+
+- `PackageBuilder` § 12: **Persona-Driven Agents (Authoring Convention)**. Codifies the four-layer split (persona / skill bundle / built bundle / instance state), bundle-and-persona decoupling, blueprint contents, composition rules, authority-via-host-primitives, two-phase gates for irreversible operations, conformance checklist, and instance-vs-bundle separation. Aligns with the metafactory agent-platform design at [`forge/design/agent-platform.md`](https://github.com/the-metafactory/forge/blob/main/design/agent-platform.md). Closes [arc#100](https://github.com/the-metafactory/arc/issues/100), pairs with [grove#230](https://github.com/the-metafactory/grove/issues/230), part of [mf#390](https://github.com/the-metafactory/meta-factory/issues/390) Phase 4.
+- New workflow `skill/Workflows/PublishBundle.md`: walks `arc bundle` -> `arc publish --dry-run` -> operator confirm -> `arc publish` -> `arc verify` round-trip. Two-phase gate at the dry-run step (halt for confirmation). Sha256 verification at the end; halt on mismatch.
+- New workflow `skill/Workflows/AuthorPersonaAgent.md`: six-step walk (decide new vs reusable, scaffold new bundles, write workflow MDs, write persona, write manifest, wire host, verify conformance) for composing a persona-driven agent on top of one or more existing skill bundles.
+- `triggers:` extended in `skill/SKILL.md` frontmatter with `author persona agent`, `persona-driven agent`, `compose blueprints`, `publish bundle`.
+
+### Notes
+
+- Docs-only release: no test suite covers SKILL.md or workflow markdown content. Existing `bun test` suite continues to pass; no behavior change in arc CLI.
+- Out of scope (post-MVP): manifest signing (SkillSeal), `arc install --type agent` runtime flow. Tracked separately under [the-metafactory/meta-factory#389](https://github.com/the-metafactory/meta-factory/issues/389).
+
 ## 0.21.0
 
 ### Added

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.21.1
+version: 0.22.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -13,6 +13,10 @@ triggers:
   - metafactory package
   - author-builder
   - package conventions
+  - author persona agent
+  - persona-driven agent
+  - compose blueprints
+  - publish bundle
 ---
 
 # PackageBuilder
@@ -41,6 +45,8 @@ Do NOT use this skill for:
 |----------|---------|------|
 | **CreatePackage** | "build package", "create package", "new package", "author-builder onramp" | `Workflows/CreatePackage.md` |
 | **SubmitPackage** | "submit package", "package review", "prepare for registry", "publish package" | `Workflows/SubmitPackage.md` |
+| **PublishBundle** | "publish bundle", "bundle and publish", "arc publish round-trip", "dry-run then publish" | `Workflows/PublishBundle.md` |
+| **AuthorPersonaAgent** | "author persona agent", "persona-driven agent", "compose blueprints into agent", "new agent on top of skills" | `Workflows/AuthorPersonaAgent.md` |
 
 When neither workflow is an exact match, use this skill's convention reference (below) to answer questions about specific conventions.
 
@@ -682,6 +688,163 @@ Before submitting your package, verify every item. Each is binary pass/fail.
 - [ ] PR includes arc manifest capability summary
 - [ ] Worktree was used (branch is not main)
 - [ ] Version bumped per versioning SOP
+
+---
+
+### 12. Persona-Driven Agents (Authoring Convention)
+
+A persona-driven agent is a thin voice and routing file that sits on top of one or more versioned skill bundles. The persona is what makes the agent recognisably itself; the skill bundles are how it actually does work. This section codifies the convention so any future agent author (Forge, Distiller, Backlogger, ...) inherits the same shape.
+
+The authoritative metafactory-level design is `forge/design/agent-platform.md`. Read it before authoring an agent, especially the manifest schema and the host-responsibilities section. This convention reference uses the same terminology (persona, blueprint, bundle, instance state) and is consistent with that doc. If anything here drifts from the design doc, the design doc wins.
+
+#### 12.1 The Four-Layer Layout
+
+A persona-driven agent is exactly four things, each with a clear owner and a clear lifetime.
+
+| Layer | What it is | Where it lives | Lifetime |
+|-------|-----------|----------------|----------|
+| **Persona** | Voice, judgment defaults, routing table, output rules, hard rules. Pure markdown. | Inside the agent bundle as `persona.md`. Host copies to `~/.config/<host>/personas/<name>.md` on install. | Bumps with the agent manifest version. |
+| **Skill bundle** (a.k.a. **blueprint**) | Procedure, scripts, workflow MDs, conventions. The HOW of one capability. | Its own arc-installable repo (`type: skill`). Installed at `~/.claude/skills/<name>/`. | Bumps with the skill bundle's own version, independent of any agent that uses it. |
+| **Bundle** (built artifact) | The tarball produced by `arc bundle` for either an agent or a skill. Content-addressed by sha256. Read-only after publish. | Local cache + the metafactory registry. | Immutable per `name@version`. |
+| **Instance state** | Live errands, dashboard, retros, env context. The WHAT-is-happening of one running agent on one host. | Per-host operator config: `~/.config/<host>/agents/<name>/`. Owned by the AgentState bundle. | Persists across uninstalls unless `--purge-state`. |
+
+The four layers compose in one direction only: instance state references a manifest, the manifest references bundles by name and version, a bundle ships a persona file. Information never flows back the other way. A bundle does not know which agents use it. A persona does not know which instance is running it.
+
+#### 12.2 Bundle / Persona Decoupling
+
+This is the lesson the metafactory got wrong twice before landing on the correct shape (grove#230). Internalise it:
+
+- A **persona references skills by name**, via the manifest's `blueprints[]` array. It does not import them, vendor them, or wrap them.
+- **Skills do not ship inside personas.** A persona file is a few hundred lines of markdown. A skill bundle is its own repo with its own version and its own publish cadence.
+- **Personas do not ship inside skill bundles.** A skill is reusable across many agents (e.g. `AgentState`, `PackageBuilder`); coupling it to one persona breaks reuse.
+
+The host wires persona and bundles together at install time by reading the manifest. The persona prompt context names the bundles it leans on; the host enforces `allowedSkills` against the same list.
+
+#### 12.3 Blueprint Contents
+
+A skill bundle (blueprint) is a single repo with a fixed shape. Workflows reference scripts by relative path so the bundle is portable across hosts.
+
+```
+my-skill/
+  arc-manifest.yaml            # type: skill
+  skill/
+    SKILL.md                   # entry point: triggers + workflow routing
+    Workflows/                  # one MD per discrete operation
+      DoOneThing.md
+      DoAnotherThing.md
+    scripts/                    # bun-runnable CLIs invoked by workflows
+      one-thing.ts
+      another-thing.ts
+    References/                 # optional domain knowledge docs
+    Templates/                  # optional template files
+  src/                          # if the skill also exposes library code
+  tests/
+  blueprint.yaml
+  CLAUDE.md
+```
+
+Workflow MDs reference scripts by **relative path from the skill root** (e.g. ``bun ./scripts/one-thing.ts --arg``) so a workflow file can be read in isolation and still find its tools. Hosts that run lifecycle hooks resolve those relative paths against the bundle install location (see `forge/design/agent-platform.md` host-responsibilities section, hook invocation contract).
+
+#### 12.4 Composition
+
+An agent leans on multiple skills; a skill is reused across multiple agents. **Compose, don't duplicate.**
+
+Forge (release agent) lists in its manifest:
+
+```yaml
+blueprints:
+  - name: ReleaseManager       # Forge-specific procedure
+    version: ">=0.1.0"
+  - name: AgentState           # shared across every persona-driven agent
+    version: ">=0.1.0"
+  - name: PackageBuilder       # shared with anyone authoring a package
+    version: ">=0.2.0"
+  - name: BlueprintTracker
+    version: ">=0.1.0"
+```
+
+`AgentState` and `PackageBuilder` are shared infrastructure; `ReleaseManager` is genuinely new domain logic that justifies its own bundle. Before authoring a new skill bundle, check the registry (`arc list`) for an existing one that already does what you need. Genuinely new domain logic gets its own bundle. Wrappers around existing skills do not.
+
+When two agents both need a capability, the capability moves into a shared bundle. When a bundle starts to carry persona-specific judgment, that judgment moves into the agent persona file. The boundary is: bundles are reusable procedure, personas are agent-specific voice.
+
+#### 12.5 Authority via Host Primitives
+
+Persona-driven agents declare authority **declaratively in the manifest**, and the host enforces it via its existing primitives. The persona file does not invent authority mechanisms.
+
+Manifest:
+
+```yaml
+guardrails:
+  allowedDirs: ["~/Developer/<repo-in-scope>"]
+  readOnlyDirs: ["~/Developer/compass"]
+  allowedSkills: ["ReleaseManager", "AgentState", "PackageBuilder"]
+  disallowedTools: ["Edit", "Write"]
+  bashAllowlist:
+    rules:
+      - pattern: "^gh\\s+"
+      - pattern: "^git\\s+"
+      - pattern: "^arc\\s+"
+```
+
+Grove's role-resolver projects these onto CC session flags (`--allowedDirs`, `--disallowed-tools`, `GROVE_ALLOWED_SKILLS`). Pilot will project them onto its own surface. The persona must not duplicate these as prose ("you may only run gh and git" type statements buried in the markdown), because that creates two sources of truth and they will drift.
+
+The persona file can refer to the guardrails ("you operate under the bashAllowlist declared in the manifest") but the source of truth is the manifest. If a guardrail is missing at runtime, that is a host bug (or a missing manifest field), not a prompt to fix.
+
+#### 12.6 Two-Phase Gates for Irreversible Operations
+
+Any operation that mutates shared state outside the agent's instance dir is a two-phase gate. **Each gate is its own workflow run** so the operator (or the upstream agent) can confirm between phases.
+
+Examples that MUST be two-phase:
+
+| Operation | Phase 1 (dry-run) | Phase 2 (commit) |
+|-----------|-------------------|-------------------|
+| Publish a bundle | `arc publish --dry-run` (echo sha256, scope, registry target) | `arc publish` |
+| Deploy a release | render diff + announce-message preview | `wrangler deploy` / `arc upgrade <repo>` |
+| Merge a PR | post review verdict + counts | `gh pr merge` |
+| Bump shared config | render diff against live config | apply diff |
+
+Each phase is a separate workflow file. The Phase 1 workflow ends by handing control back to the operator with a clear "ready to commit?" prompt. The Phase 2 workflow refuses to run if Phase 1 wasn't run in the same logical session (e.g. by checking that a dry-run sha256 was recorded).
+
+Anti-pattern: collapsing the two phases into one workflow with a `--yes` flag. The point of the gate is the human-in-the-loop pause; bypassing it via a flag defeats the design. `PublishBundle.md` is the canonical implementation.
+
+#### 12.7 Conformance Checklist
+
+Before publishing a persona-driven agent, every item below MUST pass.
+
+- [ ] Persona file is **<= 200 lines**. Longer than that and it is doing the work of a skill bundle; extract.
+- [ ] Persona file ships in the agent bundle (next to `arc-manifest.yaml`), not in any skill bundle.
+- [ ] Manifest declares `type: agent` and includes all eight required fields (`identity`, `persona`, `blueprints[]`, `guardrails`, `triggers[]`, `hooks`, `roster[]`, `instanceStateSpec`) per `forge/design/agent-platform.md`.
+- [ ] Every entry in the persona's routing table maps to an existing workflow in one of the listed `blueprints[]`. No dangling references.
+- [ ] No procedure is duplicated across two `blueprints[]`. If two leaned-on skills both implement the same step, the duplication moves into a shared bundle.
+- [ ] No authority declared in the persona file that isn't also in `guardrails`. The manifest is the source of truth.
+- [ ] `instanceStateSpec.blueprint` is set (almost always to `AgentState`).
+- [ ] All `blueprints[]` entries resolve via `arc install` on a clean machine.
+- [ ] `hooks.onStart` is set (typically `AgentState/ReplayPending`) so an in-flight queue is recovered after restart.
+- [ ] Manifest passes `arc validate` (when `arc validate` lands per AP-102).
+
+A persona that fails any of these is not yet a conformant agent. Fix the gap before publishing.
+
+#### 12.8 Instance vs Bundle Separation
+
+The bundle is read-only after `arc upgrade`; the instance state is per-operator and persists.
+
+| Concern | Bundle (read-only) | Instance state (per-operator) |
+|---------|--------------------|--------------------------------|
+| Persona markdown | `~/.claude/skills/<agent>/persona.md` (host-managed copy) | Operator override at `~/.config/<host>/personas/<agent>.md.local` |
+| Workflow MDs | `~/.claude/skills/<skill>/skill/Workflows/*.md` | n/a |
+| Scripts | `~/.claude/skills/<skill>/skill/scripts/*.ts` | n/a |
+| Errands queue | n/a | `~/.config/<host>/agents/<agent>/state.sqlite` |
+| Dashboard | n/a | `~/.config/<host>/agents/<agent>/dashboard.md` |
+| Retros | n/a | `~/.config/<host>/agents/<agent>/retros/` |
+| Per-instance prompt context | n/a | `~/.config/<host>/agents/<agent>/CLAUDE.md` (the bridge) |
+
+The `CLAUDE.md` in the instance folder is the **bridge** between the read-only bundle and the live state. It is the only place the agent gets to see "where am I, what is my current queue, what host am I running on" without crossing into mutation. The host writes it; the agent reads it.
+
+Anti-patterns:
+
+- Editing `persona.md` in the install location (the bundle copy). Host-managed; will be overwritten by the next `arc upgrade`. Use the `.md.local` sibling for env-specific tweaks.
+- Storing per-operator state inside a skill bundle. State has its own scope (`per-host` / `per-network` / `per-repo` per `instantiation.scope`); bundles are global.
+- Cross-instance state sharing through filesystem paths the agent invents. If two instances need to share state, that is a network-scope or repo-scope decision encoded in the manifest, not a path the persona writes.
 
 ---
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -705,7 +705,7 @@ A persona-driven agent is exactly four things, each with a clear owner and a cle
 |-------|-----------|----------------|----------|
 | **Persona** | Voice, judgment defaults, routing table, output rules, hard rules. Pure markdown. | Inside the agent bundle as `persona.md`. Host copies to `~/.config/<host>/personas/<name>.md` on install. | Bumps with the agent manifest version. |
 | **Skill bundle** (a.k.a. **blueprint**) | Procedure, scripts, workflow MDs, conventions. The HOW of one capability. | Its own arc-installable repo (`type: skill`). Installed at `~/.claude/skills/<name>/`. | Bumps with the skill bundle's own version, independent of any agent that uses it. |
-| **Bundle** (built artifact) | The tarball produced by `arc bundle` for either an agent or a skill. Content-addressed by sha256. Read-only after publish. | Local cache + the metafactory registry. | Immutable per `name@version`. |
+| **Manifest** | The single declarative artifact that names the agent's components and their wiring. References the persona file and pins skill bundles by name + version. The portable thing a host installs. | `arc-manifest.yaml` at the agent bundle root (`type: agent`). | Bumps with the agent itself; immutable per `name@version` once published. |
 | **Instance state** | Live errands, dashboard, retros, env context. The WHAT-is-happening of one running agent on one host. | Per-host operator config: `~/.config/<host>/agents/<name>/`. Owned by the AgentState bundle. | Persists across uninstalls unless `--purge-state`. |
 
 The four layers compose in one direction only: instance state references a manifest, the manifest references bundles by name and version, a bundle ships a persona file. Information never flows back the other way. A bundle does not know which agents use it. A persona does not know which instance is running it.
@@ -792,20 +792,20 @@ The persona file can refer to the guardrails ("you operate under the bashAllowli
 
 #### 12.6 Two-Phase Gates for Irreversible Operations
 
-Any operation that mutates shared state outside the agent's instance dir is a two-phase gate. **Each gate is its own workflow run** so the operator (or the upstream agent) can confirm between phases.
+Any operation that mutates shared state outside the agent's instance dir is a two-phase gate. **The workflow halts between phases** for an explicit operator confirmation (or upstream-agent confirmation in an agent-to-agent loop) before the irreversible step runs.
 
 Examples that MUST be two-phase:
 
 | Operation | Phase 1 (dry-run) | Phase 2 (commit) |
 |-----------|-------------------|-------------------|
-| Publish a bundle | `arc publish --dry-run` (echo sha256, scope, registry target) | `arc publish` |
+| Publish a bundle | `arc publish --dry-run` (echo sha256, scope) | `arc publish` |
 | Deploy a release | render diff + announce-message preview | `wrangler deploy` / `arc upgrade <repo>` |
 | Merge a PR | post review verdict + counts | `gh pr merge` |
 | Bump shared config | render diff against live config | apply diff |
 
-Each phase is a separate workflow file. The Phase 1 workflow ends by handing control back to the operator with a clear "ready to commit?" prompt. The Phase 2 workflow refuses to run if Phase 1 wasn't run in the same logical session (e.g. by checking that a dry-run sha256 was recorded).
+The implementation pattern is **one workflow file with discrete operator-confirmed steps**: a Phase 1 step that produces the dry-run artifact (sha256, diff, verdict, etc.) and ends with an explicit halt prompt; an operator-confirmation step that waits for an in-band yes/no; and a Phase 2 step that refuses to run unless the Phase 1 artifact (e.g. a recorded sha256) is present. The phases are gated by operator confirmation, not by file boundary. `PublishBundle.md` is the canonical implementation.
 
-Anti-pattern: collapsing the two phases into one workflow with a `--yes` flag. The point of the gate is the human-in-the-loop pause; bypassing it via a flag defeats the design. `PublishBundle.md` is the canonical implementation.
+Anti-pattern: collapsing the two phases into one command with a `--yes` flag, or skipping the confirmation halt. The point of the gate is the human-in-the-loop pause; bypassing it via a flag or a silent fall-through defeats the design.
 
 #### 12.7 Conformance Checklist
 
@@ -813,7 +813,7 @@ Before publishing a persona-driven agent, every item below MUST pass.
 
 - [ ] Persona file is **<= 200 lines**. Longer than that and it is doing the work of a skill bundle; extract.
 - [ ] Persona file ships in the agent bundle (next to `arc-manifest.yaml`), not in any skill bundle.
-- [ ] Manifest declares `type: agent` and includes all eight required fields (`identity`, `persona`, `blueprints[]`, `guardrails`, `triggers[]`, `hooks`, `roster[]`, `instanceStateSpec`) per `forge/design/agent-platform.md`.
+- [ ] Manifest declares `type: agent` and includes all nine required fields per `forge/design/agent-platform.md` (lines 159-171): `type`, `tier`, `identity`, `persona.file`, `blueprints[]`, `guardrails`, `triggers[]`, `instanceStateSpec`, `instantiation.scope`. (`hooks` and `roster[]` are recommended, not required — but `hooks.onStart` is asserted separately below.)
 - [ ] Every entry in the persona's routing table maps to an existing workflow in one of the listed `blueprints[]`. No dangling references.
 - [ ] No procedure is duplicated across two `blueprints[]`. If two leaned-on skills both implement the same step, the duplication moves into a shared bundle.
 - [ ] No authority declared in the persona file that isn't also in `guardrails`. The manifest is the source of truth.

--- a/skill/Workflows/AuthorPersonaAgent.md
+++ b/skill/Workflows/AuthorPersonaAgent.md
@@ -1,0 +1,270 @@
+# AuthorPersonaAgent Workflow
+
+> Walk an author end-to-end through composing a persona-driven agent on top of one or more existing skill bundles. The output is a `type: agent` arc package whose persona is a thin voice and routing file, and whose actual work is delegated to versioned skill bundles referenced by name.
+
+## When to Use
+
+Use this workflow when:
+
+- You are creating a new agent (e.g. Forge, Distiller, Backlogger, ...) on top of skill bundles that already exist (or that you will author alongside).
+- You are converting a hand-configured bot identity (e.g. a Grove `bot.yaml` entry) into a portable agent manifest.
+- You need a composition reference: which existing skill bundles do I lean on, what genuinely new bundle do I need to author?
+
+Do NOT use this workflow for:
+
+- Authoring a single skill bundle without a persona on top -- use `CreatePackage.md` instead.
+- Editing an existing agent's persona file (that is a normal source edit; no scaffolding needed).
+- Defining the agent platform itself -- see `forge/design/agent-platform.md` for the manifest schema and host responsibilities.
+
+The convention this workflow follows is documented in SKILL.md § 12 (Persona-Driven Agents). Read § 12 before starting; the four-layer split, the bundle/persona decoupling, and the conformance checklist are the rules this workflow enforces.
+
+## Prerequisites
+
+Before starting:
+
+- [ ] You have read SKILL.md § 12 (Persona-Driven Agents) and the manifest schema in `forge/design/agent-platform.md`.
+- [ ] You can name the agent and write a one-line description of what it does.
+- [ ] You can identify at least one trigger surface (Discord mention, CLI subcommand, cron, webhook).
+- [ ] You know which host(s) will instantiate the agent (Grove, pilot, ...). The manifest is host-agnostic, but knowing the target shapes the trigger and identity choices.
+
+---
+
+## Steps
+
+### 1. Decide What's New vs. Reusable
+
+**Action:** List every capability your agent needs. For each, decide: does an existing skill bundle already deliver it, or is it genuinely new domain logic?
+
+Run `arc list --type skill` to see what is already available. Common reusable bundles:
+
+| Bundle | What it provides |
+|--------|------------------|
+| `AgentState` | Per-instance errands queue, dashboard, retros, replay-on-restart. **Almost every persona-driven agent leans on this.** |
+| `PackageBuilder` | Authoring conformant arc-installable packages. Useful for any agent that itself authors or publishes packages. |
+| `BlueprintTracker` | Reading and updating `blueprint.yaml` feature graphs. Useful for any agent that drives feature work. |
+| `CodeReview` | Multi-lens PR review. Useful for review-loop agents (Echo, Luna). |
+
+If a capability is **already covered by an existing bundle**, list that bundle in your manifest's `blueprints[]`. Do not re-implement.
+
+If a capability is **genuinely new domain logic** (e.g. ReleaseManager's bump/tag/bundle/publish/deploy/announce sequence is specific to the release domain), it gets its own skill bundle. Author it via `CreatePackage.md` first, then come back to this workflow.
+
+**Verify:** You have a complete list of capabilities, each tagged either "existing bundle: `<name>`" or "new bundle: `<name>` (to author)".
+
+**Anti-pattern:** Wrapping an existing bundle in a new bundle "just to add some persona-specific tweaks". Persona-specific judgment goes in the persona file (Step 4); shared procedure stays in the existing bundle (SKILL.md § 12.4).
+
+### 2. Scaffold Any New Skill Bundle(s)
+
+**Action:** For each new bundle identified in Step 1, run the `CreatePackage` workflow to scaffold and author it. Each new bundle is its own arc-installable repo (typically its own GitHub repo) with `type: skill`.
+
+Each new bundle MUST follow the layout in SKILL.md § 12.3:
+
+```
+my-skill/
+  arc-manifest.yaml           # type: skill, version 0.1.0
+  skill/
+    SKILL.md                   # entry point
+    Workflows/                  # one MD per discrete operation
+    scripts/                    # bun-runnable CLIs
+  src/                          # if it also exposes library code
+  tests/
+  blueprint.yaml
+  CLAUDE.md
+```
+
+Bundle, publish, and verify each new skill via `PublishBundle.md` BEFORE wiring it into the agent. The agent manifest pins specific versions; you cannot pin a version that does not exist in the registry yet.
+
+**Verify:** Every bundle listed in your agent's `blueprints[]` is either already installable via `arc install <name>` or has been published in this step.
+
+**Anti-pattern:** Authoring the agent manifest first and "filling in the bundles later". The manifest's `blueprints[]` versions need to resolve at install time; missing bundles break the install on a clean machine.
+
+### 3. Write Workflow MDs in Each New Bundle
+
+**Action:** For each new skill bundle, write one workflow MD per discrete operation in `skill/Workflows/`.
+
+Every workflow MD follows the **Action / Verify / Anti-pattern** shape:
+
+- **Action**: imperative steps the agent executes (with concrete commands, not prose)
+- **Verify**: how the agent (or a reviewer) confirms the action succeeded -- specific, observable outcomes
+- **Anti-pattern**: what NOT to do at this step, and why
+
+Workflows reference scripts by **relative path from the skill root** so they are portable (e.g. `bun ./scripts/one-thing.ts --arg`). The host resolves the relative path against the bundle install location at runtime.
+
+If a workflow mutates shared state outside the agent's instance dir (publishes to a registry, deploys to a host, merges a PR, bumps a shared config), make it **two-phase** per SKILL.md § 12.6: a Phase 1 dry-run workflow that ends at a halt prompt, and a Phase 2 commit workflow that refuses to run without Phase 1's output.
+
+**Verify:** Every workflow file you reference in any persona's routing table (Step 4) actually exists and follows the Action/Verify/Anti-pattern shape.
+
+**Anti-pattern:** Vague workflow steps ("handle errors appropriately", "make sure things look right"). Every Verify item must be a binary pass/fail check.
+
+### 4. Write the Persona File
+
+**Action:** Write `persona.md` in the agent bundle root. This is the agent's voice, judgment defaults, routing table, output rules, and hard rules.
+
+**Cap the persona at ~200 lines** (conformance checklist § 12.7). Anything longer is doing the work of a skill bundle; extract it.
+
+The persona file SHOULD include:
+
+| Section | What goes here |
+|---------|----------------|
+| Identity | One paragraph: who is this agent, what does it do, why does it exist |
+| Voice | How the agent speaks (terse vs verbose, formal vs casual, signature phrases) |
+| Judgment defaults | Standing decisions the agent makes without re-asking (e.g. "always run dry-run before publish", "always cite the source design doc") |
+| Routing table | Maps incoming request patterns to a workflow file in one of the listed `blueprints[]` |
+| Output rules | What every response from this agent looks like (format, length, what to include / omit) |
+| Hard rules | Things the agent never does, even when asked (e.g. "never publish without operator confirm") |
+
+The persona file MUST NOT:
+
+- Duplicate authority that lives in the manifest's `guardrails`. The manifest is the source of truth (SKILL.md § 12.5). Reference it ("you operate under the bashAllowlist declared in the manifest"); do not restate it.
+- Reference workflows that are not in any `blueprints[]` listed in the manifest. Every routing-table entry must resolve.
+- Embed scripts or executable logic. The persona is markdown that the agent reads; procedure lives in the skill bundle's workflows and scripts.
+
+**The persona file ships in the agent bundle**, alongside `arc-manifest.yaml`. It does NOT ship in any skill bundle (SKILL.md § 12.2). The host copies it to `~/.config/<host>/personas/<name>.md` on install.
+
+**Verify:** Persona is <= 200 lines. Every routing-table entry maps to an existing workflow in a listed bundle. No authority is restated in prose.
+
+**Anti-pattern:** A 600-line persona that re-encodes everything the agent might do. That is not a persona; that is an unbundled skill. Extract it into a bundle.
+
+### 5. Write the Agent Manifest
+
+**Action:** Write `arc-manifest.yaml` at the agent bundle root with `type: agent` and the eight required fields per `forge/design/agent-platform.md`.
+
+Skeleton (replace placeholders; full schema in the design doc):
+
+```yaml
+schema: pai/v1
+type: agent
+namespace: metafactory                  # or your GitHub username for community tier
+name: <agent-name>
+version: 0.1.0
+tier: custom                            # custom | community | verified | official
+author:
+  name: <full-name>
+  github: <github-username>
+
+identity:
+  displayName: <Display Name>
+  shortName: <short-name>
+  oneLine: <one-line description>
+  channels:
+    discord:
+      botId: "<discord-bot-id>"          # if Discord-addressable
+      preferredChannels: ["#<channel>"]
+      dmEnabled: true|false
+    github:
+      login: <github-login>              # if GitHub-addressable
+      patScope: ["repo:status"]
+
+persona:
+  file: persona.md
+
+blueprints:
+  - name: <bundle-name>
+    version: ">=<min-version>"
+
+guardrails:
+  allowedDirs: []
+  readOnlyDirs: []
+  allowedSkills: [<list every bundle in blueprints[] above>]
+  disallowedTools: []
+  bashAllowlist:
+    rules:
+      - pattern: "^gh\\s+"
+      - pattern: "^git\\s+"
+
+triggers:
+  - type: mention
+    surface: discord
+    channelPattern: "#<pattern>"
+
+hooks:
+  onStart: AgentState/ReplayPending
+  onMessageAccepted: AgentState/EnqueueErrand
+  onMessageReplied: AgentState/MarkAckPosted
+  onError: AgentState/SnapshotError
+  onShutdown: AgentState/MarkPendingForReplay
+
+roster:
+  - name: <sibling-agent-name>
+    role: <role>
+
+instanceStateSpec:
+  blueprint: AgentState
+  version: ">=0.1.0"
+
+instantiation:
+  scope: per-host                        # per-host | per-network | per-repo
+```
+
+`guardrails.allowedSkills` MUST list every bundle declared in `blueprints[]` and nothing else. Mismatches between the two are a host-side denial waiting to happen.
+
+**Verify:** The manifest contains all eight required fields per `forge/design/agent-platform.md`. `arc bundle --dry-run` (or whatever pre-publish validation arc grows under AP-102) does not error.
+
+**Anti-pattern:** Inventing manifest fields not in the schema. Hosts read only the fields they understand; extra fields are silently dropped, and the operator gets surprised behavior. If the schema needs extending, that is a `forge/design/agent-platform.md` change first, not an in-manifest extension.
+
+### 6. Wire the Agent Into the Host
+
+**Action:** Make the agent reachable from the host(s) you target.
+
+Today, before AP-104 lands the `grove install agent <manifest>` adapter, this is a hand-mapping step. Use the worked example in `forge/design/agent-platform.md` (Grove integration section) as the guide. The mapping table there shows which manifest field becomes which `bot.yaml` field.
+
+Concretely for Grove (today, manual):
+
+1. Add an entry to `discord[]` in `~/.config/grove/bot.yaml` with the Discord bot ID and token (token stays out of the manifest -- secrets are operator config).
+2. Add a per-bot role under `discord[].roles[]` with the same `allowedSkills`, `allowedDirs`, `disallowedTools`, and `bashAllowlist` as the manifest's `guardrails`.
+3. Set `personaFile` to point at the persona path on disk (see G-905 -- Grove already supports this).
+4. If the agent will be addressable by other bots, add it to `trustedAgentBots` with the role binding.
+5. Reload the config or restart grove-bot per the AP-104 watcher rules (existing identities hot-reload; brand-new Discord identities require restart).
+
+When AP-104 lands, this step collapses to `grove install agent <bundle>`.
+
+For pilot (today): register the agent's CLI subcommand and point pilot at the manifest path. AP-105 will land the equivalent `pilot install agent` flow.
+
+**Verify:** From the host, send the agent a message via its declared trigger surface (Discord ping, CLI invocation, etc.). The agent responds in its persona voice. The response uses workflows from the listed bundles.
+
+**Anti-pattern:** Granting the agent broader authority on the host than the manifest declares. If `guardrails.disallowedTools` lists `Edit` and `Write`, the host's role config MUST also disallow them. Silent widening is a privilege-escalation finding (DD-16).
+
+### 7. Verify Conformance Against § 12.7
+
+**Action:** Walk the conformance checklist in SKILL.md § 12.7. Every item must pass.
+
+Re-paste it here for convenience; tick each:
+
+- [ ] Persona file is <= 200 lines.
+- [ ] Persona file ships in the agent bundle, not in any skill bundle.
+- [ ] Manifest declares `type: agent` and includes all eight required fields.
+- [ ] Every entry in the persona's routing table maps to an existing workflow in one of the listed `blueprints[]`. No dangling references.
+- [ ] No procedure is duplicated across two `blueprints[]`.
+- [ ] No authority declared in the persona file that isn't also in `guardrails`.
+- [ ] `instanceStateSpec.blueprint` is set.
+- [ ] All `blueprints[]` entries resolve via `arc install` on a clean machine.
+- [ ] `hooks.onStart` is set.
+- [ ] Manifest passes `arc validate` (when AP-102 lands).
+
+A failure on any item means the agent is not yet conformant. Fix the gap; do not publish until every item is green.
+
+**Verify:** Every checkbox is ticked. Where a check is currently un-runnable (e.g. `arc validate` not yet implemented), record that explicitly so it is not silently dropped.
+
+**Anti-pattern:** Publishing a non-conformant agent and "fixing it in the next version". A non-conformant agent in the registry teaches the next author bad shape; the convention only holds if every published agent honours it.
+
+---
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] Step 1: capability list has been triaged into existing-bundle vs new-bundle
+- [ ] Step 2: every new skill bundle exists, is published, and is installable on a clean machine
+- [ ] Step 3: every workflow file the persona routes to exists and follows Action/Verify/Anti-pattern
+- [ ] Step 4: persona file is <= 200 lines, lives in the agent bundle, restates no authority
+- [ ] Step 5: agent manifest has all eight required fields and is internally consistent (allowedSkills matches blueprints[])
+- [ ] Step 6: host has been wired (or `grove install agent` has run, post-AP-104) and the agent responds to its declared trigger
+- [ ] Step 7: § 12.7 conformance checklist is fully ticked
+
+## What NOT To Do
+
+- **Do not author the persona before the bundles exist.** The manifest must reference real, installable bundles; authoring top-down lands you with a manifest that does not resolve.
+- **Do not duplicate procedure between persona and bundle.** Procedure lives in workflows; the persona routes to them. SKILL.md § 12.4.
+- **Do not invent authority mechanisms in the persona.** Use host primitives via `guardrails`. SKILL.md § 12.5.
+- **Do not ship the persona inside a skill bundle.** Personas ship in the agent bundle; skills are reusable across agents. SKILL.md § 12.2.
+- **Do not skip the conformance checklist.** Every item is binary; every item matters. SKILL.md § 12.7.
+- **Do not extend the manifest schema in your manifest file.** Schema changes go through the agent-platform design doc (`forge/design/agent-platform.md`) first.

--- a/skill/Workflows/AuthorPersonaAgent.md
+++ b/skill/Workflows/AuthorPersonaAgent.md
@@ -126,7 +126,7 @@ The persona file MUST NOT:
 
 ### 5. Write the Agent Manifest
 
-**Action:** Write `arc-manifest.yaml` at the agent bundle root with `type: agent` and the eight required fields per `forge/design/agent-platform.md`.
+**Action:** Write `arc-manifest.yaml` at the agent bundle root with `type: agent` and the nine required fields per `forge/design/agent-platform.md` (lines 159-171): `type`, `tier`, `identity`, `persona.file`, `blueprints[]`, `guardrails`, `triggers[]`, `instanceStateSpec`, and `instantiation.scope`. `hooks` and `roster[]` are recommended (and the conformance checklist asserts `hooks.onStart` separately) but not required by the schema.
 
 Skeleton (replace placeholders; full schema in the design doc):
 
@@ -197,7 +197,7 @@ instantiation:
 
 `guardrails.allowedSkills` MUST list every bundle declared in `blueprints[]` and nothing else. Mismatches between the two are a host-side denial waiting to happen.
 
-**Verify:** The manifest contains all eight required fields per `forge/design/agent-platform.md`. `arc bundle --dry-run` (or whatever pre-publish validation arc grows under AP-102) does not error.
+**Verify:** The manifest contains all nine required fields per `forge/design/agent-platform.md` (lines 159-171). `arc bundle --dry-run` (or whatever pre-publish validation arc grows under AP-102) does not error.
 
 **Anti-pattern:** Inventing manifest fields not in the schema. Hosts read only the fields they understand; extra fields are silently dropped, and the operator gets surprised behavior. If the schema needs extending, that is a `forge/design/agent-platform.md` change first, not an in-manifest extension.
 
@@ -231,7 +231,7 @@ Re-paste it here for convenience; tick each:
 
 - [ ] Persona file is <= 200 lines.
 - [ ] Persona file ships in the agent bundle, not in any skill bundle.
-- [ ] Manifest declares `type: agent` and includes all eight required fields.
+- [ ] Manifest declares `type: agent` and includes all nine required fields per `forge/design/agent-platform.md`: `type`, `tier`, `identity`, `persona.file`, `blueprints[]`, `guardrails`, `triggers[]`, `instanceStateSpec`, `instantiation.scope`.
 - [ ] Every entry in the persona's routing table maps to an existing workflow in one of the listed `blueprints[]`. No dangling references.
 - [ ] No procedure is duplicated across two `blueprints[]`.
 - [ ] No authority declared in the persona file that isn't also in `guardrails`.
@@ -256,7 +256,7 @@ After completing all steps:
 - [ ] Step 2: every new skill bundle exists, is published, and is installable on a clean machine
 - [ ] Step 3: every workflow file the persona routes to exists and follows Action/Verify/Anti-pattern
 - [ ] Step 4: persona file is <= 200 lines, lives in the agent bundle, restates no authority
-- [ ] Step 5: agent manifest has all eight required fields and is internally consistent (allowedSkills matches blueprints[])
+- [ ] Step 5: agent manifest has all nine required fields per `forge/design/agent-platform.md` and is internally consistent (allowedSkills matches blueprints[])
 - [ ] Step 6: host has been wired (or `grove install agent` has run, post-AP-104) and the agent responds to its declared trigger
 - [ ] Step 7: § 12.7 conformance checklist is fully ticked
 

--- a/skill/Workflows/PublishBundle.md
+++ b/skill/Workflows/PublishBundle.md
@@ -1,0 +1,190 @@
+# PublishBundle Workflow
+
+> Publish a built arc bundle (skill, tool, agent, or other artifact type) to the metafactory registry through the `arc bundle -> arc publish --dry-run -> confirm -> arc publish -> arc verify` round-trip. Two-phase gate at the dry-run step; halt for explicit confirmation before mutating the registry.
+
+## When to Use
+
+Use this workflow when:
+
+- A package version has been bumped, the PR is merged, and the version needs to be in the registry.
+- You are publishing for the first time (initial release of a new package).
+- You are re-publishing after a fix-forward (new patch version of an existing package).
+
+Do NOT use this workflow for:
+
+- Local install testing -- use `arc install .` from the package root instead.
+- Drafting a release before the PR is merged -- bundle locally if you want to inspect the tarball, but do not publish until the version commit is on the default branch.
+- Deploying a cloud component -- publishing the bundle is one step; deploy is a separate workflow (see the deployment SOP for the relevant repo).
+
+This is a **two-phase gate** (per SKILL.md § 12.6). Phase 1 (`arc publish --dry-run`) and Phase 2 (`arc publish`) run as separate sub-steps with an explicit operator confirmation in between. Do not collapse them.
+
+## Prerequisites
+
+Before starting:
+
+- [ ] Working tree is clean (`git status` reports nothing uncommitted)
+- [ ] You are on the default branch with the merge commit that bumps the version (`git log -1 --pretty=%s` includes the version)
+- [ ] `arc-manifest.yaml` `version` field matches the release tag you intend to publish
+- [ ] `bun test` passes
+- [ ] You are logged in to the registry (`arc login` succeeded; bearer token is in your config)
+- [ ] You have write authority for the package's namespace (org member for `official`, sponsor lined up for `community`)
+
+---
+
+## Steps
+
+### 1. Pre-flight Verification
+
+**Action:** Confirm the working tree, version, and tag are all aligned.
+
+```bash
+git status                                    # must be clean
+git rev-parse --abbrev-ref HEAD               # must be the default branch
+git log -1 --pretty=%s                        # last commit subject
+grep "^version:" arc-manifest.yaml            # current manifest version
+```
+
+The version in `arc-manifest.yaml` must match the version you intend to publish. If the release SOP creates a tag at this point, also confirm the tag exists locally and on `origin`.
+
+**Verify:** Manifest version matches the merge commit. `git status` is clean. You are not on a feature branch.
+
+**Anti-pattern:** Publishing from a worktree branch. The published version must be reproducible from the default branch's commit; publishing off a branch creates an artifact that cannot be re-built later.
+
+### 2. Build the Bundle
+
+**Action:** Run `arc bundle` to produce the tarball.
+
+```bash
+arc bundle
+```
+
+Echo the resulting tarball path and size. Typical output:
+
+```
+Built ./dist/<name>-<version>.tgz (NN KB)
+```
+
+**Verify:** The tarball exists at the printed path. Its filename matches `<name>-<version>.tgz` where `<name>` and `<version>` come from `arc-manifest.yaml`. The size is non-zero and within the expected order of magnitude (a typical skill bundle is 10-200 KB; a tool bundle with a vendored binary may be larger).
+
+**Anti-pattern:** Re-running `arc bundle` repeatedly without checking the output between runs. The bundle is content-addressed; if you change anything between Phase 1 and Phase 2, the sha256 will not match.
+
+### 3. Phase 1 -- `arc publish --dry-run` (HALT FOR CONFIRMATION)
+
+**Action:** Run `arc publish` with the dry-run flag. Capture and display the dry-run summary.
+
+```bash
+arc publish --dry-run
+```
+
+Expected output includes:
+
+- `name`: the package name
+- `version`: the version about to be published
+- `scope` / `namespace`: where the package will land
+- `registry target`: the registry URL it will be pushed to
+- `sha256`: the bundle's content hash
+- `capabilities` summary: what the package declares it needs
+
+**Echo all of the above back to the operator verbatim.** Then write a clear, single-line halt prompt:
+
+> **HALT.** Bundle ready for publish: `<name>@<version>` -> `<registry-target>` (sha256 `<first-12-chars>...`). Confirm publish? (yes / no)
+
+**Verify:** The dry-run completed without errors. The sha256 is recorded (write it down, copy it to a scratch buffer, or paste it into the chat). The registry target matches the intended destination.
+
+**Anti-pattern:** Skipping the dry-run because "I just did it last time". The dry-run is what gives you the sha256 and the scope confirmation; skipping it makes Step 6's verification impossible.
+
+### 4. Operator Confirmation
+
+**Action:** Wait for explicit confirmation from the operator (or the upstream agent in an agent-to-agent loop).
+
+Acceptable confirmations: `yes`, `confirm`, `proceed`, `ship it`. Anything else (including ambiguous responses) is a deny.
+
+If the operator denies:
+
+- Do not publish.
+- If they want to abort entirely, exit cleanly. The dry-run made no mutations; nothing to roll back.
+- If they want to make a change first, exit and let them re-run the upstream workflow (likely a version-bump fix or a manifest edit). Do not loop back to Step 2 within this workflow run -- the gate is the gate.
+
+If the operator confirms, proceed to Step 5.
+
+**Verify:** A clear, in-band confirmation was received. It was not inferred from silence or from a non-committal phrase like "looks fine".
+
+**Anti-pattern:** Treating "looks fine" as confirmation. The publish is irreversible (DD-14, content-addressed immutable storage); the gate exists precisely to prevent ambiguous greenlights.
+
+### 5. Phase 2 -- `arc publish` (Real Publish)
+
+**Action:** Run `arc publish` for real.
+
+```bash
+arc publish
+```
+
+Capture the output. Note the published bundle's sha256 -- it should match the sha256 from Step 3. If the registry returns a URL or a registry-side identifier, capture that too.
+
+**Verify:** The publish returns a success exit code. The output reports the same `name`, `version`, and `sha256` as Step 3.
+
+**Anti-pattern:** Re-running `arc publish` if the first attempt errors out without checking what state the registry is in. A partial publish may have already registered the version; re-publishing the same version is rejected by content-addressed storage. If you see an error, **read it** before retrying.
+
+### 6. Verify the Round-Trip
+
+**Action:** Confirm the published bundle on the registry has the same sha256 as the local bundle from Step 3.
+
+```bash
+arc verify <name>@<version>
+```
+
+(`arc verify` resolves the package version against the registry, downloads the bundle metadata, and reports the registered sha256.)
+
+Compare the registered sha256 against the sha256 from Step 3. They MUST be identical.
+
+**If they match:** the round-trip is verified. Proceed to Step 7.
+
+**If they do not match: HALT.** This is a content-integrity failure. Do not announce. Do not promote. Do not rebuild and re-publish to "make it match" -- the registry has now recorded a sha256 that you do not control. Escalate to the metafactory steward.
+
+**Verify:** sha256 from Step 3 == sha256 from Step 6. Both bytewise equal.
+
+**Anti-pattern:** Announcing the publish before the verify step succeeds. If the sha256s don't match, you have just told the world a bundle is live that doesn't match what you built locally -- a supply-chain incident in slow motion.
+
+### 7. Announce
+
+**Action:** Post a one-liner to the relevant channel announcing the published version.
+
+The announce message should include:
+
+- Package name and version
+- The registry URL or registry-side identifier from Step 5
+- The sha256 (first 12 characters is enough for human eyes)
+- A link to the release notes or CHANGELOG entry
+
+Example:
+
+> Published `Forge@0.1.0` to https://registry.metafactory.example/forge -- sha256 `a7f2c8e1d4b9...` -- notes: https://github.com/the-metafactory/forge/releases/tag/v0.1.0
+
+If the package is a host-deployable component (Grove, Pulse, etc.), the announce step also signals the deploy step is unblocked. The actual deploy is a separate workflow (see deployment SOP).
+
+**Verify:** The announcement is posted. The links in it resolve.
+
+**Anti-pattern:** Skipping the announce. Even a one-liner matters: the team needs to know the version is live before they can install or deploy from it.
+
+---
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] Pre-flight: working tree clean, on default branch, manifest version matches intended release
+- [ ] `arc bundle` produced a tarball at the expected path
+- [ ] `arc publish --dry-run` ran successfully and the sha256 was recorded
+- [ ] Operator confirmation was explicit and in-band
+- [ ] `arc publish` returned success and the same sha256 as the dry-run
+- [ ] `arc verify` returned the same sha256 as both the dry-run and the publish
+- [ ] An announcement was posted with the registry URL and sha256
+
+## What NOT To Do
+
+- **Do not skip the dry-run.** It is the only thing that gives you the sha256 to verify against in Step 6.
+- **Do not proceed past a sha256 mismatch in Step 6.** A mismatch is a supply-chain integrity failure. Escalate; do not paper over it by re-bundling.
+- **Do not collapse Phase 1 and Phase 2 into a single command** (e.g. by adding a `--yes` flag to `arc publish`). The two-phase gate exists for the human-in-the-loop pause; bypassing it defeats the design (SKILL.md § 12.6).
+- **Do not publish from a feature branch.** The published version must trace to a commit on the default branch.
+- **Do not re-publish the same version with different content.** Content-addressed storage rejects this (DD-14). If you need to fix-forward, bump the patch version and republish.
+- **Do not announce before Step 6 passes.** Announcing a publish whose sha256 you have not verified is announcing a bundle you do not control.

--- a/skill/Workflows/PublishBundle.md
+++ b/skill/Workflows/PublishBundle.md
@@ -1,6 +1,6 @@
 # PublishBundle Workflow
 
-> Publish a built arc bundle (skill, tool, agent, or other artifact type) to the metafactory registry through the `arc bundle -> arc publish --dry-run -> confirm -> arc publish -> arc verify` round-trip. Two-phase gate at the dry-run step; halt for explicit confirmation before mutating the registry.
+> Publish a built arc bundle (skill, tool, agent, or other artifact type) to the metafactory registry through the `arc bundle -> arc publish --dry-run -> confirm -> arc publish -> registry sha256 round-trip` flow. Two-phase gate at the dry-run step; halt for explicit confirmation before mutating the registry. The post-publish round-trip is manual today (registry GET + sha256 compare); a first-class `arc verify <name>@<version>` is tracked under AP-102 -- see Step 6.
 
 ## When to Use
 
@@ -76,20 +76,21 @@ Built ./dist/<name>-<version>.tgz (NN KB)
 arc publish --dry-run
 ```
 
-Expected output includes:
+Expected output (per `arc/src/commands/publish.ts` `formatPublish`, lines 150-156) is exactly:
 
-- `name`: the package name
-- `version`: the version about to be published
-- `scope` / `namespace`: where the package will land
-- `registry target`: the registry URL it will be pushed to
-- `sha256`: the bundle's content hash
-- `capabilities` summary: what the package declares it needs
+```
+[DRY RUN] Would publish @<scope>/<name> v<version>
+  SHA-256:  <sha256>
+  Source:   <source-name>
+```
 
-**Echo all of the above back to the operator verbatim.** Then write a clear, single-line halt prompt:
+So the dry-run gives you exactly five facts: the **scope**, the **name**, the **version**, the **sha256** of the tarball, and the configured **source** (the registry the publish will target). It does not include a registry URL line or a capabilities summary -- if you need those, derive them from `arc-manifest.yaml` and your local `~/.config/arc/sources.yaml` before the halt.
 
-> **HALT.** Bundle ready for publish: `<name>@<version>` -> `<registry-target>` (sha256 `<first-12-chars>...`). Confirm publish? (yes / no)
+**Echo the dry-run output back to the operator verbatim.** Then write a clear, single-line halt prompt:
 
-**Verify:** The dry-run completed without errors. The sha256 is recorded (write it down, copy it to a scratch buffer, or paste it into the chat). The registry target matches the intended destination.
+> **HALT.** Bundle ready for publish: `@<scope>/<name>@<version>` -> source `<source-name>` (sha256 `<first-12-chars>...`). Confirm publish? (yes / no)
+
+**Verify:** The dry-run completed without errors. The sha256 is recorded (write it down, copy it to a scratch buffer, or paste it into the chat). The scope and source match the intended destination.
 
 **Anti-pattern:** Skipping the dry-run because "I just did it last time". The dry-run is what gives you the sha256 and the scope confirmation; skipping it makes Step 6's verification impossible.
 
@@ -97,7 +98,7 @@ Expected output includes:
 
 **Action:** Wait for explicit confirmation from the operator (or the upstream agent in an agent-to-agent loop).
 
-Acceptable confirmations: `yes`, `confirm`, `proceed`, `ship it`. Anything else (including ambiguous responses) is a deny.
+Acceptable confirmations: any clearly affirmative response -- "yes", "confirm", "proceed", "ship it", "do it", "go", and obvious paraphrases ("yeah do it", "approved"). The bar is intent, not a literal token match. Ambiguous, hedged, or non-committal responses ("looks fine", "sure I guess", "lgtm but...") are a deny -- if you cannot honestly summarise the response as "the operator unambiguously said yes", treat it as no.
 
 If the operator denies:
 
@@ -129,21 +130,41 @@ Capture the output. Note the published bundle's sha256 -- it should match the sh
 
 **Action:** Confirm the published bundle on the registry has the same sha256 as the local bundle from Step 3.
 
-```bash
-arc verify <name>@<version>
-```
+> **Capability gap (today):** `arc verify` does NOT do this. The current `arc verify <name>` command (see `arc/src/commands/verify.ts`) takes a package name only -- no `@version` -- and checks the integrity of an *installed* skill (repo dir present, `arc-manifest.yaml` parses, symlink valid, git tree clean, hook command paths resolve). It is not a registry round-trip. A first-class `arc verify <name>@<version>` registry-integrity command is the right home for this gate and is tracked under **AP-102** (pre-publish + post-publish validation). Until AP-102 lands, do the round-trip manually as described below.
 
-(`arc verify` resolves the package version against the registry, downloads the bundle metadata, and reports the registered sha256.)
+**Manual round-trip (today):**
 
-Compare the registered sha256 against the sha256 from Step 3. They MUST be identical.
+1. Resolve the published version against the registry. The registry exposes per-version detail at `<source.url>/api/v1/packages/@<scope>/<name>@<version>`, which returns a JSON body that includes the registered `sha256` (see `arc/src/lib/registry-install.ts:81-105` for the exact request shape that `arc install` already uses).
+
+   ```bash
+   curl -fsS -H 'Accept: application/json' \
+     "<source-url>/api/v1/packages/@<scope>/<name>@<version>" \
+     | jq -r .sha256
+   ```
+
+   `<source-url>` is the configured source URL for the registry you published to (in `~/.config/arc/sources.yaml`). `<scope>` and `<name>` come from `arc-manifest.yaml`.
+
+2. Compare the registered sha256 against the sha256 from Step 3. They MUST be byte-for-byte identical.
+
+3. (Optional but recommended) Re-download the tarball at `<source-url>/api/v1/storage/download/<sha256>` and recompute its sha256 locally to confirm storage integrity end-to-end:
+
+   ```bash
+   curl -fsS -o /tmp/<name>-<version>.tgz \
+     "<source-url>/api/v1/storage/download/<sha256-from-registry>"
+   shasum -a 256 /tmp/<name>-<version>.tgz
+   ```
+
+   The locally-recomputed sha256 must equal both the registry-reported sha256 AND the Step 3 sha256.
+
+**Once AP-102 lands:** this whole step collapses to `arc verify <name>@<version>`, which performs the registry GET, the (optional) re-download, and the sha256 compare in one command and exits non-zero on mismatch.
 
 **If they match:** the round-trip is verified. Proceed to Step 7.
 
 **If they do not match: HALT.** This is a content-integrity failure. Do not announce. Do not promote. Do not rebuild and re-publish to "make it match" -- the registry has now recorded a sha256 that you do not control. Escalate to the metafactory steward.
 
-**Verify:** sha256 from Step 3 == sha256 from Step 6. Both bytewise equal.
+**Verify:** sha256 from Step 3 == sha256 from the registry GET (and, if you did the re-download, == sha256 of the re-downloaded tarball). All three bytewise equal.
 
-**Anti-pattern:** Announcing the publish before the verify step succeeds. If the sha256s don't match, you have just told the world a bundle is live that doesn't match what you built locally -- a supply-chain incident in slow motion.
+**Anti-pattern:** Announcing the publish before the verify step succeeds. If the sha256s don't match, you have just told the world a bundle is live that doesn't match what you built locally -- a supply-chain incident in slow motion. The other anti-pattern is calling `arc verify <name>` (no `@version`) and treating its "all checks passed" output as a round-trip pass: it is not -- it only confirms a *previously-installed* copy of the skill is intact on disk, not that the published artifact matches the local build.
 
 ### 7. Announce
 
@@ -177,7 +198,7 @@ After completing all steps:
 - [ ] `arc publish --dry-run` ran successfully and the sha256 was recorded
 - [ ] Operator confirmation was explicit and in-band
 - [ ] `arc publish` returned success and the same sha256 as the dry-run
-- [ ] `arc verify` returned the same sha256 as both the dry-run and the publish
+- [ ] Registry round-trip (manual today: `curl ... /api/v1/packages/@<scope>/<name>@<version>` → `.sha256`; AP-102 will collapse this to `arc verify <name>@<version>`) returned the same sha256 as both the dry-run and the publish
 - [ ] An announcement was posted with the registry URL and sha256
 
 ## What NOT To Do


### PR DESCRIPTION
## Summary

Adds the persona-driven-agent authoring convention to the `PackageBuilder` skill (new SKILL.md § 12), plus two new workflows:

- **`skill/Workflows/PublishBundle.md`** - sibling of `CreatePackage.md` and `SubmitPackage.md`. Walks `arc bundle` -> `arc publish --dry-run` -> operator confirm -> `arc publish` -> `arc verify`. Two-phase gate at the dry-run step (halt for confirmation). Sha256 verification at the end (halt on mismatch).
- **`skill/Workflows/AuthorPersonaAgent.md`** - six-step walk for authors composing a persona-driven agent on top of one or more existing skill bundles.

## Why

This is the paired arc-side work for [grove#230](https://github.com/the-metafactory/grove/issues/230) (Forge release agent), but lands as standalone arc convention so any future agent author (Forge, Distiller, Backlogger) inherits the same shape. Convention is encoded in `PackageBuilder` because that is the skill every author already loads when building a metafactory package; § 12 plugs in next to the existing eleven sections without disrupting them.

Terminology and the four-layer split (persona / skill bundle / built bundle / instance state) follow `forge/design/agent-platform.md` exactly. Where arc#100's prose conflicts with the design doc, the design doc wins (§ 12 explicitly notes this).

## Cross-references

- Closes [the-metafactory/arc#100](https://github.com/the-metafactory/arc/issues/100)
- Pairs with [the-metafactory/grove#230](https://github.com/the-metafactory/grove/issues/230) (Forge release agent design - the worked example that drove this convention)
- Phase 4 of [the-metafactory/meta-factory#390](https://github.com/the-metafactory/meta-factory/issues/390) (agent platform iteration plan)
- Refs [the-metafactory/meta-factory#389](https://github.com/the-metafactory/meta-factory/issues/389) (manifest schema design-of-record)
- Authoritative design: [`forge/design/agent-platform.md`](https://github.com/the-metafactory/forge/blob/main/design/agent-platform.md)

## In scope

- [x] `skill/SKILL.md` § 12 with all eight subsections (12.1 four-layer layout, 12.2 bundle/persona decoupling, 12.3 blueprint contents, 12.4 composition, 12.5 authority via host primitives, 12.6 two-phase gates, 12.7 conformance checklist, 12.8 instance vs bundle)
- [x] `skill/Workflows/PublishBundle.md` with the dry-run + sha256 verification discipline
- [x] `skill/Workflows/AuthorPersonaAgent.md` with the six-step walk
- [x] `triggers:` extended in `skill/SKILL.md` frontmatter (`author persona agent`, `persona-driven agent`, `compose blueprints`, `publish bundle`)
- [x] Workflow Routing table extended with both new workflows
- [x] `arc-manifest.yaml`: `0.21.1` -> `0.22.0` (additive convention, minor bump)
- [x] `CHANGELOG.md`: 0.22.0 entry

## Out of scope (post-MVP, per arc#100 body)

- Manifest signing (SkillSeal) for `tier: verified` and above
- The `arc install --type agent` runtime flow
- Both tracked under [the-metafactory/meta-factory#389](https://github.com/the-metafactory/meta-factory/issues/389) and Phase 4 / Phase 5 of [the-metafactory/meta-factory#390](https://github.com/the-metafactory/meta-factory/issues/390)

## Test plan

- [x] `bun install` succeeds
- [x] `bun test` - 630 pass / 0 fail (full suite, no regression). The arc test suite covers manifest validation, install, registry, publish, hooks - none of it exercises SKILL.md or workflow markdown content. This is a docs-heavy convention PR with no behavior change to the arc CLI, so no new test coverage was added. The existing suite acts as a regression gate.
- [x] No em-dashes in any new content (per the SKILL.md anti-pattern in § 9)
- [x] Conformance checklist in § 12.7 cross-checked against the AuthorPersonaAgent step 7 checklist (they match item-for-item)

## Notes for review (Echo)

Echo: § 12.1 (four-layer layout table) and § 12.2 (bundle/persona decoupling) are the load-bearing parts of the convention - they are what every future agent author internalises first. Heaviest review weight should land there. The wording was chosen to match `forge/design/agent-platform.md` terminology exactly so the convention does not introduce new vocabulary; flag any drift you spot.

The two-phase gate language in § 12.6 and `PublishBundle.md` is the second-most load-bearing - if the gate description is sloppy, agents will collapse the two phases and we lose the human-in-the-loop pause.