### PR TITLE
refactor(upgrade): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -482,12 +482,13 @@ program
   .option("--force", "Re-run upgrade pipeline even if already at latest version")
   .action(async (name: string | undefined, opts: { check?: boolean; force?: boolean }) => {
     const paths = createPaths();
+    const host = getDefaultHost({ root: paths.claudeRoot });
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);
 
     if (opts.check || (!name && !opts.force)) {
       // Check mode or upgrade-all (without force): first show what's available
-      const checks = await checkUpgrades(db, paths);
+      const checks = await checkUpgrades(db, paths, host);
 
       if (opts.check) {
         // Also check if arc itself has an update
@@ -502,13 +503,13 @@ program
           console.log("All packages are up to date.");
         } else {
           console.log(`Upgrading ${upgradable.length} package(s)...\n`);
-          const results = await upgradeAll(db, paths);
+          const results = await upgradeAll(db, paths, host);
           console.log(formatUpgradeResults(results));
         }
       }
     } else if (!name && opts.force) {
       // Force upgrade all
-      const results = await upgradeAll(db, paths, { force: true });
+      const results = await upgradeAll(db, paths, host, { force: true });
       if (!results.length) {
         console.log("No packages installed.");
       } else {
@@ -530,10 +531,10 @@ program
       }
 
       if (isLibraryUpgrade) {
-        const results = await upgradeLibrary(db, paths, name!, { force: opts.force });
+        const results = await upgradeLibrary(db, paths, host, name!, { force: opts.force });
         console.log(formatUpgradeResults(results, { force: opts.force }));
       } else {
-        const result = await upgradePackage(db, paths, upgradeName, { force: opts.force });
+        const result = await upgradePackage(db, paths, host, upgradeName, { force: opts.force });
         if (result.success) {
           if (result.oldVersion === result.newVersion) {
             if (opts.force) {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -50,10 +50,16 @@ function compareSemver(a: string, b: string): number {
 
 /**
  * Check which installed packages have newer versions available.
+ *
+ * @param host Unused today; threaded for signature consistency with
+ *   upgradePackage / upgradeAll / upgradeLibrary. Will be consumed when
+ *   check needs host-specific upgrade-path detection (e.g. an adapter
+ *   that resolves upgrades through a host-side registry).
  */
 export async function checkUpgrades(
   db: Database,
-  arc: ArcPaths, host: HostAdapter
+  arc: ArcPaths,
+  host: HostAdapter,
 ): Promise<UpgradeCheckResult[]> {
   const installed = listSkills(db).filter((s) => s.status === "active");
   const sources = await loadSources(arc.sourcesPath);

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import type { PaiPaths, InstalledSkill, SourcesConfig, RulesTemplate } from "../types.js";
+import type { ArcPaths, HostAdapter, InstalledSkill, SourcesConfig, RulesTemplate } from "../types.js";
 import type { Database } from "bun:sqlite";
 import { listSkills, getSkill, listByLibrary } from "../lib/db.js";
 import { readManifest, readLibraryArtifacts } from "../lib/manifest.js";
@@ -53,10 +53,10 @@ function compareSemver(a: string, b: string): number {
  */
 export async function checkUpgrades(
   db: Database,
-  paths: PaiPaths
+  arc: ArcPaths, host: HostAdapter
 ): Promise<UpgradeCheckResult[]> {
   const installed = listSkills(db).filter((s) => s.status === "active");
-  const sources = await loadSources(paths.sourcesPath);
+  const sources = await loadSources(arc.sourcesPath);
   const results: UpgradeCheckResult[] = [];
 
   for (const skill of installed) {
@@ -69,7 +69,7 @@ export async function checkUpgrades(
     };
 
     // Check registry for advertised version
-    const found = await findInAllSources(sources, skill.name, paths.cachePath);
+    const found = await findInAllSources(sources, skill.name, arc.cachePath);
     if (found?.entry.version) {
       result.registryVersion = found.entry.version;
     }
@@ -138,7 +138,7 @@ function findConsumerRepos(templates: RulesTemplate[]): string[] {
  */
 export async function upgradePackage(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths, host: HostAdapter,
   name: string,
   opts?: { force?: boolean }
 ): Promise<UpgradeResult> {
@@ -225,15 +225,15 @@ export async function upgradePackage(
   }
 
   // Re-register hooks (remove old, add new) — no consent prompt on upgrade.
-  // paths.claudeRoot is threaded as $PAI_DIR expansion target — see install.ts.
+  // host.paths.root is threaded as $PAI_DIR expansion target — see install.ts.
   const resolvedHooks = resolveHooksFromManifest(
     manifest.provides?.hooks,
     installPath,
     name,
-    paths.claudeRoot,
+    host.paths.root,
   );
   if (resolvedHooks?.length) {
-    const settingsPath = paths.settingsPath;
+    const settingsPath = host.paths.settingsPath;
     await removeHooks(name, settingsPath);
     await registerHooks(name, resolvedHooks, settingsPath);
   }
@@ -249,7 +249,7 @@ export async function upgradePackage(
 
   // Re-wire extensions (if declared)
   if (manifest.extensions) {
-    const wired = await wireExtensions(manifest, installPath, paths.claudeRoot);
+    const wired = await wireExtensions(manifest, installPath, host.paths.root);
     for (const ext of wired) {
       console.log(`  \u2713 Extension wired: ${ext}`);
     }
@@ -311,7 +311,7 @@ export async function upgradePackage(
  */
 export async function upgradeAll(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths, host: HostAdapter,
   opts?: { force?: boolean }
 ): Promise<UpgradeResult[]> {
   const results: UpgradeResult[] = [];
@@ -320,14 +320,14 @@ export async function upgradeAll(
     // Skip checkUpgrades entirely — just get all active packages from DB
     const active = listSkills(db).filter((s) => s.status === "active");
     for (const pkg of active) {
-      const result = await upgradePackage(db, paths, pkg.name, opts);
+      const result = await upgradePackage(db, arc, host, pkg.name, opts);
       results.push(result);
     }
   } else {
-    const checks = await checkUpgrades(db, paths);
+    const checks = await checkUpgrades(db, arc, host);
     const upgradable = checks.filter((c) => c.upgradable);
     for (const check of upgradable) {
-      const result = await upgradePackage(db, paths, check.name);
+      const result = await upgradePackage(db, arc, host, check.name);
       results.push(result);
     }
   }
@@ -390,7 +390,7 @@ export function formatUpgradeResults(results: UpgradeResult[], opts?: { force?: 
  */
 export async function upgradeLibrary(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths, host: HostAdapter,
   libraryName: string,
   opts?: { force?: boolean }
 ): Promise<UpgradeResult[]> {
@@ -416,7 +416,7 @@ export async function upgradeLibrary(
   // This ensures per-artifact scripts, hooks, capabilities, and symlinks are all handled.
   const results: UpgradeResult[] = [];
   for (const artifact of artifacts) {
-    const result = await upgradePackage(db, paths, artifact.name, opts);
+    const result = await upgradePackage(db, arc, host, artifact.name, opts);
     results.push(result);
   }
 
@@ -441,7 +441,19 @@ export async function upgradeLibrary(
         const artifactDir = join(gitRoot, entry.path);
         const installResult = await installSingleArtifact(
           {
-            paths,
+            // installSingleArtifact still takes PaiPaths today — recombine
+            // arc + host into the legacy shape until install.ts migrates
+            // in a later Phase 3b slice.
+            paths: {
+              ...arc,
+              claudeRoot: host.paths.root,
+              skillsDir: host.paths.skillsDir,
+              agentsDir: host.paths.agentsDir,
+              promptsDir: host.paths.promptsDir,
+              binDir: host.paths.binDir,
+              settingsPath: host.paths.settingsPath,
+            },
+            host,
             db,
             repoUrl: artifacts[0].repo_url,
             yes: true,

--- a/test/commands/library-upgrade.test.ts
+++ b/test/commands/library-upgrade.test.ts
@@ -35,7 +35,7 @@ describe("library upgrade", () => {
       { cwd: lib.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const results = await upgradeLibrary(env.db, env.paths, "test-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "test-lib");
     expect(results).toHaveLength(2);
 
     const alpha = results.find((r) => r.name === "alpha")!;
@@ -73,7 +73,7 @@ describe("library upgrade", () => {
     );
 
     // Upgrade just alpha via upgradePackage (simulates arc upgrade library:alpha)
-    const result = await upgradePackage(env.db, env.paths, "alpha");
+    const result = await upgradePackage(env.db, env.arc, env.host, "alpha");
     expect(result.success).toBe(true);
     expect(result.oldVersion).toBe("1.0.0");
     expect(result.newVersion).toBe("1.1.0");
@@ -108,7 +108,7 @@ describe("library upgrade", () => {
       { cwd: lib.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const results = await upgradeLibrary(env.db, env.paths, "test-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "test-lib");
     expect(results).toHaveLength(2);
     expect(results.every((r) => r.success)).toBe(true);
     expect(results.every((r) => r.newVersion === "2.0.0")).toBe(true);
@@ -122,7 +122,7 @@ describe("library upgrade", () => {
 
   test("upgradeLibrary errors when no artifacts installed", async () => {
     env = await createTestEnv();
-    const results = await upgradeLibrary(env.db, env.paths, "nonexistent-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "nonexistent-lib");
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(false);
     expect(results[0].error).toContain("No artifacts installed");
@@ -140,7 +140,7 @@ describe("library upgrade", () => {
     await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
 
     // No changes in source repo
-    const results = await upgradeLibrary(env.db, env.paths, "test-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "test-lib");
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(true);
     expect(results[0].oldVersion).toBe("1.0.0");
@@ -229,7 +229,7 @@ describe("library upgrade", () => {
     );
 
     // Run upgrade
-    const results = await upgradeLibrary(env.db, env.paths, "test-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "test-lib");
 
     // Should include results for alpha, beta, AND gamma
     expect(results.length).toBeGreaterThanOrEqual(3);

--- a/test/commands/lifecycle-hooks.test.ts
+++ b/test/commands/lifecycle-hooks.test.ts
@@ -186,7 +186,7 @@ describe("upgrade lifecycle hooks", () => {
       { cwd: repo.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const result = await upgradePackage(env.db, env.paths, "UpgradeHooked");
+    const result = await upgradePackage(env.db, env.arc, env.host, "UpgradeHooked");
     expect(result.success).toBe(true);
     expect(result.newVersion).toBe("1.1.0");
 
@@ -230,7 +230,7 @@ describe("upgrade lifecycle hooks", () => {
       { cwd: repo.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const result = await upgradePackage(env.db, env.paths, "FallbackHook");
+    const result = await upgradePackage(env.db, env.arc, env.host, "FallbackHook");
     expect(result.success).toBe(true);
 
     const log = await Bun.file(logPath).text();
@@ -272,7 +272,7 @@ describe("upgrade lifecycle hooks", () => {
       { cwd: repo.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const result = await upgradePackage(env.db, env.paths, "VersionEnv");
+    const result = await upgradePackage(env.db, env.arc, env.host, "VersionEnv");
     expect(result.success).toBe(true);
 
     const content = await Bun.file(markerPath).text();
@@ -309,7 +309,7 @@ describe("upgrade lifecycle hooks", () => {
       { cwd: repo.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const result = await upgradePackage(env.db, env.paths, "FailUpgrade");
+    const result = await upgradePackage(env.db, env.arc, env.host, "FailUpgrade");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Preupgrade script failed");
   });

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -65,7 +65,7 @@ describe("checkUpgrades", () => {
     };
     await saveSources(env.paths.sourcesPath, sources);
 
-    const results = await checkUpgrades(env.db, env.paths);
+    const results = await checkUpgrades(env.db, env.arc, env.host);
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe("TestSkill");
     expect(results[0].installedVersion).toBe("1.0.0");
@@ -105,7 +105,7 @@ describe("checkUpgrades", () => {
       sources: [{ name: "test", url: `file://${regPath}`, tier: "community", enabled: true }],
     });
 
-    const results = await checkUpgrades(env.db, env.paths);
+    const results = await checkUpgrades(env.db, env.arc, env.host);
     expect(results[0].upgradable).toBe(false);
   });
 });
@@ -129,7 +129,7 @@ describe("upgradePackage", () => {
       { cwd: repo.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const result = await upgradePackage(env.db, env.paths, "Upgradeable");
+    const result = await upgradePackage(env.db, env.arc, env.host, "Upgradeable");
     expect(result.success).toBe(true);
     expect(result.oldVersion).toBe("1.0.0");
     expect(result.newVersion).toBe("1.1.0");
@@ -148,14 +148,14 @@ describe("upgradePackage", () => {
     });
     await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
 
-    const result = await upgradePackage(env.db, env.paths, "Current");
+    const result = await upgradePackage(env.db, env.arc, env.host, "Current");
     expect(result.success).toBe(true);
     expect(result.oldVersion).toBe("1.0.0");
     expect(result.newVersion).toBe("1.0.0");
   });
 
   test("returns error for unknown package", async () => {
-    const result = await upgradePackage(env.db, env.paths, "NotInstalled");
+    const result = await upgradePackage(env.db, env.arc, env.host, "NotInstalled");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not installed");
   });
@@ -168,7 +168,7 @@ describe("upgradePackage", () => {
     await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
 
     // Without force: returns success with same version (short-circuit)
-    const normalResult = await upgradePackage(env.db, env.paths, "ForceUpgrade");
+    const normalResult = await upgradePackage(env.db, env.arc, env.host, "ForceUpgrade");
     expect(normalResult.success).toBe(true);
     expect(normalResult.oldVersion).toBe("1.0.0");
     expect(normalResult.newVersion).toBe("1.0.0");
@@ -183,7 +183,7 @@ describe("upgradePackage", () => {
     expect(before.version).toBe("0.9.0");
 
     // With force: runs the full upgrade pipeline, updates DB back to manifest version
-    const forceResult = await upgradePackage(env.db, env.paths, "ForceUpgrade", { force: true });
+    const forceResult = await upgradePackage(env.db, env.arc, env.host, "ForceUpgrade", { force: true });
     expect(forceResult.success).toBe(true);
     expect(forceResult.oldVersion).toBe("0.9.0");
     expect(forceResult.newVersion).toBe("1.0.0");
@@ -266,11 +266,11 @@ describe("upgradeAll", () => {
     await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
 
     // Without force, upgradeAll would return empty (nothing upgradable)
-    const normalResults = await upgradeAll(env.db, env.paths);
+    const normalResults = await upgradeAll(env.db, env.arc, env.host);
     expect(normalResults).toHaveLength(0);
 
     // With force, upgradeAll should include all active packages
-    const forceResults = await upgradeAll(env.db, env.paths, { force: true });
+    const forceResults = await upgradeAll(env.db, env.arc, env.host, { force: true });
     expect(forceResults).toHaveLength(1);
     expect(forceResults[0].name).toBe("ForceAll");
     expect(forceResults[0].success).toBe(true);
@@ -290,14 +290,14 @@ describe("upgradeLibrary", () => {
     env.db.prepare("UPDATE skills SET library_name = ? WHERE name = ?").run("my-lib", "LibArtifact");
 
     // upgradeLibrary with force should process the artifact without error
-    const results = await upgradeLibrary(env.db, env.paths, "my-lib", { force: true });
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "my-lib", { force: true });
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe("LibArtifact");
     expect(results[0].success).toBe(true);
   });
 
   test("returns error for unknown library", async () => {
-    const results = await upgradeLibrary(env.db, env.paths, "nonexistent-lib");
+    const results = await upgradeLibrary(env.db, env.arc, env.host, "nonexistent-lib");
     expect(results).toHaveLength(1);
     expect(results[0].success).toBe(false);
     expect(results[0].error).toContain("No artifacts installed");

--- a/test/e2e/library-lifecycle.test.ts
+++ b/test/e2e/library-lifecycle.test.ts
@@ -69,7 +69,7 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
       { cwd: lib.path, stdout: "pipe", stderr: "pipe" }
     );
 
-    const upgradeResults = await upgradeLibrary(env.db, env.paths, "my-lib");
+    const upgradeResults = await upgradeLibrary(env.db, env.arc, env.host, "my-lib");
     expect(upgradeResults).toHaveLength(2);
 
     const reviewUpgrade = upgradeResults.find((r) => r.name === "review")!;


### PR DESCRIPTION
## Summary

Second production slice following the verify pattern from PR #122. Four exported functions in `src/commands/upgrade.ts` migrated to the post-Phase-2 shape.

## Changes

**Public signatures:**
- `checkUpgrades(db, arc, host)`
- `upgradePackage(db, arc, host, name, opts?)`
- `upgradeAll(db, arc, host, opts?)`
- `upgradeLibrary(db, arc, host, libraryName, opts?)`

**Internal accesses rewritten:**
| Before | After |
|---|---|
| `paths.sourcesPath`, `paths.cachePath` | `arc.<field>` |
| `paths.claudeRoot` | `host.paths.root` |
| `paths.settingsPath` | `host.paths.settingsPath` |

**One legacy bridge:** `upgradeLibrary` calls `installSingleArtifact`, which still takes the legacy `PaiPaths` shape. The InstallOptions there reconstructs the PaiPaths from `arc + host` inline (8 lines). Goes away when `install.ts` migrates in slice 3b/3.

**CLI:** derives `host` once at the top of the upgrade action and threads through every call site.

**Test callers updated:** 7 sites across:
- `test/commands/upgrade.test.ts`
- `test/commands/library-upgrade.test.ts`
- `test/commands/lifecycle-hooks.test.ts`
- `test/e2e/library-lifecycle.test.ts`

## Test plan

- [x] `bun test test/commands/upgrade.test.ts test/commands/library-upgrade.test.ts` — 20 pass
- [x] `bun test` full suite — **704/704 pass**

## References

- Issue: #117
- Phase 3b/1: #122 (b963f4e) — verify migrated, pattern established
- Same pattern from #122: signature change + internal rewrites + CLI host derivation + test caller updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)