### PR TITLE
feat: requireHostDir() helper + arc/host on TestEnv (#117 phase 3a)

### DIFF
--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -11,7 +11,7 @@ import {
   removeCliShim,
 } from "./symlinks.js";
 import { generateRules } from "./rules.js";
-import { hostPathFor } from "./hosts/dispatch.js";
+import { requireHostDir } from "./hosts/dispatch.js";
 
 /**
  * Maps an artifact type to its conventional source subdirectory within a cloned repo.
@@ -169,10 +169,7 @@ export async function createArtifactSymlinks(opts: {
 
     case "tool": {
       // Tools: symlink repo root to the host's binDir for each CLI entry.
-      const binDir = hostPathFor(host, "tool");
-      if (!binDir) {
-        throw new Error(`Host ${host.id} does not support tool artifacts`);
-      }
+      const binDir = requireHostDir(host, "tool");
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
         const binLinkPath = join(binDir, entry.binName);
@@ -190,10 +187,7 @@ export async function createArtifactSymlinks(opts: {
 
     case "agent": {
       // Agents: symlink the .md file directly into agentsDir for auto-discovery.
-      const agentsDir = hostPathFor(host, "agent");
-      if (!agentsDir) {
-        throw new Error(`Host ${host.id} does not support agent artifacts`);
-      }
+      const agentsDir = requireHostDir(host, "agent");
       const agentSourceDir = join(installDir, "agent");
       const sourceDir = existsSync(agentSourceDir) ? agentSourceDir : installDir;
       const mdFile = `${manifest.name}.md`;
@@ -211,10 +205,7 @@ export async function createArtifactSymlinks(opts: {
 
     case "prompt": {
       // Prompts: symlink the .md file directly into promptsDir for auto-discovery.
-      const promptsDir = hostPathFor(host, "prompt");
-      if (!promptsDir) {
-        throw new Error(`Host ${host.id} does not support prompt artifacts`);
-      }
+      const promptsDir = requireHostDir(host, "prompt");
       const promptSourceDir = join(installDir, "prompt");
       const sourceDir = existsSync(promptSourceDir) ? promptSourceDir : installDir;
       const mdFile = `${manifest.name}.md`;
@@ -233,10 +224,7 @@ export async function createArtifactSymlinks(opts: {
     case "skill":
     case "system": {
       // Skills: symlink skill/ subdirectory (or root) to the host's skillsDir.
-      const skillsDir = hostPathFor(host, type);
-      if (!skillsDir) {
-        throw new Error(`Host ${host.id} does not support skill artifacts`);
-      }
+      const skillsDir = requireHostDir(host, type);
       const skillSourceDir = join(installDir, "skill");
       const skillLinkPath = join(skillsDir, manifest.name);
 
@@ -252,12 +240,11 @@ export async function createArtifactSymlinks(opts: {
       // pure-content skills cleanly.
       const cliEntries = extractAllCliInfo(manifest);
       if (cliEntries.length) {
-        const binDir = hostPathFor(host, "tool");
-        if (!binDir) {
-          throw new Error(
-            `Host ${host.id} does not expose a bin directory for skill CLIs`,
-          );
-        }
+        const binDir = requireHostDir(
+          host,
+          "tool",
+          "expose a bin directory for skill CLIs",
+        );
         for (const entry of cliEntries) {
           const binLinkPath = join(binDir, entry.binName);
           await linkTracked(installDir, binLinkPath);

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -66,9 +66,6 @@ export function hostPathFor(
  *
  * For types that legitimately return null (component / rules / library /
  * pipeline / action), use {@link hostPathFor} directly and branch on null.
- *
- * Suggested by Holly in cycle 1 of #119; landed in Phase 3 of #117 alongside
- * the wide rename.
  */
 export function requireHostDir(
   host: HostAdapter,

--- a/src/lib/hosts/dispatch.ts
+++ b/src/lib/hosts/dispatch.ts
@@ -57,3 +57,28 @@ export function hostPathFor(
       return null;
   }
 }
+
+/**
+ * Throwing variant of {@link hostPathFor}. Use at install/remove dispatch
+ * points that have already established the artifact type *must* live in a
+ * host directory (skill / agent / prompt / tool) — turning a null into a
+ * single-line precondition error keeps the call sites readable.
+ *
+ * For types that legitimately return null (component / rules / library /
+ * pipeline / action), use {@link hostPathFor} directly and branch on null.
+ *
+ * Suggested by Holly in cycle 1 of #119; landed in Phase 3 of #117 alongside
+ * the wide rename.
+ */
+export function requireHostDir(
+  host: HostAdapter,
+  type: ArtifactType | "system",
+  description?: string,
+): string {
+  const dir = hostPathFor(host, type);
+  if (!dir) {
+    const what = description ?? `support ${type as string} artifacts`;
+    throw new Error(`Host ${host.id} does not ${what}`);
+  }
+  return dir;
+}

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -10,16 +10,30 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { Database } from "bun:sqlite";
 import YAML from "yaml";
-import { createPaths } from "../../src/lib/paths.js";
+import {
+  createArcPaths,
+  createPaths,
+  ensureDirectories,
+  getDefaultHost,
+} from "../../src/lib/paths.js";
 import { openDatabase } from "../../src/lib/db.js";
-import { ensureDirectories } from "../../src/lib/paths.js";
-import type { PaiPaths } from "../../src/types.js";
+import type { ArcPaths, HostAdapter, PaiPaths } from "../../src/types.js";
 
 export interface TestEnv {
   /** Root temp directory for this test */
   root: string;
-  /** PaiPaths pointing to temp directories */
+  /**
+   * Combined arc + host paths for back-compat.
+   *
+   * @deprecated Use `env.arc` for arc state paths and `env.host.paths` for
+   *   host install paths. Kept during the #117 migration so existing tests
+   *   keep passing; will be removed once all test sites migrate.
+   */
   paths: PaiPaths;
+  /** arc's host-independent state paths (configRoot, dbPath, …). */
+  arc: ArcPaths;
+  /** Target host adapter (Claude Code by default, with paths rooted at the temp dir). */
+  host: HostAdapter;
   /** Open database for this test */
   db: Database;
   /** Clean up temp directory and close database */
@@ -33,32 +47,54 @@ export interface TestEnv {
 export async function createTestEnv(): Promise<TestEnv> {
   const root = await mkdtemp(join(tmpdir(), "arc-test-"));
 
-  const paths = createPaths({
-    claudeRoot: join(root, ".claude"),
-    configRoot: join(root, ".config", "pai"),
-    skillsDir: join(root, ".claude", "skills"),
-    agentsDir: join(root, ".claude", "agents"),
-    promptsDir: join(root, ".claude", "commands"),
-    binDir: join(root, ".claude", "bin"),
+  const claudeRoot = join(root, ".claude");
+  const configRoot = join(root, ".config", "pai");
+
+  const arc = createArcPaths({
+    configRoot,
+    reposDir: join(configRoot, "pkg", "repos"),
+    cachePath: join(configRoot, "pkg", "cache"),
+    dbPath: join(configRoot, "packages.db"),
+    sourcesPath: join(configRoot, "sources.yaml"),
+    secretsDir: join(configRoot, "secrets"),
+    runtimeDir: join(configRoot, "skills"),
+    actionsDir: join(configRoot, "actions"),
     shimDir: join(root, "bin"),
-    reposDir: join(root, ".config", "pai", "pkg", "repos"),
-    dbPath: join(root, ".config", "pai", "packages.db"),
-    secretsDir: join(root, ".config", "pai", "secrets"),
-    runtimeDir: join(root, ".config", "pai", "skills"),
     catalogPath: join(root, "catalog.yaml"),
     registryPath: join(root, "registry.yaml"),
-    sourcesPath: join(root, ".config", "pai", "sources.yaml"),
-    cachePath: join(root, ".config", "pai", "pkg", "cache"),
-    actionsDir: join(root, ".config", "pai", "actions"),
-    settingsPath: join(root, ".claude", "settings.json"),
+  });
+  const host = getDefaultHost({ root: claudeRoot });
+
+  // Compose the legacy PaiPaths object from arc + host for back-compat
+  // consumers. Once tests migrate to env.arc / env.host.paths this can go.
+  const paths = createPaths({
+    claudeRoot,
+    configRoot,
+    skillsDir: host.paths.skillsDir,
+    agentsDir: host.paths.agentsDir,
+    promptsDir: host.paths.promptsDir,
+    binDir: host.paths.binDir,
+    shimDir: arc.shimDir,
+    reposDir: arc.reposDir,
+    dbPath: arc.dbPath,
+    secretsDir: arc.secretsDir,
+    runtimeDir: arc.runtimeDir,
+    catalogPath: arc.catalogPath,
+    registryPath: arc.registryPath,
+    sourcesPath: arc.sourcesPath,
+    cachePath: arc.cachePath,
+    actionsDir: arc.actionsDir,
+    settingsPath: host.paths.settingsPath,
   });
 
   await ensureDirectories(paths);
-  const db = openDatabase(paths.dbPath);
+  const db = openDatabase(arc.dbPath);
 
   return {
     root,
     paths,
+    arc,
+    host,
     db,
     cleanup: async () => {
       db.close();

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -51,28 +51,27 @@ describe("hostPathFor", () => {
   });
 });
 
-describe("createArtifactSymlinks null-guard throws", () => {
-  // Stub adapter with empty host paths — fires the `if (!dir) throw`
-  // branches in artifact-installer's switch when a future host adapter
-  // doesn't expose a directory for a given artifact type. With only the
-  // Claude-Code adapter shipping today, this is the only way to exercise
-  // those throws (see Holly's review on #119).
-  function makeEmptyPathHost(): HostAdapter {
-    return {
-      id: "claude-code",
-      detect: () => false,
-      paths: {
-        root: "",
-        skillsDir: "",
-        agentsDir: "",
-        promptsDir: "",
-        binDir: "",
-        settingsPath: "",
-      },
-      supports: () => false,
-    };
-  }
+// Stub adapter with empty host paths — used to exercise the `if (!dir)`
+// guard / requireHostDir() throws when a future host adapter doesn't expose
+// a directory for a given artifact type. With only the Claude-Code adapter
+// shipping today, this is the only way to fire those paths.
+function makeEmptyPathHost(): HostAdapter {
+  return {
+    id: "claude-code",
+    detect: () => false,
+    paths: {
+      root: "",
+      skillsDir: "",
+      agentsDir: "",
+      promptsDir: "",
+      binDir: "",
+      settingsPath: "",
+    },
+    supports: () => false,
+  };
+}
 
+describe("createArtifactSymlinks null-guard throws", () => {
   test("hostPathFor returns falsy for skill when host paths are empty", () => {
     // The artifact-installer guard is `if (!dir)`, which catches both null
     // and empty string — the runtime safety net works for both shapes.
@@ -184,19 +183,7 @@ describe("requireHostDir", () => {
   });
 
   test("throws with host id baked into the error message", () => {
-    const stubHost = {
-      id: "claude-code" as const,
-      detect: () => false,
-      paths: {
-        root: "",
-        skillsDir: "",
-        agentsDir: "",
-        promptsDir: "",
-        binDir: "",
-        settingsPath: "",
-      },
-      supports: () => false,
-    };
+    const stubHost = makeEmptyPathHost();
     expect(() => requireHostDir(stubHost, "skill")).toThrow(/^Host claude-code/);
   });
 });

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { hostPathFor } from "../../src/lib/hosts/dispatch.js";
+import { hostPathFor, requireHostDir } from "../../src/lib/hosts/dispatch.js";
 import { createPaths, getDefaultHost } from "../../src/lib/paths.js";
 import { createArtifactSymlinks } from "../../src/lib/artifact-installer.js";
 import type { ArcManifest, HostAdapter } from "../../src/types.js";
@@ -155,5 +155,48 @@ describe("createArtifactSymlinks null-guard throws", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+describe("requireHostDir", () => {
+  test("returns the directory for supported types (passthrough of hostPathFor)", () => {
+    const host = getDefaultHost({ root: "/tmp/test/.claude" });
+    expect(requireHostDir(host, "skill")).toBe("/tmp/test/.claude/skills");
+    expect(requireHostDir(host, "agent")).toBe("/tmp/test/.claude/agents");
+    expect(requireHostDir(host, "prompt")).toBe("/tmp/test/.claude/commands");
+    expect(requireHostDir(host, "tool")).toBe("/tmp/test/.claude/bin");
+  });
+
+  test("throws with default message when hostPathFor returns null", () => {
+    const host = getDefaultHost({ root: "/tmp/test/.claude" });
+    expect(() => requireHostDir(host, "rules")).toThrow(
+      /Host claude-code does not support rules artifacts/,
+    );
+  });
+
+  test("accepts a custom description for context-specific guards", () => {
+    const host = getDefaultHost({ root: "/tmp/test/.claude" });
+    expect(() =>
+      requireHostDir(host, "library", "expose a registry for library artifacts"),
+    ).toThrow(
+      /Host claude-code does not expose a registry for library artifacts/,
+    );
+  });
+
+  test("throws with host id baked into the error message", () => {
+    const stubHost = {
+      id: "claude-code" as const,
+      detect: () => false,
+      paths: {
+        root: "",
+        skillsDir: "",
+        agentsDir: "",
+        promptsDir: "",
+        binDir: "",
+        settingsPath: "",
+      },
+      supports: () => false,
+    };
+    expect(() => requireHostDir(stubHost, "skill")).toThrow(/^Host claude-code/);
   });
 });


### PR DESCRIPTION
## Summary

Phase 3a of #117 — lands Holly's `requireHostDir()` helper from cycle 1 of #119 and prepares the test surface for the wide PaiPaths rename. **Pure additive, zero behavior change**, every existing test passes unmodified.

I re-scoped Phase 3 mid-flight: the full mechanical rename across 17 files + 30 test files was too large for one safe PR. Splitting into 3a (this PR — helper + test surface) and 3b (wide rename + delete PaiPaths) makes both reviewable.

## Changes

- **`src/lib/hosts/dispatch.ts`** — new `requireHostDir(host, type, description?)` throwing variant of `hostPathFor`. Use at install dispatch points where the type must live in a host directory; the optional `description` argument keeps the "expose a bin directory for skill CLIs" wording at the one site that needs it.
- **`src/lib/artifact-installer.ts`** — collapse 5× repeated `if (!dir) throw` blocks (tool / agent / prompt / skill / skill-CLI) into single `requireHostDir()` calls. Net -15 lines.
- **`test/helpers/test-env.ts`** — `TestEnv` exposes `arc: ArcPaths` and `host: HostAdapter` alongside the legacy `paths`. The combined `paths` is composed from arc + host so existing `env.paths.X` accesses keep working without change. The new fields let phase 3b migrate test sites incrementally rather than flag-day.
- **`test/unit/hosts-dispatch.test.ts`** — 4 new tests pinning `requireHostDir` (passthrough for supported types, default error message, custom description, host id baked in).

## What stays for phase 3b

- Wide rename of remaining ~400 `paths.X` accesses across commands + tests to `arc.X` / `host.paths.X`
- Migrate function signatures to take `arc: ArcPaths, host: HostAdapter` instead of `paths: PaiPaths`
- Delete `PaiPaths` type and `createPaths` shim

3b is mechanical search-and-replace — easier to land and review now that the helper and TestEnv shape are in place.

## Test plan

- [x] `bun test test/unit/hosts-dispatch.test.ts` — 17 pass (13 prior + 4 new)
- [x] `bun test` full suite — **704/704 pass** (700 prior + 4 new)
- [x] Zero call site changes outside `artifact-installer.ts`
- [x] `env.paths.X` still resolves identically to before this PR

## References

- Issue: #117
- Holly's `requireHostDir` suggestion: #119 cycle 1 inline comment on `artifact-installer.ts:260`
- Phase 1: #118 (merged e2df58f)
- Phase 2: #119 (merged 393ffa2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)