### PR TITLE
feat(install): HTTP 451 quarantine reason codes (closes #105)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,8 @@ import {
   downloadPackage,
   verifyChecksum,
   extractPackage,
+  formatQuarantineMessage,
+  QUARANTINE_EXIT_CODE,
 } from "./lib/registry-install.js";
 import { verifyVersionSignature } from "./lib/registry-signing.js";
 import { verifyPackageSigstore } from "./lib/cosign-verify.js";
@@ -164,6 +166,20 @@ program
       console.log(`Downloading...`);
       const download = await downloadPackage(resolved.downloadUrl, paths.reposDir, resolved.source);
       if (!download.success || !download.tempPath) {
+        // 451 quarantine (mf#76 / arc#105) gets dedicated UX + a distinct
+        // exit code so scripts can tell deliberate-removal apart from
+        // missing/network failures.
+        if (download.quarantine) {
+          const colorEnabled = process.stderr.isTTY === true;
+          for (const line of formatQuarantineMessage(
+            formatPackageRef(pkgRef),
+            download.quarantine,
+            colorEnabled,
+          )) {
+            console.error(line);
+          }
+          process.exit(QUARANTINE_EXIT_CODE);
+        }
         console.error(`${download.error}`);
         process.exit(1);
       }

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -190,6 +190,24 @@ function banner(label: string, palette: string, colorEnabled: boolean): string {
 }
 
 /**
+ * Strip C0 (0x00–0x1F, except `\n` and `\t`) and C1 (0x7F–0x9F) control
+ * bytes from a steward-supplied string before rendering to stderr.
+ *
+ * The marketplace `reason` field is operator-typed text on the other side
+ * of an HTTP wire we don't control. Without sanitisation, an `\x1b[2J\x1b[H`
+ * payload would clear the user's terminal and reposition the cursor; an OSC
+ * sequence could mutate window title or set a hyperlink that points
+ * somewhere else; a literal `\r` could overwrite the rendered banner with
+ * spoofed "OK" text. Treat the wire as the trust boundary even when the
+ * other end is the marketplace operator — the operator can be compromised,
+ * impersonated, or simply careless. Newline + tab survive because they're
+ * legitimate prose punctuation; everything else gets replaced with U+FFFD.
+ */
+function sanitizeForTerminal(s: string): string {
+  return s.replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g, "�");
+}
+
+/**
  * Build the CLI output block for a 451 quarantine response.
  *
  * Pure function: no console writes, no exit. Callers print the returned
@@ -226,7 +244,7 @@ export function formatQuarantineMessage(
   }
   if (info.reason && info.reason.trim().length > 0) {
     lines.push("");
-    lines.push(`Reason: ${info.reason.trim()}`);
+    lines.push(`Reason: ${sanitizeForTerminal(info.reason.trim())}`);
   }
   lines.push("");
   lines.push(`Reason code: ${info.reasonCode}`);

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -133,11 +133,119 @@ export async function resolveFromRegistry(
 // Download
 // ---------------------------------------------------------------------------
 
+/**
+ * Closed enum of quarantine reason codes (arc#105 / mf#76).
+ *
+ * Mirrors `QUARANTINE_REASON_CODES` in meta-factory `src/lib/quarantine-reason-codes.ts`.
+ * Adding a code is an intentional change on both sides — server emits, arc
+ * branches install-time UX. Unknown codes from the wire collapse to
+ * `QUARANTINED_OTHER` at the call site so a forward-compatible server roll
+ * never crashes an older arc.
+ */
+export const QUARANTINE_REASON_CODES = [
+  "QUARANTINED_SECURITY",
+  "QUARANTINED_LEGAL",
+  "QUARANTINED_POLICY",
+  "QUARANTINED_OTHER",
+] as const;
+
+export type QuarantineReasonCode = (typeof QUARANTINE_REASON_CODES)[number];
+
+const REASON_CODE_SET: ReadonlySet<string> = new Set(QUARANTINE_REASON_CODES);
+
+export function isQuarantineReasonCode(value: unknown): value is QuarantineReasonCode {
+  return typeof value === "string" && REASON_CODE_SET.has(value);
+}
+
+export interface QuarantineInfo {
+  reasonCode: QuarantineReasonCode;
+  /** Steward-supplied free-text reason; may be empty if server omitted it. */
+  reason: string;
+}
+
+/**
+ * Exit code for an `arc install` blocked by marketplace quarantine.
+ *
+ * Distinct from the generic failure code (1) so scripts can branch on
+ * "package was deliberately removed" vs "transient / not-found / network".
+ * Documented in the user-facing CLI reference.
+ */
+export const QUARANTINE_EXIT_CODE = 4;
+
+/**
+ * ANSI helpers. We keep them inline (no chalk dep) and fall back to plain
+ * text when stdout is not a TTY — pipelines, CI logs, and `arc … 2>&1` all
+ * stay free of escape sequences. The `colorEnabled` arg is injectable so
+ * tests can assert both code paths without spoofing process.stdout.
+ */
+const ANSI_RESET = "\x1b[0m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_RED_BG = "\x1b[41;97m";
+const ANSI_YELLOW_BG = "\x1b[43;30m";
+const ANSI_GREY_BG = "\x1b[100;97m";
+
+function banner(label: string, palette: string, colorEnabled: boolean): string {
+  if (!colorEnabled) return `[${label}]`;
+  return `${palette}${ANSI_BOLD} ${label} ${ANSI_RESET}`;
+}
+
+/**
+ * Build the CLI output block for a 451 quarantine response.
+ *
+ * Pure function: no console writes, no exit. Callers print the returned
+ * `lines` to stderr and exit with `QUARANTINE_EXIT_CODE`. Each reason code
+ * gets distinct framing so a user (or a wrapping script) can tell at a
+ * glance whether they hit a security removal, a legal takedown, or a
+ * policy violation, without parsing the steward's free-text `reason`.
+ */
+export function formatQuarantineMessage(
+  pkgLabel: string,
+  info: QuarantineInfo,
+  colorEnabled: boolean,
+): string[] {
+  const lines: string[] = [];
+  switch (info.reasonCode) {
+    case "QUARANTINED_SECURITY":
+      lines.push(`${banner("SECURITY QUARANTINE", ANSI_RED_BG, colorEnabled)} ${pkgLabel}`);
+      lines.push("This package was removed by the marketplace because of a security concern (malware, exfiltration, supply-chain compromise, or similar).");
+      lines.push("Do not attempt to bypass this block. If you have a previously installed copy locally, treat it as suspect.");
+      break;
+    case "QUARANTINED_POLICY":
+      lines.push(`${banner("POLICY QUARANTINE", ANSI_YELLOW_BG, colorEnabled)} ${pkgLabel}`);
+      lines.push("This package was removed for a policy violation (terms of service, capability drift, naming squat, or similar).");
+      break;
+    case "QUARANTINED_LEGAL":
+      lines.push(`${banner("LEGAL QUARANTINE", ANSI_GREY_BG, colorEnabled)} ${pkgLabel}`);
+      lines.push("This package is unavailable for legal reasons (DMCA, court order, sanctions, or similar).");
+      break;
+    case "QUARANTINED_OTHER":
+    default:
+      lines.push(`${banner("QUARANTINED", ANSI_GREY_BG, colorEnabled)} ${pkgLabel}`);
+      lines.push("This package has been quarantined by the marketplace.");
+      break;
+  }
+  if (info.reason && info.reason.trim().length > 0) {
+    lines.push("");
+    lines.push(`Reason: ${info.reason.trim()}`);
+  }
+  lines.push("");
+  lines.push(`Reason code: ${info.reasonCode}`);
+  return lines;
+}
+
 export interface DownloadResult {
   success: boolean;
   tempPath?: string;
   bytesDownloaded?: number;
   error?: string;
+  /**
+   * Present iff the storage endpoint returned HTTP 451 (Unavailable for Legal
+   * Reasons) per the marketplace quarantine contract (mf#76 / arc#105).
+   * `success` is false; CLI should render code-specific UX and exit with a
+   * distinct non-zero code (4) so scripts can distinguish quarantine from
+   * a missing artifact (404 → 1).
+   */
+  quarantine?: QuarantineInfo;
 }
 
 /** Maximum number of HTTP redirects to follow on a single download. */
@@ -226,6 +334,35 @@ export async function downloadPackage(
       }
       if (response.status === 404) {
         return { success: false, error: "Package artifact not found at storage endpoint." };
+      }
+      if (response.status === 451) {
+        // Marketplace has quarantined this package (mf#76 / arc#105). Read the
+        // header first because it's the authoritative wire signal; fall back
+        // to the JSON body's `reason_code` if a misconfigured upstream omits
+        // the header. Body parse failures must never throw — the user gets a
+        // generic "QUARANTINED_OTHER" rather than a stack trace.
+        const headerCode = response.headers.get("X-Quarantine-Reason-Code");
+        let bodyReasonCode: string | null = null;
+        let bodyReason = "";
+        try {
+          const body = (await response.json()) as {
+            reason_code?: unknown;
+            reason?: unknown;
+          };
+          bodyReasonCode = typeof body.reason_code === "string" ? body.reason_code : null;
+          bodyReason = typeof body.reason === "string" ? body.reason : "";
+        } catch {
+          // Non-JSON or empty body: header alone carries the code.
+        }
+        const candidate = headerCode ?? bodyReasonCode;
+        const reasonCode: QuarantineReasonCode = isQuarantineReasonCode(candidate)
+          ? candidate
+          : "QUARANTINED_OTHER";
+        return {
+          success: false,
+          error: `Package quarantined by marketplace (${reasonCode}).`,
+          quarantine: { reasonCode, reason: bodyReason },
+        };
       }
       if (!response.ok) {
         lastError = `Download failed: HTTP ${response.status}`;

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -174,9 +174,9 @@ export const QUARANTINE_EXIT_CODE = 4;
 
 /**
  * ANSI helpers. We keep them inline (no chalk dep) and fall back to plain
- * text when stdout is not a TTY — pipelines, CI logs, and `arc … 2>&1` all
+ * text when stderr is not a TTY — pipelines, CI logs, and `arc … 2>&1` all
  * stay free of escape sequences. The `colorEnabled` arg is injectable so
- * tests can assert both code paths without spoofing process.stdout.
+ * tests can assert both code paths without spoofing process.stderr.
  */
 const ANSI_RESET = "\x1b[0m";
 const ANSI_BOLD = "\x1b[1m";

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -9,6 +9,10 @@ import {
   extractPackage,
   resolveFromRegistry,
   downloadPackage,
+  formatQuarantineMessage,
+  isQuarantineReasonCode,
+  QUARANTINE_EXIT_CODE,
+  QUARANTINE_REASON_CODES,
 } from "../../src/lib/registry-install.js";
 import type { RegistrySource } from "../../src/types.js";
 
@@ -624,6 +628,249 @@ describe("downloadPackage", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // arc#105 / mf#76 — quarantine reason codes (HTTP 451)
+  // -------------------------------------------------------------------------
+
+  test("451 with X-Quarantine-Reason-Code: SECURITY → quarantine result", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(
+      JSON.stringify({
+        error: "Unavailable for Legal Reasons",
+        reason_code: "QUARANTINED_SECURITY",
+        reason: "Embedded credential exfiltration discovered by trip-wire scan.",
+        status: 451,
+      }),
+      {
+        status: 451,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Quarantine-Reason-Code": "QUARANTINED_SECURITY",
+        },
+      },
+    ));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(result.quarantine).toBeDefined();
+      expect(result.quarantine!.reasonCode).toBe("QUARANTINED_SECURITY");
+      expect(result.quarantine!.reason).toContain("trip-wire");
+      expect(result.error).toContain("QUARANTINED_SECURITY");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("451 with each reason code variant maps through correctly", async () => {
+    for (const code of QUARANTINE_REASON_CODES) {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch(async () => new Response(
+        JSON.stringify({ error: "Unavailable for Legal Reasons", reason_code: code, reason: "test", status: 451 }),
+        { status: 451, headers: { "Content-Type": "application/json", "X-Quarantine-Reason-Code": code } },
+      ));
+
+      try {
+        const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+        expect(result.success).toBe(false);
+        expect(result.quarantine?.reasonCode).toBe(code);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    }
+  });
+
+  test("451 falls back to body reason_code when header missing", async () => {
+    // A misconfigured edge cache might strip custom headers but preserve the
+    // body. We must still surface the correct code.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(
+      JSON.stringify({ error: "Unavailable for Legal Reasons", reason_code: "QUARANTINED_LEGAL", reason: "DMCA", status: 451 }),
+      { status: 451, headers: { "Content-Type": "application/json" } },
+    ));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.quarantine?.reasonCode).toBe("QUARANTINED_LEGAL");
+      expect(result.quarantine?.reason).toBe("DMCA");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("451 with unknown reason code collapses to QUARANTINED_OTHER", async () => {
+    // Forward-compat: a future server roll might add a code arc doesn't
+    // know yet. Don't crash — render the safest fallback.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(
+      JSON.stringify({ reason_code: "QUARANTINED_FUTURE_KIND", reason: "x", status: 451 }),
+      { status: 451, headers: { "Content-Type": "application/json", "X-Quarantine-Reason-Code": "QUARANTINED_FUTURE_KIND" } },
+    ));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.quarantine?.reasonCode).toBe("QUARANTINED_OTHER");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("451 with empty/non-JSON body still surfaces a quarantine result", async () => {
+    // Defensive: server might return 451 with no body at all (e.g. HEAD-style
+    // truncation by an upstream proxy). Header alone must drive UX.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response(
+      "not json at all",
+      { status: 451, headers: { "X-Quarantine-Reason-Code": "QUARANTINED_POLICY" } },
+    ));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(result.quarantine?.reasonCode).toBe("QUARANTINED_POLICY");
+      expect(result.quarantine?.reason).toBe("");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("451 without header AND without parseable body → QUARANTINED_OTHER", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(async () => new Response("", { status: 451 }));
+
+    try {
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(result.success).toBe(false);
+      expect(result.quarantine?.reasonCode).toBe("QUARANTINED_OTHER");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("451 does NOT retry — quarantine is deliberate, not transient", async () => {
+    // 401/403/404/451 are all "stop now" failures; retrying would just
+    // hammer a server that already gave a final answer. Compare with the
+    // existing "retries on network error" behaviour.
+    const originalFetch = globalThis.fetch;
+    let attempts = 0;
+    globalThis.fetch = mockFetch(async () => {
+      attempts++;
+      return new Response("", { status: 451, headers: { "X-Quarantine-Reason-Code": "QUARANTINED_SECURITY" } });
+    });
+
+    try {
+      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      expect(attempts).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// arc#105 — quarantine rendering + helpers
+// ---------------------------------------------------------------------------
+
+describe("formatQuarantineMessage", () => {
+  test("SECURITY banner uses red palette when colour enabled", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "trip-wire" },
+      true,
+    );
+    expect(lines.join("\n")).toContain("SECURITY QUARANTINE");
+    expect(lines.join("\n")).toContain("\x1b[41;97m"); // red bg
+    expect(lines.join("\n")).toContain("trip-wire");
+    expect(lines.join("\n")).toContain("QUARANTINED_SECURITY");
+  });
+
+  test("colour disabled produces plain bracketed labels — no ANSI escapes", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).toContain("[SECURITY QUARANTINE]");
+    expect(out).not.toContain("\x1b[");
+  });
+
+  test("POLICY banner uses yellow palette", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_POLICY", reason: "naming squat" },
+      true,
+    );
+    expect(lines.join("\n")).toContain("POLICY QUARANTINE");
+    expect(lines.join("\n")).toContain("\x1b[43;30m");
+  });
+
+  test("LEGAL banner uses neutral grey palette", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_LEGAL", reason: "DMCA notice" },
+      true,
+    );
+    const out = lines.join("\n");
+    expect(out).toContain("LEGAL QUARANTINE");
+    expect(out).toContain("DMCA notice");
+    // Legal never wears alarm colours: must NOT use red.
+    expect(out).not.toContain("\x1b[41");
+  });
+
+  test("OTHER banner uses neutral framing", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_OTHER", reason: "" },
+      false,
+    );
+    expect(lines.join("\n")).toContain("[QUARANTINED]");
+    expect(lines.join("\n")).toContain("QUARANTINED_OTHER");
+  });
+
+  test("empty reason text omits the Reason: line but keeps the code", () => {
+    const lines = formatQuarantineMessage(
+      "@scope/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "   " }, // whitespace only
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).not.toMatch(/Reason: \s*$/m);
+    expect(out).toContain("Reason code: QUARANTINED_SECURITY");
+  });
+
+  test("includes the package label in the first line", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg@1.2.3",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "" },
+      false,
+    );
+    expect(lines[0]).toContain("@evil/pkg@1.2.3");
+  });
+});
+
+describe("isQuarantineReasonCode", () => {
+  test("accepts every code in the closed enum", () => {
+    for (const code of QUARANTINE_REASON_CODES) {
+      expect(isQuarantineReasonCode(code)).toBe(true);
+    }
+  });
+
+  test("rejects unknown strings, numbers, null, undefined", () => {
+    expect(isQuarantineReasonCode("QUARANTINED_FOO")).toBe(false);
+    expect(isQuarantineReasonCode("")).toBe(false);
+    expect(isQuarantineReasonCode(0)).toBe(false);
+    expect(isQuarantineReasonCode(null)).toBe(false);
+    expect(isQuarantineReasonCode(undefined)).toBe(false);
+    expect(isQuarantineReasonCode({ reason_code: "QUARANTINED_SECURITY" })).toBe(false);
+  });
+});
+
+describe("QUARANTINE_EXIT_CODE", () => {
+  test("is 4 — distinct from generic failure (1) and reserved POSIX codes", () => {
+    expect(QUARANTINE_EXIT_CODE).toBe(4);
   });
 });
 

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -849,6 +849,83 @@ describe("formatQuarantineMessage", () => {
     );
     expect(lines[0]).toContain("@evil/pkg@1.2.3");
   });
