### PR TITLE
feat(nats): bot identity provisioning CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import {
 import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
+import { addBot, reissueBot, listBots, removeBot } from "./commands/nats.js";
 import { bundle, formatBundle } from "./commands/bundle.js";
 import { publish, formatPublish } from "./commands/publish.js";
 import {
@@ -1173,8 +1174,6 @@ catalog
 
 // ── NATS bot identity commands ─────────────────────────────
 
-import { addBot, reissueBot, listBots, removeBot } from "./commands/nats.js";
-
 const nats = program
   .command("nats")
   .description("NATS bot identity management — provision per-bot users");
@@ -1212,8 +1211,9 @@ nats
   .command("remove-bot <name>")
   .description("Revoke a bot user and optionally delete credentials")
   .option("-a, --account <account>", "NSC account name")
+  .option("-o, --output <path>", "Credentials file path to delete (if --delete-creds)")
   .option("--delete-creds", "Also delete the credentials file")
-  .action((name: string, opts: { account?: string; deleteCreds?: boolean }) => {
+  .action((name: string, opts: { account?: string; output?: string; deleteCreds?: boolean }) => {
     removeBot(name, opts);
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1171,4 +1171,50 @@ catalog
     }
   });
 
+// ── NATS bot identity commands ─────────────────────────────
+
+import { addBot, reissueBot, listBots, removeBot } from "./commands/nats.js";
+
+const nats = program
+  .command("nats")
+  .description("NATS bot identity management — provision per-bot users");
+
+nats
+  .command("add-bot <name>")
+  .description("Issue a new per-bot NATS user with credentials")
+  .option("-a, --account <account>", "NSC account name (default: active account)")
+  .option("--pub <subjects>", "Comma-separated publish permissions")
+  .option("--sub <subjects>", "Comma-separated subscribe permissions")
+  .option("-o, --output <path>", "Credentials output path")
+  .option("--force", "Overwrite existing user")
+  .action((name: string, opts: { account?: string; pub?: string; sub?: string; output?: string; force?: boolean }) => {
+    addBot(name, opts);
+  });
+
+nats
+  .command("reissue-bot <name>")
+  .description("Revoke and re-issue credentials for a bot user")
+  .option("-a, --account <account>", "NSC account name")
+  .option("-o, --output <path>", "Credentials output path")
+  .action((name: string, opts: { account?: string; output?: string }) => {
+    reissueBot(name, opts);
+  });
+
+nats
+  .command("list-bots")
+  .description("List bot users under current operator account")
+  .option("-a, --account <account>", "NSC account name")
+  .action((opts: { account?: string }) => {
+    listBots(opts.account);
+  });
+
+nats
+  .command("remove-bot <name>")
+  .description("Revoke a bot user and optionally delete credentials")
+  .option("-a, --account <account>", "NSC account name")
+  .option("--delete-creds", "Also delete the credentials file")
+  .action((name: string, opts: { account?: string; deleteCreds?: boolean }) => {
+    removeBot(name, opts);
+  });
+
 program.parse();

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -3,47 +3,45 @@
  *
  * Wraps NSC to provision per-bot NATS users under an operator's account.
  * Part of grove#320 (bot-level AAA) — operator-level infrastructure tooling.
- *
- * Commands:
- *   arc nats add-bot <name>       Issue a new per-bot NATS user
- *   arc nats reissue-bot <name>   Revoke + re-issue credentials
- *   arc nats list-bots            List bot users under current account
- *   arc nats remove-bot <name>    Revoke a bot user
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { existsSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 const CREDS_DIR = join(homedir(), ".config", "nats");
 const NAMING_RE = /^[a-z][a-z0-9-]*$/;
+const NATS_SUBJECT_RE = /^[a-zA-Z0-9.*>_-]+$/;
 
-function nsc(args: string): string {
-  try {
-    // nsc writes some output to stderr (e.g., `nsc env`), merge both streams
-    return execSync(`nsc ${args} 2>&1`, { encoding: "utf-8" }).trim();
-  } catch (e: unknown) {
-    const err = e as { stderr?: string; stdout?: string };
-    const msg = err.stderr?.trim() || err.stdout?.trim() || "unknown error";
-    throw new Error(`nsc ${args.split(" ")[0]} failed: ${msg}`);
+function nsc(args: string[]): string {
+  const result = spawnSync("nsc", args, { encoding: "utf-8" });
+  if (result.status !== 0) {
+    const msg = (result.stderr || result.stdout || "unknown error").trim();
+    throw new Error(`nsc ${args[0]} failed: ${msg}`);
   }
+  // nsc writes some output to stderr (e.g., `nsc env`)
+  return (result.stdout + result.stderr).trim();
 }
 
 export function ensureNscInstalled(): void {
-  try {
-    execSync("which nsc", { encoding: "utf-8" });
-  } catch {
+  const result = spawnSync("which", ["nsc"], { encoding: "utf-8" });
+  if (result.status !== 0) {
     console.error("Error: nsc not found on PATH.");
     console.error("Install: brew install nats-io/nats-tools/nsc");
-    console.error("  or: https://github.com/nats-io/nsc");
     process.exit(1);
   }
 }
 
+function validateSubject(subject: string): void {
+  if (!NATS_SUBJECT_RE.test(subject)) {
+    throw new Error(`Invalid NATS subject: "${subject}" — only alphanumeric, dots, wildcards, hyphens, underscores allowed`);
+  }
+}
+
 export function detectAccount(): string {
-  const env = nsc("env");
-  const match = env.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
+  const output = nsc(["env"]);
+  const match = output.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
   if (match) return match[1];
   throw new Error("Cannot detect NSC account. Run: nsc env -a <account>");
 }
@@ -54,11 +52,24 @@ function credsPath(name: string): string {
 
 function userExists(account: string, name: string): boolean {
   try {
-    nsc(`describe user -a ${account} -n ${name}`);
+    nsc(["describe", "user", "-a", account, "-n", name]);
     return true;
   } catch {
     return false;
   }
+}
+
+function ensureCredsDir(path: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  chmodSync(dir, 0o700);
+}
+
+function writeCredsFile(path: string, content: string): void {
+  writeFileSync(path, content, { mode: 0o600 });
+  chmodSync(path, 0o600);
 }
 
 export interface AddBotOptions {
@@ -90,31 +101,32 @@ export function addBot(name: string, opts: AddBotOptions): void {
       console.error(`Error: user "${name}" exists under "${account}". Use --force to re-create.`);
       process.exit(1);
     }
-    nsc(`delete user -a ${account} -n ${name}`);
+    nsc(["delete", "user", "-a", account, "-n", name]);
     console.log(`Removed existing user: ${name}`);
   }
 
-  nsc(`add user -a ${account} -n ${name}`);
+  nsc(["add", "user", "-a", account, "-n", name]);
   console.log(`Created NATS user: ${name} (account: ${account})`);
 
   if (opts.pub) {
     for (const subj of opts.pub.split(",").map((s) => s.trim())) {
-      nsc(`edit user -a ${account} -n ${name} --allow-pub "${subj}"`);
+      validateSubject(subj);
+      nsc(["edit", "user", "-a", account, "-n", name, "--allow-pub", subj]);
     }
     console.log(`  publish: ${opts.pub}`);
   }
 
   if (opts.sub) {
     for (const subj of opts.sub.split(",").map((s) => s.trim())) {
-      nsc(`edit user -a ${account} -n ${name} --allow-sub "${subj}"`);
+      validateSubject(subj);
+      nsc(["edit", "user", "-a", account, "-n", name, "--allow-sub", subj]);
     }
     console.log(`  subscribe: ${opts.sub}`);
   }
 
-  const creds = nsc(`generate creds -a ${account} -n ${name}`);
-  const outDir = dirname(outPath);
-  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
-  writeFileSync(outPath, creds, { mode: 0o600 });
+  const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
+  ensureCredsDir(outPath);
+  writeCredsFile(outPath, creds);
   console.log(`  credentials: ${outPath} (mode 600)`);
 }
 
@@ -133,11 +145,28 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     process.exit(1);
   }
 
-  nsc(`delete user -a ${account} -n ${name}`);
-  nsc(`add user -a ${account} -n ${name}`);
+  // Capture existing user config before delete for rollback
+  let existingConfig: string;
+  try {
+    existingConfig = nsc(["describe", "user", "-a", account, "-n", name, "--json"]);
+  } catch {
+    console.error(`Error: cannot read existing user config for "${name}".`);
+    process.exit(1);
+  }
 
-  const creds = nsc(`generate creds -a ${account} -n ${name}`);
-  writeFileSync(outPath, creds, { mode: 0o600 });
+  nsc(["delete", "user", "-a", account, "-n", name]);
+
+  try {
+    nsc(["add", "user", "-a", account, "-n", name]);
+  } catch (err) {
+    console.error(`Error: failed to re-create user "${name}". Previous config saved to stderr.`);
+    process.stderr.write(`Previous user config:\n${existingConfig}\n`);
+    process.exit(1);
+  }
+
+  const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
+  ensureCredsDir(outPath);
+  writeCredsFile(outPath, creds);
 
   console.log(`Re-issued credentials for ${name}`);
   console.log(`  credentials: ${outPath} (mode 600)`);
@@ -147,12 +176,13 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
 export function listBots(account?: string): void {
   ensureNscInstalled();
   const acct = account ?? detectAccount();
-  console.log(nsc(`list users -a ${acct}`));
+  console.log(nsc(["list", "users", "-a", acct]));
 }
 
 export interface RemoveBotOptions {
   account?: string;
   deleteCreds?: boolean;
+  output?: string;
 }
 
 export function removeBot(name: string, opts: RemoveBotOptions): void {
@@ -164,14 +194,16 @@ export function removeBot(name: string, opts: RemoveBotOptions): void {
     process.exit(1);
   }
 
-  nsc(`delete user -a ${account} -n ${name}`);
+  nsc(["delete", "user", "-a", account, "-n", name]);
   console.log(`Removed user: ${name} (account: ${account})`);
 
   if (opts.deleteCreds) {
-    const path = credsPath(name);
+    const path = opts.output ?? credsPath(name);
     if (existsSync(path)) {
       unlinkSync(path);
       console.log(`Deleted credentials: ${path}`);
+    } else {
+      console.log(`Warning: no credentials file at ${path} (custom -o path used at creation?)`);
     }
   }
 }

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -22,13 +22,22 @@ const NSC_CONFIG_CANDIDATES = [
 
 function nsc(args: string[]): string {
   const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
-  const stdout = result.stdout.toString();
-  const stderr = result.stderr.toString();
+  const stdout = result.stdout.toString().trim();
+  const stderr = result.stderr.toString().trim();
   if (result.exitCode !== 0) {
-    const msg = (stderr || stdout || "unknown error").trim();
-    throw new Error(`nsc ${args[0]} failed: ${msg}`);
+    throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
   }
-  return (stdout + stderr).trim();
+  return stdout;
+}
+
+function nscWithStderr(args: string[]): string {
+  const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    const stdout = result.stdout.toString().trim();
+    throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
+  }
+  return (result.stdout.toString() + result.stderr.toString()).trim();
 }
 
 export function ensureNscInstalled(): void {
@@ -36,6 +45,13 @@ export function ensureNscInstalled(): void {
   if (result.exitCode !== 0) {
     console.error("Error: nsc not found on PATH.");
     console.error("Install: brew install nats-io/nats-tools/nsc");
+    process.exit(1);
+  }
+}
+
+function validateBotName(name: string): void {
+  if (!NAMING_RE.test(name)) {
+    console.error(`Error: bot name "${name}" must be lowercase alphanumeric + hyphens.`);
     process.exit(1);
   }
 }
@@ -58,8 +74,8 @@ export function detectAccount(): string {
       continue;
     }
   }
-  // Fallback: parse nsc env output
-  const output = nsc(["env"]);
+  // Fallback: parse nsc env output (env writes to stderr)
+  const output = nscWithStderr(["env"]);
   const match = output.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
   if (match) return match[1];
   throw new Error("Cannot detect NSC account. Run: nsc env -a <account>");
@@ -105,10 +121,7 @@ export interface AddBotOptions {
 export function addBot(name: string, opts: AddBotOptions): void {
   ensureNscInstalled();
 
-  if (!NAMING_RE.test(name)) {
-    console.error(`Error: bot name "${name}" must be lowercase alphanumeric + hyphens.`);
-    process.exit(1);
-  }
+  validateBotName(name);
 
   const account = opts.account ?? detectAccount();
   const outPath = opts.output ?? defaultCredsPath(name);
@@ -164,6 +177,7 @@ export interface ReissueBotOptions {
 
 export function reissueBot(name: string, opts: ReissueBotOptions): void {
   ensureNscInstalled();
+  validateBotName(name);
   const account = opts.account ?? detectAccount();
   const outPath = opts.output ?? defaultCredsPath(name);
 
@@ -172,9 +186,8 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     process.exit(1);
   }
 
-  // Generate new creds BEFORE deleting old user — validate the operation succeeds
-  // before making destructive changes. nsc requires delete+add for new keys,
-  // but we can at least back up the old creds file.
+  // nsc requires delete+add for new keys (no in-place rekey).
+  // Back up old creds file before the destructive delete.
   if (existsSync(outPath)) {
     const backup = `${outPath}.bak`;
     writeFileSync(backup, readFileSync(outPath));
@@ -221,6 +234,7 @@ export interface RemoveBotOptions {
 
 export function removeBot(name: string, opts: RemoveBotOptions): void {
   ensureNscInstalled();
+  validateBotName(name);
   const account = opts.account ?? detectAccount();
 
   if (!userExists(account, name)) {

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -1,0 +1,177 @@
+/**
+ * arc nats — NATS bot identity management.
+ *
+ * Wraps NSC to provision per-bot NATS users under an operator's account.
+ * Part of grove#320 (bot-level AAA) — operator-level infrastructure tooling.
+ *
+ * Commands:
+ *   arc nats add-bot <name>       Issue a new per-bot NATS user
+ *   arc nats reissue-bot <name>   Revoke + re-issue credentials
+ *   arc nats list-bots            List bot users under current account
+ *   arc nats remove-bot <name>    Revoke a bot user
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const CREDS_DIR = join(homedir(), ".config", "nats");
+const NAMING_RE = /^[a-z][a-z0-9-]*$/;
+
+function nsc(args: string): string {
+  try {
+    // nsc writes some output to stderr (e.g., `nsc env`), merge both streams
+    return execSync(`nsc ${args} 2>&1`, { encoding: "utf-8" }).trim();
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; stdout?: string };
+    const msg = err.stderr?.trim() || err.stdout?.trim() || "unknown error";
+    throw new Error(`nsc ${args.split(" ")[0]} failed: ${msg}`);
+  }
+}
+
+export function ensureNscInstalled(): void {
+  try {
+    execSync("which nsc", { encoding: "utf-8" });
+  } catch {
+    console.error("Error: nsc not found on PATH.");
+    console.error("Install: brew install nats-io/nats-tools/nsc");
+    console.error("  or: https://github.com/nats-io/nsc");
+    process.exit(1);
+  }
+}
+
+export function detectAccount(): string {
+  const env = nsc("env");
+  const match = env.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
+  if (match) return match[1];
+  throw new Error("Cannot detect NSC account. Run: nsc env -a <account>");
+}
+
+function credsPath(name: string): string {
+  return join(CREDS_DIR, `${name}.creds`);
+}
+
+function userExists(account: string, name: string): boolean {
+  try {
+    nsc(`describe user -a ${account} -n ${name}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface AddBotOptions {
+  account?: string;
+  pub?: string;
+  sub?: string;
+  output?: string;
+  force?: boolean;
+}
+
+export function addBot(name: string, opts: AddBotOptions): void {
+  ensureNscInstalled();
+
+  if (!NAMING_RE.test(name)) {
+    console.error(`Error: bot name "${name}" must be lowercase alphanumeric + hyphens.`);
+    process.exit(1);
+  }
+
+  const account = opts.account ?? detectAccount();
+  const outPath = opts.output ?? credsPath(name);
+
+  if (existsSync(outPath) && !opts.force) {
+    console.error(`Error: credentials exist at ${outPath}. Use --force to overwrite.`);
+    process.exit(1);
+  }
+
+  if (userExists(account, name)) {
+    if (!opts.force) {
+      console.error(`Error: user "${name}" exists under "${account}". Use --force to re-create.`);
+      process.exit(1);
+    }
+    nsc(`delete user -a ${account} -n ${name}`);
+    console.log(`Removed existing user: ${name}`);
+  }
+
+  nsc(`add user -a ${account} -n ${name}`);
+  console.log(`Created NATS user: ${name} (account: ${account})`);
+
+  if (opts.pub) {
+    for (const subj of opts.pub.split(",").map((s) => s.trim())) {
+      nsc(`edit user -a ${account} -n ${name} --allow-pub "${subj}"`);
+    }
+    console.log(`  publish: ${opts.pub}`);
+  }
+
+  if (opts.sub) {
+    for (const subj of opts.sub.split(",").map((s) => s.trim())) {
+      nsc(`edit user -a ${account} -n ${name} --allow-sub "${subj}"`);
+    }
+    console.log(`  subscribe: ${opts.sub}`);
+  }
+
+  const creds = nsc(`generate creds -a ${account} -n ${name}`);
+  const outDir = dirname(outPath);
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  writeFileSync(outPath, creds, { mode: 0o600 });
+  console.log(`  credentials: ${outPath} (mode 600)`);
+}
+
+export interface ReissueBotOptions {
+  account?: string;
+  output?: string;
+}
+
+export function reissueBot(name: string, opts: ReissueBotOptions): void {
+  ensureNscInstalled();
+  const account = opts.account ?? detectAccount();
+  const outPath = opts.output ?? credsPath(name);
+
+  if (!userExists(account, name)) {
+    console.error(`Error: user "${name}" not found under "${account}".`);
+    process.exit(1);
+  }
+
+  nsc(`delete user -a ${account} -n ${name}`);
+  nsc(`add user -a ${account} -n ${name}`);
+
+  const creds = nsc(`generate creds -a ${account} -n ${name}`);
+  writeFileSync(outPath, creds, { mode: 0o600 });
+
+  console.log(`Re-issued credentials for ${name}`);
+  console.log(`  credentials: ${outPath} (mode 600)`);
+  console.log(`  Note: old credentials are now invalid.`);
+}
+
+export function listBots(account?: string): void {
+  ensureNscInstalled();
+  const acct = account ?? detectAccount();
+  console.log(nsc(`list users -a ${acct}`));
+}
+
+export interface RemoveBotOptions {
+  account?: string;
+  deleteCreds?: boolean;
+}
+
+export function removeBot(name: string, opts: RemoveBotOptions): void {
+  ensureNscInstalled();
+  const account = opts.account ?? detectAccount();
+
+  if (!userExists(account, name)) {
+    console.error(`Error: user "${name}" not found under "${account}".`);
+    process.exit(1);
+  }
+
+  nsc(`delete user -a ${account} -n ${name}`);
+  console.log(`Removed user: ${name} (account: ${account})`);
+
+  if (opts.deleteCreds) {
+    const path = credsPath(name);
+    if (existsSync(path)) {
+      unlinkSync(path);
+      console.log(`Deleted credentials: ${path}`);
+    }
+  }
+}

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -8,25 +8,32 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { spawnSync } from "node:child_process";
 
-const CREDS_DIR = join(homedir(), ".config", "nats");
-const NSC_CONFIG = join(homedir(), ".config", "nats", "nsc", "nsc.json");
+const DEFAULT_CREDS_DIR = join(homedir(), ".config", "nats");
 const NAMING_RE = /^[a-z][a-z0-9-]*$/;
 const NATS_SUBJECT_RE = /^[a-zA-Z0-9.*>_-]+$/;
 
+// NSC config can live in several locations depending on version/platform
+const NSC_CONFIG_CANDIDATES = [
+  join(homedir(), ".config", "nats", "nsc", "nsc.json"),
+  join(homedir(), ".nsc", "nsc.json"),
+  join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "nsc", "nsc.json"),
+];
+
 function nsc(args: string[]): string {
-  const result = spawnSync("nsc", args, { encoding: "utf-8" });
-  if (result.status !== 0) {
-    const msg = (result.stderr || result.stdout || "unknown error").trim();
+  const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+  if (result.exitCode !== 0) {
+    const msg = (stderr || stdout || "unknown error").trim();
     throw new Error(`nsc ${args[0]} failed: ${msg}`);
   }
-  return (result.stdout + result.stderr).trim();
+  return (stdout + stderr).trim();
 }
 
 export function ensureNscInstalled(): void {
-  const result = spawnSync("which", ["nsc"], { encoding: "utf-8" });
-  if (result.status !== 0) {
+  const result = Bun.spawnSync(["which", "nsc"], { stdout: "pipe" });
+  if (result.exitCode !== 0) {
     console.error("Error: nsc not found on PATH.");
     console.error("Install: brew install nats-io/nats-tools/nsc");
     process.exit(1);
@@ -40,15 +47,15 @@ function validateSubject(subject: string): void {
 }
 
 export function detectAccount(): string {
-  // Primary: read NSC config file (stable, no parsing)
-  if (existsSync(NSC_CONFIG)) {
+  for (const candidate of NSC_CONFIG_CANDIDATES) {
+    if (!existsSync(candidate)) continue;
     try {
-      const config = JSON.parse(readFileSync(NSC_CONFIG, "utf-8"));
+      const config = JSON.parse(readFileSync(candidate, "utf-8"));
       if (config.account && typeof config.account === "string") {
         return config.account;
       }
     } catch {
-      // fall through to regex
+      continue;
     }
   }
   // Fallback: parse nsc env output
@@ -58,8 +65,8 @@ export function detectAccount(): string {
   throw new Error("Cannot detect NSC account. Run: nsc env -a <account>");
 }
 
-function credsPath(name: string): string {
-  return join(CREDS_DIR, `${name}.creds`);
+function defaultCredsPath(name: string): string {
+  return join(DEFAULT_CREDS_DIR, `${name}.creds`);
 }
 
 function userExists(account: string, name: string): boolean {
@@ -71,15 +78,18 @@ function userExists(account: string, name: string): boolean {
   }
 }
 
-function ensureCredsDir(path: string): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
+function ensureDefaultCredsDir(): void {
+  if (!existsSync(DEFAULT_CREDS_DIR)) {
+    mkdirSync(DEFAULT_CREDS_DIR, { recursive: true, mode: 0o700 });
   }
-  chmodSync(dir, 0o700);
+  chmodSync(DEFAULT_CREDS_DIR, 0o700);
 }
 
 function writeCredsFile(path: string, content: string): void {
+  // Only enforce directory permissions on the default creds dir
+  if (dirname(path) === DEFAULT_CREDS_DIR) {
+    ensureDefaultCredsDir();
+  }
   writeFileSync(path, content, { mode: 0o600 });
   chmodSync(path, 0o600);
 }
@@ -101,7 +111,7 @@ export function addBot(name: string, opts: AddBotOptions): void {
   }
 
   const account = opts.account ?? detectAccount();
-  const outPath = opts.output ?? credsPath(name);
+  const outPath = opts.output ?? defaultCredsPath(name);
 
   if (existsSync(outPath) && !opts.force) {
     console.error(`Error: credentials exist at ${outPath}. Use --force to overwrite.`);
@@ -119,7 +129,6 @@ export function addBot(name: string, opts: AddBotOptions): void {
 
   nsc(["add", "user", "-a", account, "-n", name]);
 
-  // Permissions + creds generation wrapped for rollback on failure
   try {
     if (opts.pub) {
       for (const subj of opts.pub.split(",").map((s) => s.trim())) {
@@ -136,10 +145,8 @@ export function addBot(name: string, opts: AddBotOptions): void {
     }
 
     const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
-    ensureCredsDir(outPath);
     writeCredsFile(outPath, creds);
   } catch (err) {
-    // Rollback: delete the partially-configured user
     try { nsc(["delete", "user", "-a", account, "-n", name]); } catch { /* best effort */ }
     throw new Error(`Failed to configure user "${name}" — rolled back. Cause: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -158,28 +165,42 @@ export interface ReissueBotOptions {
 export function reissueBot(name: string, opts: ReissueBotOptions): void {
   ensureNscInstalled();
   const account = opts.account ?? detectAccount();
-  const outPath = opts.output ?? credsPath(name);
+  const outPath = opts.output ?? defaultCredsPath(name);
 
   if (!userExists(account, name)) {
     console.error(`Error: user "${name}" not found under "${account}".`);
     process.exit(1);
   }
 
+  // Generate new creds BEFORE deleting old user — validate the operation succeeds
+  // before making destructive changes. nsc requires delete+add for new keys,
+  // but we can at least back up the old creds file.
+  if (existsSync(outPath)) {
+    const backup = `${outPath}.bak`;
+    writeFileSync(backup, readFileSync(outPath));
+    chmodSync(backup, 0o600);
+    console.log(`  backup: ${backup}`);
+  }
+
   nsc(["delete", "user", "-a", account, "-n", name]);
 
   try {
     nsc(["add", "user", "-a", account, "-n", name]);
+    const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
+    writeCredsFile(outPath, creds);
   } catch (err) {
     console.error(`CRITICAL: failed to re-create user "${name}" after delete.`);
-    console.error(`The user has been removed but could not be re-created.`);
+    if (existsSync(`${outPath}.bak`)) {
+      console.error(`Old credentials backed up at: ${outPath}.bak`);
+      console.error(`Note: old creds are invalidated — backup is for reference only.`);
+    }
     console.error(`Manual recovery: nsc add user -a ${account} -n ${name}`);
     console.error(`Cause: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
 
-  const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
-  ensureCredsDir(outPath);
-  writeCredsFile(outPath, creds);
+  // Clean up backup on success
+  try { unlinkSync(`${outPath}.bak`); } catch { /* ok if no backup */ }
 
   console.log(`Re-issued credentials for ${name}`);
   console.log(`  credentials: ${outPath} (mode 600)`);
@@ -211,7 +232,7 @@ export function removeBot(name: string, opts: RemoveBotOptions): void {
   console.log(`Removed user: ${name} (account: ${account})`);
 
   if (opts.deleteCreds) {
-    const path = opts.output ?? credsPath(name);
+    const path = opts.output ?? defaultCredsPath(name);
     if (existsSync(path)) {
       unlinkSync(path);
       console.log(`Deleted credentials: ${path}`);

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -5,12 +5,13 @@
  * Part of grove#320 (bot-level AAA) — operator-level infrastructure tooling.
  */
 
-import { existsSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 
 const CREDS_DIR = join(homedir(), ".config", "nats");
+const NSC_CONFIG = join(homedir(), ".config", "nats", "nsc", "nsc.json");
 const NAMING_RE = /^[a-z][a-z0-9-]*$/;
 const NATS_SUBJECT_RE = /^[a-zA-Z0-9.*>_-]+$/;
 
@@ -20,7 +21,6 @@ function nsc(args: string[]): string {
     const msg = (result.stderr || result.stdout || "unknown error").trim();
     throw new Error(`nsc ${args[0]} failed: ${msg}`);
   }
-  // nsc writes some output to stderr (e.g., `nsc env`)
   return (result.stdout + result.stderr).trim();
 }
 
@@ -40,6 +40,18 @@ function validateSubject(subject: string): void {
 }
 
 export function detectAccount(): string {
+  // Primary: read NSC config file (stable, no parsing)
+  if (existsSync(NSC_CONFIG)) {
+    try {
+      const config = JSON.parse(readFileSync(NSC_CONFIG, "utf-8"));
+      if (config.account && typeof config.account === "string") {
+        return config.account;
+      }
+    } catch {
+      // fall through to regex
+    }
+  }
+  // Fallback: parse nsc env output
   const output = nsc(["env"]);
   const match = output.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
   if (match) return match[1];
@@ -106,27 +118,35 @@ export function addBot(name: string, opts: AddBotOptions): void {
   }
 
   nsc(["add", "user", "-a", account, "-n", name]);
+
+  // Permissions + creds generation wrapped for rollback on failure
+  try {
+    if (opts.pub) {
+      for (const subj of opts.pub.split(",").map((s) => s.trim())) {
+        validateSubject(subj);
+        nsc(["edit", "user", "-a", account, "-n", name, "--allow-pub", subj]);
+      }
+    }
+
+    if (opts.sub) {
+      for (const subj of opts.sub.split(",").map((s) => s.trim())) {
+        validateSubject(subj);
+        nsc(["edit", "user", "-a", account, "-n", name, "--allow-sub", subj]);
+      }
+    }
+
+    const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
+    ensureCredsDir(outPath);
+    writeCredsFile(outPath, creds);
+  } catch (err) {
+    // Rollback: delete the partially-configured user
+    try { nsc(["delete", "user", "-a", account, "-n", name]); } catch { /* best effort */ }
+    throw new Error(`Failed to configure user "${name}" — rolled back. Cause: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   console.log(`Created NATS user: ${name} (account: ${account})`);
-
-  if (opts.pub) {
-    for (const subj of opts.pub.split(",").map((s) => s.trim())) {
-      validateSubject(subj);
-      nsc(["edit", "user", "-a", account, "-n", name, "--allow-pub", subj]);
-    }
-    console.log(`  publish: ${opts.pub}`);
-  }
-
-  if (opts.sub) {
-    for (const subj of opts.sub.split(",").map((s) => s.trim())) {
-      validateSubject(subj);
-      nsc(["edit", "user", "-a", account, "-n", name, "--allow-sub", subj]);
-    }
-    console.log(`  subscribe: ${opts.sub}`);
-  }
-
-  const creds = nsc(["generate", "creds", "-a", account, "-n", name]);
-  ensureCredsDir(outPath);
-  writeCredsFile(outPath, creds);
+  if (opts.pub) console.log(`  publish: ${opts.pub}`);
+  if (opts.sub) console.log(`  subscribe: ${opts.sub}`);
   console.log(`  credentials: ${outPath} (mode 600)`);
 }
 
@@ -145,22 +165,15 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     process.exit(1);
   }
 
-  // Capture existing user config before delete for rollback
-  let existingConfig: string;
-  try {
-    existingConfig = nsc(["describe", "user", "-a", account, "-n", name, "--json"]);
-  } catch {
-    console.error(`Error: cannot read existing user config for "${name}".`);
-    process.exit(1);
-  }
-
   nsc(["delete", "user", "-a", account, "-n", name]);
 
   try {
     nsc(["add", "user", "-a", account, "-n", name]);
   } catch (err) {
-    console.error(`Error: failed to re-create user "${name}". Previous config saved to stderr.`);
-    process.stderr.write(`Previous user config:\n${existingConfig}\n`);
+    console.error(`CRITICAL: failed to re-create user "${name}" after delete.`);
+    console.error(`The user has been removed but could not be re-created.`);
+    console.error(`Manual recovery: nsc add user -a ${account} -n ${name}`);
+    console.error(`Cause: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
 

--- a/test/commands/nats.test.ts
+++ b/test/commands/nats.test.ts
@@ -1,20 +1,18 @@
 import { describe, test, expect, afterAll } from "bun:test";
 import { detectAccount, addBot, removeBot } from "../../src/commands/nats.js";
-import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
-const NSC_AVAILABLE = spawnSync("which", ["nsc"], { encoding: "utf-8" }).status === 0;
+const NSC_AVAILABLE = Bun.spawnSync(["which", "nsc"]).exitCode === 0;
 const TEST_ACCOUNT = "OP_JC";
 const TEST_BOT = "arc-test-bot";
 const CREDS_PATH = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
 
-// Cleanup in case prior run left state — use spawnSync to avoid process.exit
 function cleanupTestBot(): void {
-  spawnSync("nsc", ["delete", "user", "-a", TEST_ACCOUNT, "-n", TEST_BOT], { encoding: "utf-8" });
-  const p = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
-  try { require("fs").unlinkSync(p); } catch { /* ok */ }
+  Bun.spawnSync(["nsc", "delete", "user", "-a", TEST_ACCOUNT, "-n", TEST_BOT]);
+  try { unlinkSync(CREDS_PATH); } catch { /* ok */ }
+  try { unlinkSync(`${CREDS_PATH}.bak`); } catch { /* ok */ }
 }
 
 afterAll(() => {
@@ -52,23 +50,20 @@ describe("nats commands", () => {
 
   describe("subject validation", () => {
     test.skipIf(!NSC_AVAILABLE)("rejects subjects with shell metacharacters via CLI", () => {
-      const result = spawnSync("bun", [
-        "src/cli.ts", "nats", "add-bot", "subj-test",
-        "-a", TEST_ACCOUNT,
-        "--pub", "valid.subject,$(evil)",
-      ], { encoding: "utf-8", cwd: join(import.meta.dir, "../..") });
+      const result = Bun.spawnSync(["bun", "src/cli.ts", "nats", "add-bot", "subj-test",
+        "-a", TEST_ACCOUNT, "--pub", "valid.subject,$(evil)",
+      ], { cwd: join(import.meta.dir, "../.."), stderr: "pipe" });
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("Invalid NATS subject");
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain("Invalid NATS subject");
     });
 
     test.skipIf(!NSC_AVAILABLE)("rejects invalid bot name via CLI", () => {
-      const result = spawnSync("bun", [
-        "src/cli.ts", "nats", "add-bot", "UPPER-CASE",
+      const result = Bun.spawnSync(["bun", "src/cli.ts", "nats", "add-bot", "UPPER-CASE",
         "-a", TEST_ACCOUNT,
-      ], { encoding: "utf-8", cwd: join(import.meta.dir, "../..") });
+      ], { cwd: join(import.meta.dir, "../.."), stderr: "pipe" });
 
-      expect(result.status).not.toBe(0);
+      expect(result.exitCode).not.toBe(0);
     });
   });
 

--- a/test/commands/nats.test.ts
+++ b/test/commands/nats.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { detectAccount, addBot, removeBot } from "../../src/commands/nats.js";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const NSC_AVAILABLE = spawnSync("which", ["nsc"], { encoding: "utf-8" }).status === 0;
+const TEST_ACCOUNT = "OP_JC";
+const TEST_BOT = "arc-test-bot";
+const CREDS_PATH = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
+
+// Cleanup in case prior run left state — use spawnSync to avoid process.exit
+function cleanupTestBot(): void {
+  spawnSync("nsc", ["delete", "user", "-a", TEST_ACCOUNT, "-n", TEST_BOT], { encoding: "utf-8" });
+  const p = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
+  try { require("fs").unlinkSync(p); } catch { /* ok */ }
+}
+
+afterAll(() => {
+  if (!NSC_AVAILABLE) return;
+  cleanupTestBot();
+});
+
+describe("nats commands", () => {
+  describe("detectAccount", () => {
+    test.skipIf(!NSC_AVAILABLE)("detects current account from nsc config", () => {
+      const account = detectAccount();
+      expect(typeof account).toBe("string");
+      expect(account.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("addBot + removeBot lifecycle", () => {
+    test.skipIf(!NSC_AVAILABLE)("creates user, writes creds with correct perms, removes cleanly", () => {
+      cleanupTestBot();
+
+      addBot(TEST_BOT, { account: TEST_ACCOUNT });
+
+      expect(existsSync(CREDS_PATH)).toBe(true);
+      const stat = statSync(CREDS_PATH);
+      expect(stat.mode & 0o777).toBe(0o600);
+
+      const content = readFileSync(CREDS_PATH, "utf-8");
+      expect(content).toContain("BEGIN NATS USER JWT");
+      expect(content).toContain("BEGIN USER NKEY SEED");
+
+      removeBot(TEST_BOT, { account: TEST_ACCOUNT, deleteCreds: true });
+      expect(existsSync(CREDS_PATH)).toBe(false);
+    });
+  });
+
+  describe("subject validation", () => {
+    test.skipIf(!NSC_AVAILABLE)("rejects subjects with shell metacharacters via CLI", () => {
+      const result = spawnSync("bun", [
+        "src/cli.ts", "nats", "add-bot", "subj-test",
+        "-a", TEST_ACCOUNT,
+        "--pub", "valid.subject,$(evil)",
+      ], { encoding: "utf-8", cwd: join(import.meta.dir, "../..") });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Invalid NATS subject");
+    });
+
+    test.skipIf(!NSC_AVAILABLE)("rejects invalid bot name via CLI", () => {
+      const result = spawnSync("bun", [
+        "src/cli.ts", "nats", "add-bot", "UPPER-CASE",
+        "-a", TEST_ACCOUNT,
+      ], { encoding: "utf-8", cwd: join(import.meta.dir, "../..") });
+
+      expect(result.status).not.toBe(0);
+    });
+  });
+
+  describe("creds directory permissions", () => {
+    test.skipIf(!NSC_AVAILABLE)("creds directory is mode 700", () => {
+      const dir = join(homedir(), ".config", "nats");
+      if (existsSync(dir)) {
+        const stat = statSync(dir);
+        expect(stat.mode & 0o777).toBe(0o700);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds \`arc nats\` subcommand group for per-bot NATS user provisioning
- 4 commands: \`add-bot\`, \`reissue-bot\`, \`list-bots\`, \`remove-bot\`
- Wraps NSC with metafactory naming conventions
- Credentials at \`~/.config/nats/{name}.creds\` (mode 600)
- Tested end-to-end: add → list → remove with real NSC

## Architecture decision

Bot identity provisioning is operator-level infrastructure (Layer 2-3 in the [aPaaS vision](https://github.com/the-metafactory/meta-factory/blob/main/research/2026-05-06-apaas-nervous-system-vision.md)). Lives in arc (operator CLI), not grove (observability/dashboard).

## Changes

- \`src/commands/nats.ts\` — new: 4 exported functions + NSC helpers
- \`src/cli.ts\` — wires \`arc nats\` subcommand group

## Test plan

- [x] \`arc nats add-bot spike-test -a OP_JC\` — creates user + creds
- [x] \`arc nats list-bots -a OP_JC\` — shows spike-test in list
- [x] \`arc nats remove-bot spike-test -a OP_JC --delete-creds\` — removes user + file
- [x] \`arc nats list-bots\` (no account) — auto-detects active account

Part of [grove#320](https://github.com/the-metafactory/grove/issues/320) — Task T-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)