### PR TITLE
feat(arc-102): install for type:agent bundles — closes #102, Phase 9.1 of mf#392

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -846,6 +846,46 @@ Anti-patterns:
 - Storing per-operator state inside a skill bundle. State has its own scope (`per-host` / `per-network` / `per-repo` per `instantiation.scope`); bundles are global.
 - Cross-instance state sharing through filesystem paths the agent invents. If two instances need to share state, that is a network-scope or repo-scope decision encoded in the manifest, not a path the persona writes.
 
+#### 12.9 Installing a Persona-Driven Agent (arc#102)
+
+Once a persona-driven agent bundle conforms to § 12.7, it installs through arc the same way a skill bundle does. The git-URL path is the canonical entry point for Phase 9.1; registry-resolved name install (`arc install <name>`) follows once the agent is published.
+
+**From a git URL:**
+
+```bash
+arc install https://github.com/the-metafactory/<agent-repo> -y
+```
+
+What arc does:
+
+1. Clones the repo to `~/.config/metafactory/pkg/repos/<repo-name>/`.
+2. Reads `arc-manifest.yaml` from the bundle root. If no root manifest is present, falls back to `<repo>/agent/arc-manifest.yaml` — but only when the nested manifest declares `type: agent`. The fallback exists so source repos that nest the agent files under `agent/` (e.g. forge: `agent/{persona.md, scaffold-instance.sh, CLAUDE.md, arc-manifest.yaml}`) install cleanly without forcing a layout migration. Skills/tools/etc. continue to require the manifest at the repo root.
+3. Validates the manifest. For `type: agent`, the `capabilities` block is **optional** — persona-driven agents declare authority via `guardrails`, and the host enforces it through its own primitives (`allowedDirs`, `disallowedTools`, `bashAllowlist`). Authoring a `capabilities` block on an agent manifest is allowed for forward compatibility but is not required.
+4. Records the install in `packages.db` with `artifact_type: agent` so `arc list --type agent` and host-side discovery can find it.
+5. Creates a convenience symlink under `~/.claude/agents/<name>` pointing at the bundle. Persona-driven hosts (grove, pilot) read the bundle directly from `~/.config/metafactory/pkg/repos/<name>/`; the symlink is for legacy single-file agent discovery.
+
+**What arc does NOT do (host responsibility):**
+
+- Copy `persona.md` to `~/.config/<host>/personas/<name>.md`. That belongs to the host install step (`grove install agent <name>`, etc.) per `forge/design/agent-platform.md` § "Instantiation flow".
+- Wire the agent into a host's adapter config (Discord bot ID, GitHub login, mention pattern). The host derives those from the manifest's `identity` block.
+- Install the bundles named in `blueprints[]`. The host (or operator) runs `arc install <bundle>` for each before installing the agent — see § "Instantiation flow" step 3 in `forge/design/agent-platform.md`.
+
+**Verifying the install:**
+
+```bash
+# Bundle landed at canonical reposDir
+ls ~/.config/metafactory/pkg/repos/<repo-name>/
+
+# Manifest is readable (root, or under agent/ for nested-source repos)
+cat ~/.config/metafactory/pkg/repos/<repo-name>/arc-manifest.yaml \
+  || cat ~/.config/metafactory/pkg/repos/<repo-name>/agent/arc-manifest.yaml
+
+# DB row exists with artifact_type: agent
+arc list --type agent
+```
+
+After this verification passes, the agent is ready for the host install step.
+
 ---
 
 ## Quick Reference

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -15,11 +15,46 @@ export const MANIFEST_FILENAMES = [MANIFEST_FILENAME, LEGACY_MANIFEST_FILENAME] 
 /**
  * Read and parse an arc-manifest.yaml (or legacy pai-manifest.yaml) from a directory.
  * Prefers arc-manifest.yaml; falls back to pai-manifest.yaml.
- * Returns null if neither file exists.
- * Throws if a file exists but is invalid.
+ *
+ * Search order (arc#102):
+ *   1. <dir>/arc-manifest.yaml
+ *   2. <dir>/pai-manifest.yaml          (legacy)
+ *   3. <dir>/agent/arc-manifest.yaml    (persona-driven-agent bundles whose
+ *                                        source repo nests the agent files
+ *                                        under agent/, e.g. the-metafactory/forge)
+ *   4. <dir>/agent/pai-manifest.yaml
+ *
+ * Falling back into agent/ is gated to a manifest whose `type` is `agent`
+ * — we never silently install something under a non-canonical layout for
+ * other artifact types. Returns null if no manifest exists. Throws if a
+ * file exists but is invalid.
  */
 export async function readManifest(
   dir: string
+): Promise<ArcManifest | null> {
+  // Try root first (the canonical location for every artifact type).
+  const rootResult = await readManifestFromDir(dir);
+  if (rootResult) return rootResult;
+
+  // Fallback: agent/<manifest> for persona-driven-agent source repos that
+  // ship the agent files under agent/ at the repo root (forge layout).
+  // Only honor the fallback when the manifest declares type: agent —
+  // skills/tools/prompts must continue to fail at the root if missing.
+  const agentDir = join(dir, "agent");
+  const agentResult = await readManifestFromDir(agentDir);
+  if (agentResult && agentResult.type === "agent") {
+    return agentResult;
+  }
+  return null;
+}
+
+/**
+ * Read a manifest from a single directory. Returns null if neither
+ * arc-manifest.yaml nor pai-manifest.yaml is present in that directory.
+ * Throws if a file is present but malformed.
+ */
+async function readManifestFromDir(
+  dir: string,
 ): Promise<ArcManifest | null> {
   for (const filename of MANIFEST_FILENAMES) {
     const manifestPath = join(dir, filename);
@@ -39,12 +74,21 @@ export async function readManifest(
         return parsed;
       }
 
-      // capabilities optional for component and rules types, required for others
-      if (!parsed.capabilities && parsed.type !== "component" && parsed.type !== "rules") {
+      // capabilities optional for component, rules, and agent types, required for others.
+      // Persona-driven agents (arc#100 §12 / arc#102) declare authority via
+      // `guardrails` instead of `capabilities` — the host enforces guardrails
+      // through its own primitives (allowedDirs, disallowedTools, bashAllowlist),
+      // so the per-package capabilities block does not apply.
+      if (
+        !parsed.capabilities &&
+        parsed.type !== "component" &&
+        parsed.type !== "rules" &&
+        parsed.type !== "agent"
+      ) {
         throw new Error(
           [
             `Invalid ${filename}: missing required field 'capabilities'`,
-            `Required for type: skill, tool, agent, prompt, pipeline, system (optional only for: component, rules).`,
+            `Required for type: skill, tool, prompt, pipeline, system (optional only for: component, rules, agent).`,
             ``,
             `Minimal example:`,
             ``,

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -236,6 +236,211 @@ describe("install command", () => {
     expect(getSkill(env.db, "A_DISCOVER_REPOS")).toBeNull();
   });
 
+  // arc#102 Phase 9.1 — type:agent install (git-URL path).
+  test("installs canonical agent bundle (manifest at root, persona at agent/<name>.md)", async () => {
+    const repo = await createMockSkillRepo(env.root, {
+      name: "TestAgent",
+      type: "agent",
+    });
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl: repo.url,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("TestAgent");
+
+    // Bundle landed at the canonical reposDir path (the user-facing
+    // contract from arc#102: `~/.config/metafactory/pkg/repos/<name>/`).
+    const repoDir = join(env.paths.reposDir, "mock-TestAgent");
+    expect(existsSync(repoDir)).toBe(true);
+    expect(existsSync(join(repoDir, "arc-manifest.yaml"))).toBe(true);
+
+    // DB row records the artifact_type so subsequent `arc list --type agent`
+    // and host-side discovery can find this install.
+    const skill = getSkill(env.db, "TestAgent");
+    expect(skill).not.toBeNull();
+    expect(skill!.artifact_type).toBe("agent");
+    expect(skill!.status).toBe("active");
+
+    // Symlink convenience: createArtifactSymlinks landed something under
+    // agentsDir for legacy single-file discovery. The persona-driven
+    // contract owned by the host (grove) does not depend on this, but
+    // we keep the link-shape check so future regressions to the
+    // artifact-installer agent case surface here.
+    expect(existsSync(join(env.paths.agentsDir, "TestAgent.md"))).toBe(true);
+  });
+
+  // Persona-driven agent shape (arc#100 § 12) — no `capabilities` block.
+  // Authority is declared in `guardrails`; the host enforces. Install
+  // must succeed without forcing the publisher to declare capabilities.
+  test("installs agent bundle without capabilities (persona-driven shape)", async () => {
+    const repoDir = join(env.root, "mock-PersonaAgent");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(join(repoDir, "agent"), { recursive: true });
+    await writeFile(
+      join(repoDir, "agent", "persona.md"),
+      `# PersonaAgent\n\nVoice file. Host copies this to ~/.config/<host>/personas/<name>.md on install.\n`,
+    );
+    await writeFile(
+      join(repoDir, "arc-manifest.yaml"),
+      [
+        `schema: pai/v1`,
+        `name: PersonaAgent`,
+        `version: 0.1.0`,
+        `type: agent`,
+        `tier: custom`,
+        `description: Persona-driven agent (no capabilities block)`,
+        `author:`,
+        `  name: testuser`,
+        `  github: testuser`,
+        `persona:`,
+        `  file: agent/persona.md`,
+        `guardrails:`,
+        `  allowedDirs:`,
+        `    - "~/Developer/scope"`,
+        `  disallowedTools:`,
+        `    - Edit`,
+        ``,
+      ].join("\n"),
+    );
+    Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=t@t.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl: repoDir,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("PersonaAgent");
+
+    const skill = getSkill(env.db, "PersonaAgent");
+    expect(skill).not.toBeNull();
+    expect(skill!.artifact_type).toBe("agent");
+  });
+
+  // Forge shape (arc#102): manifest nested under agent/ at the repo root.
+  // The readManifest fallback discovers it; install lands the bundle at
+  // ~/.config/metafactory/pkg/repos/<repo-name>/, with the manifest still
+  // accessible at <bundle>/agent/arc-manifest.yaml — matching the smoke
+  // test in arc#102.
+  test("installs agent bundle with manifest nested under agent/ (forge shape)", async () => {
+    const repoDir = join(env.root, "mock-NestedAgent");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(join(repoDir, "agent"), { recursive: true });
+    await writeFile(
+      join(repoDir, "agent", "persona.md"),
+      `# NestedAgent\n\nPersona.\n`,
+    );
+    await writeFile(
+      join(repoDir, "agent", "scaffold-instance.sh"),
+      `#!/bin/bash\necho "scaffolding $1"\n`,
+    );
+    await writeFile(
+      join(repoDir, "agent", "CLAUDE.md"),
+      `# Per-instance bridge\n`,
+    );
+    await writeFile(
+      join(repoDir, "agent", "arc-manifest.yaml"),
+      [
+        `schema: pai/v1`,
+        `name: NestedAgent`,
+        `version: 0.1.0`,
+        `type: agent`,
+        `tier: custom`,
+        `description: Agent bundle with manifest nested under agent/`,
+        `author:`,
+        `  name: testuser`,
+        `  github: testuser`,
+        `persona:`,
+        `  file: persona.md`,
+        ``,
+      ].join("\n"),
+    );
+    Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=t@t.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl: repoDir,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.name).toBe("NestedAgent");
+
+    // Bundle landed at canonical reposDir; manifest accessible at
+    // <bundle>/agent/arc-manifest.yaml (matches arc#102 smoke test).
+    const bundleRoot = join(env.paths.reposDir, "mock-NestedAgent");
+    expect(existsSync(join(bundleRoot, "agent", "arc-manifest.yaml"))).toBe(true);
+    expect(existsSync(join(bundleRoot, "agent", "persona.md"))).toBe(true);
+
+    const skill = getSkill(env.db, "NestedAgent");
+    expect(skill).not.toBeNull();
+    expect(skill!.artifact_type).toBe("agent");
+  });
+
+  // Negative case: a non-agent manifest under agent/ must NOT be picked
+  // up by the fallback. The fallback is gated to type: agent so we never
+  // silently install a misplaced skill under the wrong layout.
+  test("readManifest fallback into agent/ is gated to type: agent only", async () => {
+    const repoDir = join(env.root, "mock-WrongTypeUnderAgent");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(join(repoDir, "agent"), { recursive: true });
+    await writeFile(
+      join(repoDir, "agent", "arc-manifest.yaml"),
+      [
+        `name: WrongTypeUnderAgent`,
+        `version: 0.1.0`,
+        `type: skill`,
+        `tier: custom`,
+        `author:`,
+        `  name: testuser`,
+        `  github: testuser`,
+        `provides:`,
+        `  skill:`,
+        `    - trigger: wrongtype`,
+        `capabilities:`,
+        `  filesystem: { read: [], write: [] }`,
+        `  network: []`,
+        `  bash: { allowed: false }`,
+        `  secrets: []`,
+        ``,
+      ].join("\n"),
+    );
+    Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=t@t.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    const result = await install({
+      paths: env.paths,
+      db: env.db,
+      repoUrl: repoDir,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No arc-manifest.yaml");
+  });
+
   test("rejects already-installed skill", async () => {
     const repo = await createMockSkillRepo(env.root, {
       name: "TestSkill",

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -178,6 +178,132 @@ author:
     // affordance.
     expect(msg).toContain("README.md#capability-declarations");
   });
+
+  // arc#102 Phase 9.1 — type:agent install. Persona-driven agents declare
+  // authority via `guardrails`, not `capabilities`, so the capabilities
+  // block is optional. Install must NOT reject these manifests.
+  test("type: agent allows missing capabilities (persona-driven shape)", async () => {
+    await Bun.write(
+      join(tempDir, MANIFEST_FILENAME),
+      `schema: pai/v1
+name: PersonaAgent
+version: 0.1.0
+type: agent
+tier: custom
+author:
+  name: testuser
+  github: testuser
+persona:
+  file: persona.md
+guardrails:
+  allowedDirs: ["~/Developer/scope"]
+  disallowedTools: ["Edit"]
+`,
+    );
+
+    const manifest = await readManifest(tempDir);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.type).toBe("agent");
+    expect(manifest!.capabilities).toBeUndefined();
+  });
+
+  // arc#102 — fallback search into agent/ for persona-driven-agent source
+  // repos that nest the agent files under agent/ (e.g. forge: agent/{persona.md,
+  // arc-manifest.yaml, scaffold-instance.sh, CLAUDE.md}). The fallback only
+  // applies when the nested manifest declares type: agent — never silently
+  // for skills/tools/etc.
+  test("falls back to agent/arc-manifest.yaml for type: agent (forge layout)", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "agent"), { recursive: true });
+    await Bun.write(
+      join(tempDir, "agent", MANIFEST_FILENAME),
+      `name: NestedAgent
+version: 0.1.0
+type: agent
+tier: custom
+author:
+  name: testuser
+  github: testuser
+persona:
+  file: persona.md
+`,
+    );
+
+    const manifest = await readManifest(tempDir);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.name).toBe("NestedAgent");
+    expect(manifest!.type).toBe("agent");
+  });
+
+  // Negative: a skill manifest at agent/arc-manifest.yaml is NOT a valid
+  // fallback target. The fallback is gated to type: agent so misplaced
+  // skills can never silently install under the wrong layout.
+  test("agent/ fallback ignores non-agent manifests", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "agent"), { recursive: true });
+    await Bun.write(
+      join(tempDir, "agent", MANIFEST_FILENAME),
+      `name: MisplacedSkill
+version: 0.1.0
+type: skill
+tier: custom
+author:
+  name: testuser
+  github: testuser
+provides:
+  skill:
+    - trigger: misplaced
+capabilities:
+  filesystem: { read: [], write: [] }
+  network: []
+  bash: { allowed: false }
+  secrets: []
+`,
+    );
+
+    const manifest = await readManifest(tempDir);
+    // No root manifest, and the agent/ candidate is type: skill — fallback
+    // gated, so we get null (caller surfaces "no arc-manifest.yaml found").
+    expect(manifest).toBeNull();
+  });
+
+  // Root manifest takes precedence over an agent/ sibling. The fallback
+  // only fires when the root has no manifest — never as a silent override.
+  test("root manifest takes precedence over agent/ sibling", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "agent"), { recursive: true });
+    await Bun.write(
+      join(tempDir, MANIFEST_FILENAME),
+      `name: RootAgent
+version: 0.1.0
+type: agent
+tier: custom
+author:
+  name: testuser
+  github: testuser
+persona:
+  file: agent/persona.md
+`,
+    );
+    await Bun.write(
+      join(tempDir, "agent", MANIFEST_FILENAME),
+      `name: NestedSibling
+version: 9.9.9
+type: agent
+tier: custom
+author:
+  name: testuser
+  github: testuser
+persona:
+  file: persona.md
+`,
+    );
+
+    const manifest = await readManifest(tempDir);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.name).toBe("RootAgent");
+    expect(manifest!.version).toBe("0.1.0");
+  });
 });
 
 describe("assessRisk", () => {


### PR DESCRIPTION
## Summary

Extends `arc install <git-url>` to land persona-driven agent bundles (per arc#100 §12) at the canonical reposDir path. Phase 9.1 of mf#392 — the install-side counterpart to arc#100's authoring-side PackageBuilder work.

Two narrow validator changes are sufficient; the rest of the install pipeline (clone → manifest → symlinks → DB) already supports `agent`:

1. **`capabilities` becomes optional for `type: agent`.** Persona-driven agents declare authority via `guardrails` (which the host enforces through `allowedDirs` / `disallowedTools` / `bashAllowlist`). Forcing a capabilities block would reject the canonical agent shape.
2. **Fallback to `<repo>/agent/arc-manifest.yaml`** when the repo root has no manifest, **gated to `type: agent`**. This makes [`the-metafactory/forge`](https://github.com/the-metafactory/forge) installable as-is (its manifest currently lives under `agent/`) without forcing a source-layout migration. Skills/tools/etc. continue to require root manifests — the gate prevents misplaced non-agent manifests from silently installing.

Bundle still lands at `~/.config/metafactory/pkg/repos/<name>/`, DB records `artifact_type: agent`, `arc list --type agent` surfaces it.

## Scope

**In:**
- `arc install <git-url>` for `type: agent` bundles
- Manifest validation: capabilities optional for `agent`
- Manifest discovery fallback: `agent/arc-manifest.yaml` (gated to `type: agent`)
- Tests covering canonical layout, persona-driven (no capabilities), forge-shape (nested manifest), and the negative gate
- SKILL.md §12.9 documents the install path

**Out (separate issues):**
- Registry-resolved name install (`arc install <name>` → metafactory registry). The legacy registry.yaml resolution already supports `agent` (`src/lib/registry.ts`), so the path that does name lookup will inherit transparently. The new sigstore-signed publish flow is a separate concern — operator is catching up on its current shape; deferring rather than landing speculative code against an evolving registry.
- `arc publish` for agent bundles — separate issue if not already covered.
- `grove install agent <name>` (grove#261 / forge#11) — depends on this PR landing.

## Smoke test (against the-metafactory/forge)

```
$ arc install https://github.com/the-metafactory/forge -y
✅ Installed forge v0.2.0

$ ls ~/.config/metafactory/pkg/repos/forge/
agent  design  README.md

$ head -7 ~/.config/metafactory/pkg/repos/forge/agent/arc-manifest.yaml
schema: pai/v1
type: agent
namespace: metafactory
name: forge
version: 0.2.0
tier: custom
description: Release agent for the metafactory ecosystem — walks the release SOP end-to-end (gates → bump → tag → bundle → staged deploy → announce → retro)

$ arc list --type agent
Installed skills (1):
  ✅ forge v0.2.0 [active]
```

Existing skill-bundle install still works (verified: AgentState / Grove / code-review / compass / pilot-review-loop unchanged in DB after running this branch).

## Test plan

- [x] `bun test` — 638 pass / 0 fail (was 630 before this PR; +8 new tests)
- [x] `bunx tsc --noEmit` — clean
- [x] Smoke test: install forge from git URL, verify bundle layout + DB row
- [x] Regression: existing skill-bundle install unaffected
- [ ] Reviewer: confirm scope reduction (deferred registry-resolved install) is the right call given the operator's arc-registry deep-dive is still in progress

## Refs

- Closes #102
- arc#100 §12 (sibling: PackageBuilder authoring side; this PR is the install side)
- `forge/design/agent-platform.md` §"Instantiation flow" step 3 (`arc install $name` as precondition for host install)
- mf#392 Phase 9 (plug-and-play agent platform)
- grove#261 / forge#11 (downstream: `grove install agent <name>` depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)