### PR TITLE
chore: bump package.json to 0.23.0 (matches arc-manifest.yaml) — closes #114

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.21.1",
+  "version": "0.23.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

One-line bump of `package.json` `"version"` field from `0.21.1` to `0.23.0`, matching what `arc-manifest.yaml` already reports.

Closes #114.

## Why

`arc --version` reads from `package.json`. Recent version bumps (e.g., [`abcb27a`](https://github.com/the-metafactory/arc/commit/abcb27a)) only touch `arc-manifest.yaml`, so `arc --version` reports a stale number even on the latest main. This PR resyncs the two.

## Diff

```diff
 {
   "name": "arc",
-  "version": "0.21.1",
+  "version": "0.23.0",
```

One field, one line.

## Test plan

- [x] `git diff` shows the single line change
- [x] `arc --version` will report `0.23.0` after merge + reinstall
- [ ] Reviewer-checked: no other consumers of package.json's `version` field that would break (quick `git grep '"version"' src` shows no consumers; the field is metadata only)

## Follow-up (not in this PR)

Per #114, the durable fix is one of:
- a) Add a release script that bumps both `package.json` and `arc-manifest.yaml` atomically
- b) Change `arc --version` to read from `arc-manifest.yaml` (single source of truth)

Either is fine; (b) is structurally cleaner. Worth deciding before the next version bump so this doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)