### PR TITLE
feat: hostPathFor() dispatch + HostAdapter in install (#117 phase 2)

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import { existsSync } from "fs";
-import type { PaiPaths, ArcManifest, ArtifactType, PackageTier } from "../types.js";
+import type { PaiPaths, ArcManifest, ArtifactType, HostAdapter, PackageTier } from "../types.js";
+import { getDefaultHost } from "../lib/paths.js";
 import type { Database } from "bun:sqlite";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
@@ -22,6 +23,13 @@ import { extractRepoName } from "../lib/repo-name.js";
 
 export interface InstallOptions {
   paths: PaiPaths;
+  /**
+   * Target host adapter. Defaults to the Claude-Code adapter when omitted —
+   * Phase 2 of #117 keeps every existing caller working unchanged. Callers
+   * that want to install into a specific backend (Codex, Cursor, …) pass
+   * their adapter explicitly once Phase 2's host detection lands.
+   */
+  host?: HostAdapter;
   db: Database;
   repoUrl: string;
   /** Skip capability display confirmation (for non-interactive / test use) */
@@ -69,6 +77,8 @@ export interface InstallResult {
  */
 export async function install(opts: InstallOptions): Promise<InstallResult> {
   const { paths, db, repoUrl } = opts;
+  // Resolve target host: caller-supplied or default (Claude Code).
+  const host = opts.host ?? getDefaultHost({ root: paths.claudeRoot });
 
   // 1. Clone repo (or use pre-extracted path for registry installs)
   const repoName = opts.preExtractedPath
@@ -264,6 +274,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     type: manifest.type,
     manifest,
     paths,
+    host,
     installDir: installPath,
     consumerDir: opts.consumerDir,
     quiet: opts.yes,
@@ -507,6 +518,7 @@ export async function installSingleArtifact(
   libraryName: string,
 ): Promise<InstallResult> {
   const { paths, db, repoUrl } = opts;
+  const host = opts.host ?? getDefaultHost({ root: paths.claudeRoot });
 
   // Display capabilities per-artifact
   const risk = assessRisk(manifest);
@@ -546,6 +558,7 @@ export async function installSingleArtifact(
     type: artifactType,
     manifest,
     paths,
+    host,
     installDir: artifactDir,
     consumerDir: opts.consumerDir,
     quiet: opts.yes,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -23,12 +23,7 @@ import { extractRepoName } from "../lib/repo-name.js";
 
 export interface InstallOptions {
   paths: PaiPaths;
-  /**
-   * Target host adapter. Defaults to the Claude-Code adapter when omitted —
-   * Phase 2 of #117 keeps every existing caller working unchanged. Callers
-   * that want to install into a specific backend (Codex, Cursor, …) pass
-   * their adapter explicitly once Phase 2's host detection lands.
-   */
+  /** Target host adapter. Defaults to Claude-Code when omitted. */
   host?: HostAdapter;
   db: Database;
   repoUrl: string;

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -237,8 +237,7 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "skill":
-    case "system":
-    default: {
+    case "system": {
       // Skills: symlink skill/ subdirectory (or root) to the host's skillsDir.
       const skillsDir = hostPathFor(host, type);
       if (!skillsDir) {
@@ -253,21 +252,33 @@ export async function createArtifactSymlinks(opts: {
         await linkTracked(installDir, skillLinkPath);
       }
 
-      // Create bin symlinks and shims for all CLI entries (skills with CLI).
-      // binDir comes from the same host as the skill install — they ship together.
-      const binDir = hostPathFor(host, "tool");
-      if (!binDir) {
-        throw new Error(`Host ${host.id} does not expose a bin directory for skill CLIs`);
-      }
+      // CLI symlinks + shims only when the skill declares CLI entries.
+      // The binDir lookup must stay inside this guard so a future adapter
+      // that supports skills but exposes no bin directory still installs
+      // pure-content skills cleanly.
       const cliEntries = extractAllCliInfo(manifest);
-      for (const entry of cliEntries) {
-        const binLinkPath = join(binDir, entry.binName);
-        await linkTracked(installDir, binLinkPath);
-      }
       if (cliEntries.length) {
+        const binDir = hostPathFor(host, "tool");
+        if (!binDir) {
+          throw new Error(
+            `Host ${host.id} does not expose a bin directory for skill CLIs`,
+          );
+        }
+        for (const entry of cliEntries) {
+          const binLinkPath = join(binDir, entry.binName);
+          await linkTracked(installDir, binLinkPath);
+        }
         await shimTracked();
       }
       break;
+    }
+
+    default: {
+      // Library is unwound at install.ts:181 before reaching this dispatch;
+      // any other value is a programming bug, not a user-facing error.
+      throw new Error(
+        `Unsupported artifact type "${type as string}" in createArtifactSymlinks`,
+      );
     }
   }
 

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -71,13 +71,7 @@ export async function createArtifactSymlinks(opts: {
   type: ArtifactType | "rules" | "system";
   manifest: ArcManifest;
   paths: PaiPaths;
-  /**
-   * Target host adapter. Used to look up per-host install directories via
-   * `hostPathFor(host, type)`. Phase 2 of #117: today it's always the
-   * Claude-Code adapter (so the host paths match what `paths` carries), but
-   * the parameter is here so callers can target Codex/Cursor adapters once
-   * those land.
-   */
+  /** Target host adapter. Defaults to Claude-Code in the caller. */
   host: HostAdapter;
   installDir: string;
   consumerDir?: string;

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -2,7 +2,7 @@ import { join, dirname } from "path";
 import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import type { ArtifactType, ArcManifest, PaiPaths } from "../types.js";
+import type { ArtifactType, ArcManifest, HostAdapter, PaiPaths } from "../types.js";
 import {
   createSymlink,
   createCliShim,
@@ -11,6 +11,7 @@ import {
   removeCliShim,
 } from "./symlinks.js";
 import { generateRules } from "./rules.js";
+import { hostPathFor } from "./hosts/dispatch.js";
 
 /**
  * Maps an artifact type to its conventional source subdirectory within a cloned repo.
@@ -70,6 +71,14 @@ export async function createArtifactSymlinks(opts: {
   type: ArtifactType | "rules" | "system";
   manifest: ArcManifest;
   paths: PaiPaths;
+  /**
+   * Target host adapter. Used to look up per-host install directories via
+   * `hostPathFor(host, type)`. Phase 2 of #117: today it's always the
+   * Claude-Code adapter (so the host paths match what `paths` carries), but
+   * the parameter is here so callers can target Codex/Cursor adapters once
+   * those land.
+   */
+  host: HostAdapter;
   installDir: string;
   consumerDir?: string;
   quiet?: boolean;
@@ -78,7 +87,7 @@ export async function createArtifactSymlinks(opts: {
   filesMissingSource: Array<{ source: string; target: string }>;
   record: ArtifactSymlinkRecord;
 }> {
-  const { type, manifest, paths, installDir, quiet } = opts;
+  const { type, manifest, paths, host, installDir, quiet } = opts;
   const record: ArtifactSymlinkRecord = { symlinks: [], shims: { dir: paths.shimDir, names: [] } };
 
   // Helper that wraps createSymlink + tracks the target for rollback (#89).
@@ -87,7 +96,7 @@ export async function createArtifactSymlinks(opts: {
     record.symlinks.push(target);
   };
   const shimTracked = async () => {
-    const created = await createCliShim(paths.shimDir, paths.binDir, manifest);
+    const created = await createCliShim(paths.shimDir, host.paths.binDir, manifest);
     record.shims.names.push(...created);
   };
 
@@ -138,16 +147,18 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "pipeline": {
-      // Pipelines: symlink repo root (or pipeline/ subdirectory) to pipelinesDir
+      // Pipelines: symlink repo root (or pipeline/ subdirectory) to pipelinesDir.
+      // pipelinesDir is arc state (host-independent) — pipelines aren't host-installed.
       const pipelineSourceDir = join(installDir, "pipeline");
       const sourceDir = existsSync(pipelineSourceDir) ? pipelineSourceDir : installDir;
       const pipelineLinkPath = join(paths.pipelinesDir, manifest.name);
       await linkTracked(sourceDir, pipelineLinkPath);
 
-      // If the manifest declares CLI entries, also create shims
+      // If the manifest declares CLI entries, the bin shims still go through
+      // the host (binDir is per-host).
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
-        const binLinkPath = join(paths.binDir, entry.binName);
+        const binLinkPath = join(host.paths.binDir, entry.binName);
         await linkTracked(installDir, binLinkPath);
       }
       if (cliEntries.length) {
@@ -163,15 +174,19 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "tool": {
-      // Tools: symlink repo root to binDir for each CLI entry
+      // Tools: symlink repo root to the host's binDir for each CLI entry.
+      const binDir = hostPathFor(host, "tool");
+      if (!binDir) {
+        throw new Error(`Host ${host.id} does not support tool artifacts`);
+      }
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
-        const binLinkPath = join(paths.binDir, entry.binName);
+        const binLinkPath = join(binDir, entry.binName);
         await linkTracked(installDir, binLinkPath);
       }
       if (!cliEntries.length) {
         // Fallback: symlink under manifest name if no CLI declared
-        await linkTracked(installDir, join(paths.binDir, manifest.name));
+        await linkTracked(installDir, join(binDir, manifest.name));
       }
 
       // Create PATH-accessible shims for all CLI entries
@@ -180,35 +195,43 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "agent": {
-      // Agents: symlink the .md file directly into agentsDir for Claude auto-discovery
+      // Agents: symlink the .md file directly into agentsDir for auto-discovery.
+      const agentsDir = hostPathFor(host, "agent");
+      if (!agentsDir) {
+        throw new Error(`Host ${host.id} does not support agent artifacts`);
+      }
       const agentSourceDir = join(installDir, "agent");
       const sourceDir = existsSync(agentSourceDir) ? agentSourceDir : installDir;
       const mdFile = `${manifest.name}.md`;
       const sourcePath = join(sourceDir, mdFile);
-      const linkPath = join(paths.agentsDir, mdFile);
+      const linkPath = join(agentsDir, mdFile);
 
       if (existsSync(sourcePath)) {
         await linkTracked(sourcePath, linkPath);
       } else {
         // Fallback: symlink directory if .md file not found by convention name
-        await linkTracked(sourceDir, join(paths.agentsDir, manifest.name));
+        await linkTracked(sourceDir, join(agentsDir, manifest.name));
       }
       break;
     }
 
     case "prompt": {
-      // Prompts: symlink the .md file directly into promptsDir for Claude auto-discovery
+      // Prompts: symlink the .md file directly into promptsDir for auto-discovery.
+      const promptsDir = hostPathFor(host, "prompt");
+      if (!promptsDir) {
+        throw new Error(`Host ${host.id} does not support prompt artifacts`);
+      }
       const promptSourceDir = join(installDir, "prompt");
       const sourceDir = existsSync(promptSourceDir) ? promptSourceDir : installDir;
       const mdFile = `${manifest.name}.md`;
       const sourcePath = join(sourceDir, mdFile);
-      const linkPath = join(paths.promptsDir, mdFile);
+      const linkPath = join(promptsDir, mdFile);
 
       if (existsSync(sourcePath)) {
         await linkTracked(sourcePath, linkPath);
       } else {
         // Fallback: symlink directory if .md file not found by convention name
-        await linkTracked(sourceDir, join(paths.promptsDir, manifest.name));
+        await linkTracked(sourceDir, join(promptsDir, manifest.name));
       }
       break;
     }
@@ -216,9 +239,13 @@ export async function createArtifactSymlinks(opts: {
     case "skill":
     case "system":
     default: {
-      // Skills: symlink skill/ subdirectory (or root) to skillsDir
+      // Skills: symlink skill/ subdirectory (or root) to the host's skillsDir.
+      const skillsDir = hostPathFor(host, type);
+      if (!skillsDir) {
+        throw new Error(`Host ${host.id} does not support skill artifacts`);
+      }
       const skillSourceDir = join(installDir, "skill");
-      const skillLinkPath = join(paths.skillsDir, manifest.name);
+      const skillLinkPath = join(skillsDir, manifest.name);
 
       if (existsSync(skillSourceDir)) {
         await linkTracked(skillSourceDir, skillLinkPath);
@@ -226,10 +253,15 @@ export async function createArtifactSymlinks(opts: {
         await linkTracked(installDir, skillLinkPath);
       }
 
-      // Create bin symlinks and shims for all CLI entries (skills with CLI)
+      // Create bin symlinks and shims for all CLI entries (skills with CLI).
+      // binDir comes from the same host as the skill install — they ship together.
+      const binDir = hostPathFor(host, "tool");
+      if (!binDir) {
+        throw new Error(`Host ${host.id} does not expose a bin directory for skill CLIs`);
+      }
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
-        const binLinkPath = join(paths.binDir, entry.binName);
+        const binLinkPath = join(binDir, entry.binName);
         await linkTracked(installDir, binLinkPath);
       }
       if (cliEntries.length) {

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -18,6 +18,20 @@ import type { ArtifactType, HostAdapter } from "../../types.js";
  * Returning `null` is the right "I cannot install this" signal — callers
  * should fall back to the arc-state path or the consumer repo, never invent
  * a host directory the adapter didn't promise.
+ *
+ * ## Not equivalent to `HostAdapter.supports()`
+ *
+ * The two answer different questions:
+ *
+ *   - `supports(type)` → "does the host *recognize* this artifact type?"
+ *   - `hostPathFor(host, type)` → "does this type *install into* a host
+ *     directory, and if so, where?"
+ *
+ * `host.supports("component")` is `true` (Claude Code recognizes components)
+ * but `hostPathFor(host, "component")` is `null` (components don't install
+ * into a host directory). Don't bridge them — calling
+ * `hostPathFor(host, type)!` after a positive `supports()` check will hit a
+ * null on component / rules / library.
  */
 export function hostPathFor(
   host: HostAdapter,

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -1,0 +1,45 @@
+import type { ArtifactType, HostAdapter } from "../../types.js";
+
+/**
+ * Map an artifact type to its install directory on a given host.
+ *
+ * Returns `null` for types that don't live inside a host's directory tree:
+ *
+ *   - `pipeline` / `action` — arc state (`~/.config/metafactory/{pipelines,actions}/`)
+ *   - `rules`               — writes templates into the consumer repo
+ *   - `library`             — meta type; contained artifacts route individually
+ *   - `component`           — no per-type primary layout; uses provides.files only
+ *
+ * Phase 2 install dispatch (per #117) uses this to ask the host "where does
+ * this go on you?" instead of hard-coding `host.paths.skillsDir` etc. at
+ * every call site. When future adapters land (Codex, Cursor, …) they can
+ * differ on directory naming without changing dispatch code.
+ *
+ * Returning `null` is the right "I cannot install this" signal — callers
+ * should fall back to the arc-state path or the consumer repo, never invent
+ * a host directory the adapter didn't promise.
+ */
+export function hostPathFor(
+  host: HostAdapter,
+  type: ArtifactType | "system",
+): string | null {
+  switch (type) {
+    case "skill":
+    case "system":
+      return host.paths.skillsDir;
+    case "agent":
+      return host.paths.agentsDir;
+    case "prompt":
+      return host.paths.promptsDir;
+    case "tool":
+      return host.paths.binDir;
+    case "component":
+    case "rules":
+    case "library":
+    case "pipeline":
+    case "action":
+      return null;
+    default:
+      return null;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -486,7 +486,15 @@ export interface HostAdapter {
   detect(): boolean;
   /** Per-host install paths. */
   paths: HostPaths;
-  /** Whether this host accepts the given artifact type. */
+  /**
+   * Whether this host *recognizes* the given artifact type.
+   *
+   * Note: `supports(type) === true` does NOT imply
+   * `hostPathFor(host, type) !== null`. Some types (`component`, `rules`,
+   * `library`) are recognized but don't install into a host directory —
+   * `hostPathFor()` returns `null` for them. The two predicates answer
+   * different questions; never bridge them.
+   */
   supports(type: ArtifactType): boolean;
 }
 

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -108,4 +108,52 @@ describe("createArtifactSymlinks null-guard throws", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test("skills without CLI entries install cleanly even when host has no binDir", async () => {
+    // Carryover from Holly's review on #119: the binDir guard used to fire
+    // unconditionally for every skill install. A skill with zero CLI
+    // entries doesn't need binDir, so a future adapter that supports
+    // skills but exposes no binDir should still install pure-content
+    // skills successfully.
+    const tmp = mkdtempSync(join(tmpdir(), "arc-skill-nocli-"));
+    try {
+      const paths = createPaths({
+        claudeRoot: join(tmp, ".claude"),
+        configRoot: join(tmp, ".config", "metafactory"),
+      });
+      // Host that exposes skillsDir but no binDir.
+      const skillsOnlyHost: HostAdapter = {
+        id: "claude-code",
+        detect: () => true,
+        paths: {
+          root: paths.claudeRoot,
+          skillsDir: join(paths.claudeRoot, "skills"),
+          agentsDir: "",
+          promptsDir: "",
+          binDir: "",
+          settingsPath: "",
+        },
+        supports: () => true,
+      };
+      const manifest: ArcManifest = {
+        name: "pure-content-skill",
+        version: "1.0.0",
+        type: "skill",
+      };
+
+      const result = await createArtifactSymlinks({
+        type: "skill",
+        manifest,
+        paths,
+        host: skillsOnlyHost,
+        installDir: tmp,
+        quiet: true,
+      });
+
+      expect(result.record.symlinks.length).toBe(1);
+      expect(result.record.shims.names.length).toBe(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "bun:test";
+import { hostPathFor } from "../../src/lib/hosts/dispatch.js";
+import { getDefaultHost } from "../../src/lib/paths.js";
+
+describe("hostPathFor", () => {
+  const host = getDefaultHost({ root: "/tmp/test/.claude" });
+
+  test("maps skill → skillsDir", () => {
+    expect(hostPathFor(host, "skill")).toBe("/tmp/test/.claude/skills");
+  });
+
+  test("maps system (legacy alias) → skillsDir", () => {
+    expect(hostPathFor(host, "system")).toBe("/tmp/test/.claude/skills");
+  });
+
+  test("maps agent → agentsDir", () => {
+    expect(hostPathFor(host, "agent")).toBe("/tmp/test/.claude/agents");
+  });
+
+  test("maps prompt → promptsDir", () => {
+    expect(hostPathFor(host, "prompt")).toBe("/tmp/test/.claude/commands");
+  });
+
+  test("maps tool → binDir", () => {
+    expect(hostPathFor(host, "tool")).toBe("/tmp/test/.claude/bin");
+  });
+
+  test("returns null for component (no per-type primary layout)", () => {
+    expect(hostPathFor(host, "component")).toBeNull();
+  });
+
+  test("returns null for rules (writes into consumer repo, not host)", () => {
+    expect(hostPathFor(host, "rules")).toBeNull();
+  });
+
+  test("returns null for library (meta type; contained artifacts route individually)", () => {
+    expect(hostPathFor(host, "library")).toBeNull();
+  });
+
+  test("returns null for pipeline (arc state, not host)", () => {
+    expect(hostPathFor(host, "pipeline")).toBeNull();
+  });
+
+  test("returns null for action (arc state, not host)", () => {
+    expect(hostPathFor(host, "action")).toBeNull();
+  });
+});

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -1,6 +1,11 @@
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { hostPathFor } from "../../src/lib/hosts/dispatch.js";
-import { getDefaultHost } from "../../src/lib/paths.js";
+import { createPaths, getDefaultHost } from "../../src/lib/paths.js";
+import { createArtifactSymlinks } from "../../src/lib/artifact-installer.js";
+import type { ArcManifest, HostAdapter } from "../../src/types.js";
 
 describe("hostPathFor", () => {
   const host = getDefaultHost({ root: "/tmp/test/.claude" });
@@ -43,5 +48,64 @@ describe("hostPathFor", () => {
 
   test("returns null for action (arc state, not host)", () => {
     expect(hostPathFor(host, "action")).toBeNull();
+  });
+});
+
+describe("createArtifactSymlinks null-guard throws", () => {
+  // Stub adapter with empty host paths — fires the `if (!dir) throw`
+  // branches in artifact-installer's switch when a future host adapter
+  // doesn't expose a directory for a given artifact type. With only the
+  // Claude-Code adapter shipping today, this is the only way to exercise
+  // those throws (see Holly's review on #119).
+  function makeEmptyPathHost(): HostAdapter {
+    return {
+      id: "claude-code",
+      detect: () => false,
+      paths: {
+        root: "",
+        skillsDir: "",
+        agentsDir: "",
+        promptsDir: "",
+        binDir: "",
+        settingsPath: "",
+      },
+      supports: () => false,
+    };
+  }
+
+  test("hostPathFor returns falsy for skill when host paths are empty", () => {
+    // The artifact-installer guard is `if (!dir)`, which catches both null
+    // and empty string — the runtime safety net works for both shapes.
+    const stub = makeEmptyPathHost();
+    expect(Boolean(hostPathFor(stub, "skill"))).toBe(false);
+  });
+
+  test("createArtifactSymlinks throws when the host has no agent directory", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "arc-guard-test-"));
+    try {
+      const paths = createPaths({
+        claudeRoot: join(tmp, ".claude"),
+        configRoot: join(tmp, ".config", "metafactory"),
+      });
+      const stub = makeEmptyPathHost();
+      const manifest: ArcManifest = {
+        name: "stub-agent",
+        version: "1.0.0",
+        type: "agent",
+      };
+
+      await expect(
+        createArtifactSymlinks({
+          type: "agent",
+          manifest,
+          paths,
+          host: stub,
+          installDir: tmp,
+          quiet: true,
+        }),
+      ).rejects.toThrow(/does not support agent artifacts/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of #117 — surgical migration of the install hot path to the `HostAdapter` abstraction from Phase 1, plus the type→path mapping Holly asked for in round 3 of #118's review (see https://github.com/the-metafactory/arc/issues/117#issuecomment-4425374042).

## Changes

- **`src/lib/hosts/dispatch.ts`** *(new)* — `hostPathFor(host, type)` returns the host's directory for an artifact type, or `null` for types that don't live inside the host tree:
  - `skill` / `system` → `host.paths.skillsDir`
  - `agent` → `host.paths.agentsDir`
  - `prompt` → `host.paths.promptsDir`
  - `tool` → `host.paths.binDir`
  - `component`, `rules`, `library`, `pipeline`, `action` → `null`
- **`src/lib/artifact-installer.ts`** — `createArtifactSymlinks()` takes a new required `host: HostAdapter` parameter. The skill/agent/prompt/tool dispatch cases use `hostPathFor()` instead of hard-coded `paths.skillsDir` etc. Pipeline still uses `paths.pipelinesDir` because it's host-independent arc state.
- **`src/commands/install.ts`** — `InstallOptions` gains optional `host?: HostAdapter`. `install()` and `installSingleArtifact()` resolve it via `opts.host ?? getDefaultHost(...)`. Existing callers (CLI, tests) keep working unchanged.
- **`test/unit/hosts-dispatch.test.ts`** *(new)* — 10 tests pinning the dispatch table.

## Why `null` instead of throwing in `hostPathFor`

Holly's design note on #117 spelled out the rationale: the mapping should be honest about which types aren't host-installed (rules → consumer repo, pipeline/action → arc state, component → no per-type primary layout, library → meta type). Returning `null` lets callers fall back to the right place rather than inventing a host directory the adapter never promised.

Callers that reach a `null` after asking for what should be a host artifact (skill/agent/prompt/tool) throw a clear `Host \<id\> does not support \<type\> artifacts` error.

## Design choices

**`host?: HostAdapter` optional, not required, on `InstallOptions`.** Making it required would propagate to ~20 callers (CLI + tests). Optional + default = no caller churn for this PR. Phase 3 may tighten this once the rest of the migration is done.

**`getDefaultHost({ root: paths.claudeRoot })`** — explicit pass-through of `paths.claudeRoot` so test isolation works: tests overriding `claudeRoot` automatically get a host pointing at the temp dir without needing to pass `host` explicitly.

**`pipeline` case keeps `paths.pipelinesDir`, not `hostPathFor(host, "pipeline")`.** That's intentional — `hostPathFor` returns `null` for pipelines because they aren't host-installed. The pipeline case continues to use arc state directly. Same logic for `action` (handled in PR 3 when we migrate `paths.actionsDir`).

## Test plan

- [x] `bun test test/unit/hosts-dispatch.test.ts` — 10 pass (new)
- [x] `bun test` full suite — **697/697 pass** (687 prior + 10 new)
- [x] Type-check passes
- [x] Existing `install()` callers untouched
- [x] Holly's design note addressed (issue #117 comment-4425374042)

## What stays for PR 3

Wide mechanical rename of the remaining ~400 `paths.X` accesses to `arc.X` / `host.paths.X`, then deletion of `PaiPaths` and `createPaths`. PR 3 is pure search-and-replace once the abstraction is proven.

## References

- Issue: #117
- Holly's design note: https://github.com/the-metafactory/arc/issues/117#issuecomment-4425374042
- Phase 1 PR: #118 (merged as e2df58f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)