### PR TITLE
refactor(verify): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
-import { createPaths, ensureDirectories } from "./lib/paths.js";
+import { createPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
 import { openDatabase } from "./lib/db.js";
 import { install, parseNameVersion } from "./commands/install.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
@@ -468,8 +468,9 @@ program
   .description("Verify integrity of an installed skill")
   .action(async (name: string) => {
     const paths = createPaths();
+    const host = getDefaultHost({ root: paths.claudeRoot });
     const db = openDatabase(paths.dbPath);
-    const result = await verify(db, paths, name);
+    const result = await verify(db, paths, host, name);
     console.log(formatVerify(result));
     db.close();
   });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -23,6 +23,13 @@ export interface VerifyResult {
 /**
  * Verify integrity of an installed skill.
  */
+/**
+ * Verify integrity of an installed skill.
+ *
+ * @param arc Unused until Phase 3c, which adds arc-state checks (db row /
+ *   manifest cross-reference, sources.yaml integrity). Kept in the
+ *   signature now so that pass doesn't churn every call site twice.
+ */
 export async function verify(
   db: Database,
   arc: ArcPaths,

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,7 +1,7 @@
 import { join, relative } from "path";
 import { existsSync, readdirSync, statSync } from "fs";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths, HostAdapter } from "../types.js";
 import { getSkill } from "../lib/db.js";
 import { isValidSymlink } from "../lib/symlinks.js";
 import { readManifest } from "../lib/manifest.js";
@@ -25,7 +25,8 @@ export interface VerifyResult {
  */
 export async function verify(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<VerifyResult> {
   const skill = getSkill(db, name);
@@ -57,7 +58,7 @@ export async function verify(
 
   // Check 3: Skill symlink valid (only for active skills)
   if (skill.status === "active") {
-    const skillLink = join(paths.skillsDir, name);
+    const skillLink = join(host.paths.skillsDir, name);
     const linkValid = await isValidSymlink(skillLink);
     checks.push({
       check: "Skill symlink valid",
@@ -94,7 +95,7 @@ export async function verify(
   // package whose installer registered hooks pointing at files that were
   // never placed (see #84) would still pass verify. Walk the package's hooks
   // from settings.json and stat each absolute path token.
-  const registeredHooks = listPackageHooks(name, paths.settingsPath);
+  const registeredHooks = listPackageHooks(name, host.paths.settingsPath);
   if (registeredHooks.length) {
     const missing = findMissingHookFiles(registeredHooks);
     if (missing.length === 0) {

--- a/test/commands/verify.test.ts
+++ b/test/commands/verify.test.ts
@@ -30,7 +30,7 @@ describe("verify command", () => {
       yes: true,
     });
 
-    const result = await verify(env.db, env.paths, "TestSkill");
+    const result = await verify(env.db, env.arc, env.host, "TestSkill");
     expect(result.allPassed).toBe(true);
 
     const symlinkCheck = result.checks.find((c) =>
@@ -51,7 +51,7 @@ describe("verify command", () => {
       yes: true,
     });
 
-    const result = await verify(env.db, env.paths, "TestSkill");
+    const result = await verify(env.db, env.arc, env.host, "TestSkill");
     const manifestCheck = result.checks.find((c) =>
       c.check.includes("manifest")
     );
@@ -59,7 +59,7 @@ describe("verify command", () => {
   });
 
   test("returns error for non-installed skill", async () => {
-    const result = await verify(env.db, env.paths, "NonExistent");
+    const result = await verify(env.db, env.arc, env.host, "NonExistent");
     expect(result.allPassed).toBe(false);
     expect(result.error).toContain("not installed");
   });
@@ -78,7 +78,7 @@ describe("verify command", () => {
       yes: true,
     });
 
-    const result = await verify(env.db, env.paths, "NoHookSkill");
+    const result = await verify(env.db, env.arc, env.host, "NoHookSkill");
     expect(result.allPassed).toBe(true);
     const hookCheck = result.checks.find((c) => c.check.includes("Hook command"));
     expect(hookCheck).toBeUndefined();
@@ -132,7 +132,7 @@ describe("verify command", () => {
     });
     expect(installResult.success).toBe(true);
 
-    const result = await verify(env.db, env.paths, "LiveHook");
+    const result = await verify(env.db, env.arc, env.host, "LiveHook");
     const hookCheck = result.checks.find((c) => c.check.includes("Hook command"));
     expect(hookCheck).toBeDefined();
     expect(hookCheck!.passed).toBe(true);
@@ -190,7 +190,7 @@ describe("verify command", () => {
     // still points at the path, repo dir still has the source file.
     await rm(targetPath, { force: true });
 
-    const result = await verify(env.db, env.paths, "DeletedHook");
+    const result = await verify(env.db, env.arc, env.host, "DeletedHook");
     expect(result.allPassed).toBe(false);
     const hookCheck = result.checks.find((c) => c.check.includes("Hook command"));
     expect(hookCheck).toBeDefined();

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -97,7 +97,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(infoResult.manifest!.author?.name).toBe("mellanon");
 
     // --- VERIFY ---
-    const verifyResult = await verify(env.db, env.paths, "_JIRA");
+    const verifyResult = await verify(env.db, env.arc, env.host, "_JIRA");
     expect(verifyResult.allPassed).toBe(true);
 
     // --- AUDIT ---


### PR DESCRIPTION
## Summary

First production caller migrated to the post-Phase-2 shape. Demonstrates the pattern for the remaining ~6 command files. Small atomic slice so the pattern can be reviewed before propagating.

## Changes

- **`src/commands/verify.ts`** — signature changes from `verify(db, paths: PaiPaths, name)` to `verify(db, arc: ArcPaths, host: HostAdapter, name)`. Internal `paths.skillsDir` and `paths.settingsPath` accesses become `host.paths.skillsDir` / `host.paths.settingsPath`. The `arc` parameter isn't read yet but stays in the signature for Phase 3 consistency (future verify checks will need arc state).
- **`src/cli.ts`** — verify command action derives `host` via `getDefaultHost({ root: paths.claudeRoot })` and passes both to `verify()`. Other commands stay on the old signature until their slice lands.
- **`test/commands/verify.test.ts`** — 6 call sites updated to pass `env.arc` and `env.host` (fields added in Phase 3a).
- **`test/e2e/lifecycle.test.ts`** — single verify call updated.

## Pattern this slice establishes

For each remaining command (catalog / disable / enable / install / remove / upgrade):

1. Replace `paths: PaiPaths` in the public signature with `arc: ArcPaths, host: HostAdapter`
2. Inside the body, replace `paths.<host-field>` with `host.paths.<field>` (`claudeRoot` → `root`)
3. Update the CLI action site: add `const host = getDefaultHost({ root: paths.claudeRoot })`
4. Update test call sites: `env.paths` → `env.arc, env.host`

After all command slices land, the final phase (3d) deletes `PaiPaths`, `createPaths`, and the `paths` back-compat field from `TestEnv`.

## Test plan

- [x] `bun test test/commands/verify.test.ts` — 6 pass
- [x] `bun test test/e2e/lifecycle.test.ts` — 8 pass (incl. lifecycle that uses verify)
- [x] `bun test` full suite — **704/704 pass**

## References

- Issue: #117
- Phase 1: #118 (e2df58f) — types + adapter
- Phase 2: #119 (393ffa2) — hostPathFor() + install dispatch
- Phase 3a: #120 (77938e8) — requireHostDir() + TestEnv arc/host

🤖 Generated with [Claude Code](https://claude.com/claude-code)