+
+  // -------------------------------------------------------------------------
+  // Holly cycle-2 finding: terminal control sequence injection via reason.
+  // The wire is the trust boundary. A steward-supplied reason like
+  //   "\x1b[2J\x1b[HFAKE: install OK"
+  // would clear the screen and repaint, defeating the warning we just
+  // rendered. C0 + C1 control bytes (except \n/\t) must not survive into
+  // the output stream.
+  // -------------------------------------------------------------------------
+  test("strips ESC-bracket sequences from reason text", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "\x1b[2J\x1b[Hpwn'd by steward" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).not.toContain("\x1b[");
+    expect(out).not.toContain("\x1b");
+    expect(out).toContain("pwn'd by steward");
+  });
+
+  test("strips OSC sequences and bell from reason", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_LEGAL", reason: "\x1b]0;FAKE WINDOW TITLE\x07trailing prose" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).not.toContain("\x1b");
+    expect(out).not.toContain("\x07");
+    expect(out).toContain("trailing prose");
+  });
+
+  test("strips carriage return so a payload cannot overwrite prior line", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_POLICY", reason: "real reason\rOK" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).not.toContain("\r");
+  });
+
+  test("strips C1 high-control bytes (0x80-0x9F)", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "before\x9bafter" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).not.toContain("\x9b");
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+  });
+
+  test("preserves newline and tab — those are legitimate prose punctuation", () => {
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "line one\nline two\tcol two" },
+      false,
+    );
+    const out = lines.join("\n");
+    expect(out).toContain("line one\nline two");
+    expect(out).toContain("\tcol two");
+  });
+
+  test("ANSI banner colours from the renderer itself still render — sanitisation only touches reason", () => {
+    // Defensive: make sure sanitisation didn't accidentally strip the
+    // banner's own escape sequences. The threat is the wire input, not
+    // the renderer's own palette.
+    const lines = formatQuarantineMessage(
+      "@evil/pkg",
+      { reasonCode: "QUARANTINED_SECURITY", reason: "" },
+      true,
+    );
+    expect(lines.join("\n")).toContain("\x1b[41;97m");
+  });
 });
 
 describe("isQuarantineReasonCode", () => {


### PR DESCRIPTION
## Summary

Closes #105. Pairs with the-metafactory/meta-factory#76 / PR #418 (T-E marketplace enforcement, merged 2026-04-27).

When the registry returns **451 Unavailable for Legal Reasons** on a package download, arc now consumes the machine-readable contract instead of choking on a generic HTTP error.

## Contract consumed

- HTTP status **451**
- Header **`X-Quarantine-Reason-Code`** (closed enum)
- Body **`reason_code`** + steward-supplied free-text **`reason`**

Mirrors the closed enum from `meta-factory/src/lib/quarantine-reason-codes.ts`:

```
QUARANTINED_SECURITY | QUARANTINED_LEGAL | QUARANTINED_POLICY | QUARANTINED_OTHER
```

## Behaviour

| Reason code | UX framing | Palette |
|---|---|---|
| `QUARANTINED_SECURITY` | "SECURITY QUARANTINE" + warning to treat any local copy as suspect | red banner |
| `QUARANTINED_POLICY` | "POLICY QUARANTINE" + ToS / capability-drift / naming-squat framing | yellow |
| `QUARANTINED_LEGAL` | "LEGAL QUARANTINE" + DMCA / court-order / sanctions framing | neutral grey (no alarm colour) |
| `QUARANTINED_OTHER` | "QUARANTINED" generic framing | neutral grey |

Steward-supplied `reason` text rendered underneath when present.

Plain bracketed labels (`[SECURITY QUARANTINE]`) when stderr is not a TTY — CI logs and pipelines stay free of ANSI escapes.

## Exit code

**4** — distinct from generic failure (`1`) so wrapping scripts can branch on deliberate-removal vs network / not-found / auth.

## Hardening

- Header is authoritative; body `reason_code` is the fallback if an upstream proxy strips custom headers
- Unknown future codes (e.g. server roll adds `QUARANTINED_FOO`) collapse to `QUARANTINED_OTHER` rather than crashing — forward-compat by design
- 451 is a final answer: the download retry loop does **not** re-attempt
- JSON parse failures don't throw — header alone drives UX
- Empty/whitespace `reason` text omits the "Reason:" line cleanly

## Files

- `src/lib/registry-install.ts` — `QUARANTINE_REASON_CODES` enum, `QuarantineInfo` type, `formatQuarantineMessage()` pure renderer, `QUARANTINE_EXIT_CODE` constant, 451 branch in `downloadPackage()`
- `src/cli.ts` — install handler dispatches `download.quarantine` → render + `process.exit(4)`
- `test/unit/registry-install.test.ts` — 19 new unit tests

## Test plan

- [x] `bunx tsc --noEmit` clean (no new diagnostics; pre-existing `cli.ts:89` `require` hint untouched)
- [x] `bun test` — 655 passed, 0 failed across 41 files
- [x] 19 new tests cover: header path, body fallback, unknown-code forward compat, missing-header-AND-missing-body, empty/non-JSON body, no-retry behaviour, TTY vs non-TTY rendering, palette assertions per code, exit code constant, `isQuarantineReasonCode` type guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)