### PR TITLE
refactor(install): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/3)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,7 @@ program
     const paths = createPaths();
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);
+    const host = getDefaultHost({ root: paths.claudeRoot });
 
     // Check if input is a registry package ref (@scope/name[@version])
     const pkgRef = parsePackageRef(nameOrUrl);
@@ -270,7 +271,8 @@ program
       // Continue with standard install flow (manifest, symlinks, hooks, DB).
       // Use preExtractedPath so install() skips git clone.
       const result = await install({
-        paths,
+        arc: paths,
+        host,
         db,
         repoUrl: formatPackageRef({ scope: resolved.scope, name: resolved.name, version: resolved.version }),
         yes: opts.yes,
@@ -286,7 +288,7 @@ program
       }
     } else if (isUrl) {
       // Direct git install
-      const result = await install({ paths, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion });
+      const result = await install({ arc: paths, host, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion });
       if (result.success) {
         if (result.artifacts?.length) {
           console.log(`\n✅ Installed ${result.artifacts.filter(a => a.success).length} artifact(s) from ${result.name}`);
@@ -312,7 +314,8 @@ program
 
       // Install directly from the source URL
       const result = await install({
-        paths,
+        arc: paths,
+        host,
         db,
         repoUrl: found.entry.source,
         yes: opts.yes,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,7 +1,6 @@
 import { join } from "path";
 import { existsSync } from "fs";
-import type { PaiPaths, ArcManifest, ArtifactType, HostAdapter, PackageTier } from "../types.js";
-import { getDefaultHost } from "../lib/paths.js";
+import type { ArcPaths, ArcManifest, ArtifactType, HostAdapter, PackageTier } from "../types.js";
 import type { Database } from "bun:sqlite";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
@@ -22,9 +21,10 @@ import { wireExtensions } from "../lib/extensions.js";
 import { extractRepoName } from "../lib/repo-name.js";
 
 export interface InstallOptions {
-  paths: PaiPaths;
-  /** Target host adapter. Defaults to Claude-Code when omitted. */
-  host?: HostAdapter;
+  /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
+  arc: ArcPaths;
+  /** Target host adapter (Claude Code today; Codex/Cursor later). */
+  host: HostAdapter;
   db: Database;
   repoUrl: string;
   /** Skip capability display confirmation (for non-interactive / test use) */
@@ -71,19 +71,17 @@ export interface InstallResult {
  * 7. Record in database
  */
 export async function install(opts: InstallOptions): Promise<InstallResult> {
-  const { paths, db, repoUrl } = opts;
-  // Resolve target host: caller-supplied or default (Claude Code).
-  const host = opts.host ?? getDefaultHost({ root: paths.claudeRoot });
+  const { arc, host, db, repoUrl } = opts;
 
   // 1. Clone repo (or use pre-extracted path for registry installs)
   const repoName = opts.preExtractedPath
     ? opts.preExtractedPath.split("/").pop() ?? extractRepoName(repoUrl)
     : extractRepoName(repoUrl);
-  const installPath = opts.preExtractedPath ?? join(paths.reposDir, repoName);
+  const installPath = opts.preExtractedPath ?? join(arc.reposDir, repoName);
 
   // S2: Path traversal guard — ensure installPath stays inside reposDir
   const normalizedInstall = join(installPath); // resolves ../ segments
-  const normalizedRepos = join(paths.reposDir);
+  const normalizedRepos = join(arc.reposDir);
   if (!normalizedInstall.startsWith(normalizedRepos + "/") && normalizedInstall !== normalizedRepos) {
     return {
       success: false,
@@ -200,7 +198,8 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       }
 
       const depResult = await install({
-        paths,
+        arc,
+        host,
         db,
         repoUrl: dep.repo,
         yes: opts.yes,
@@ -268,7 +267,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   const symlinkResult = await createArtifactSymlinks({
     type: manifest.type,
     manifest,
-    paths,
+    arc,
     host,
     installDir: installPath,
     consumerDir: opts.consumerDir,
@@ -286,14 +285,14 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   }
 
   // 5b. Register hooks (if declared, with consent gating).
-  // paths.claudeRoot is passed as the $PAI_DIR expansion target so a hook
+  // host.paths.root is passed as the $PAI_DIR expansion target so a hook
   // command like ${PAI_DIR}/hooks/handlers/Foo.ts gets stat'd against the
   // absolute path the runtime would resolve to (issue #85).
   const resolvedHooks = resolveHooksFromManifest(
     manifest.provides?.hooks,
     installPath,
     manifest.name,
-    paths.claudeRoot,
+    host.paths.root,
   );
   if (resolvedHooks?.length) {
     // Refuse to register hooks whose command points at a file that does not
@@ -323,7 +322,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       opts.yes,
     );
     if (approved) {
-      const settingsPath = paths.settingsPath;
+      const settingsPath = host.paths.settingsPath;
       await registerHooks(manifest.name, resolvedHooks, settingsPath);
       if (!opts.yes) {
         console.log("  \u2713 Hooks registered in settings.json");
@@ -337,7 +336,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
 
   // 5c. Wire extensions (if declared)
   if (manifest.extensions) {
-    const wired = await wireExtensions(manifest, installPath, paths.claudeRoot);
+    const wired = await wireExtensions(manifest, installPath, host.paths.root);
     if (wired.length && !opts.yes) {
       for (const ext of wired) {
         console.log(`  \u2713 Extension wired: ${ext}`);
@@ -363,7 +362,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       // Tear down hook registrations and symlinks before returning so the
       // user gets a clean failure rather than orphans they have to clean up
       // by hand.
-      await removeHooks(manifest.name, paths.settingsPath);
+      await removeHooks(manifest.name, host.paths.settingsPath);
       await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,
@@ -512,8 +511,7 @@ export async function installSingleArtifact(
   manifest: ArcManifest,
   libraryName: string,
 ): Promise<InstallResult> {
-  const { paths, db, repoUrl } = opts;
-  const host = opts.host ?? getDefaultHost({ root: paths.claudeRoot });
+  const { arc, host, db, repoUrl } = opts;
 
   // Display capabilities per-artifact
   const risk = assessRisk(manifest);
@@ -552,7 +550,7 @@ export async function installSingleArtifact(
   const symlinkResult = await createArtifactSymlinks({
     type: artifactType,
     manifest,
-    paths,
+    arc,
     host,
     installDir: artifactDir,
     consumerDir: opts.consumerDir,
@@ -570,12 +568,12 @@ export async function installSingleArtifact(
   }
 
   // Register hooks (with consent gating — same as standalone install).
-  // See note above on paths.claudeRoot threading $PAI_DIR substitution.
+  // See note above on host.paths.root threading $PAI_DIR substitution.
   const resolvedHooks = resolveHooksFromManifest(
     manifest.provides?.hooks,
     artifactDir,
     manifest.name,
-    paths.claudeRoot,
+    host.paths.root,
   );
   if (resolvedHooks?.length) {
     // Refuse to register hooks whose command points at a file that does not
@@ -605,7 +603,7 @@ export async function installSingleArtifact(
       opts.yes,
     );
     if (approved) {
-      const settingsPath = paths.settingsPath;
+      const settingsPath = host.paths.settingsPath;
       await registerHooks(manifest.name, resolvedHooks, settingsPath);
       if (!opts.yes) {
         console.log("  \u2713 Hooks registered in settings.json");
@@ -635,7 +633,7 @@ export async function installSingleArtifact(
       // Tear down hook registrations and symlinks before returning so the
       // user gets a clean failure rather than orphans they have to clean up
       // by hand.
-      await removeHooks(manifest.name, paths.settingsPath);
+      await removeHooks(manifest.name, host.paths.settingsPath);
       await rollbackArtifactSymlinks(symlinkResult.record);
       return {
         success: false,

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -447,18 +447,7 @@ export async function upgradeLibrary(
         const artifactDir = join(gitRoot, entry.path);
         const installResult = await installSingleArtifact(
           {
-            // installSingleArtifact still takes PaiPaths today — recombine
-            // arc + host into the legacy shape until install.ts migrates
-            // in a later Phase 3b slice.
-            paths: {
-              ...arc,
-              claudeRoot: host.paths.root,
-              skillsDir: host.paths.skillsDir,
-              agentsDir: host.paths.agentsDir,
-              promptsDir: host.paths.promptsDir,
-              binDir: host.paths.binDir,
-              settingsPath: host.paths.settingsPath,
-            },
+            arc,
             host,
             db,
             repoUrl: artifacts[0].repo_url,

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -2,7 +2,7 @@ import { join, dirname } from "path";
 import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import type { ArtifactType, ArcManifest, HostAdapter, PaiPaths } from "../types.js";
+import type { ArtifactType, ArcManifest, ArcPaths, HostAdapter } from "../types.js";
 import {
   createSymlink,
   createCliShim,
@@ -70,7 +70,7 @@ export interface ArtifactSymlinkRecord {
 export async function createArtifactSymlinks(opts: {
   type: ArtifactType | "rules" | "system";
   manifest: ArcManifest;
-  paths: PaiPaths;
+  arc: ArcPaths;
   /** Target host adapter. Defaults to Claude-Code in the caller. */
   host: HostAdapter;
   installDir: string;
@@ -81,8 +81,8 @@ export async function createArtifactSymlinks(opts: {
   filesMissingSource: Array<{ source: string; target: string }>;
   record: ArtifactSymlinkRecord;
 }> {
-  const { type, manifest, paths, host, installDir, quiet } = opts;
-  const record: ArtifactSymlinkRecord = { symlinks: [], shims: { dir: paths.shimDir, names: [] } };
+  const { type, manifest, arc, host, installDir, quiet } = opts;
+  const record: ArtifactSymlinkRecord = { symlinks: [], shims: { dir: arc.shimDir, names: [] } };
 
   // Helper that wraps createSymlink + tracks the target for rollback (#89).
   const linkTracked = async (source: string, target: string) => {
@@ -90,7 +90,7 @@ export async function createArtifactSymlinks(opts: {
     record.symlinks.push(target);
   };
   const shimTracked = async () => {
-    const created = await createCliShim(paths.shimDir, host.paths.binDir, manifest);
+    const created = await createCliShim(arc.shimDir, host.paths.binDir, manifest);
     record.shims.names.push(...created);
   };
 
@@ -116,7 +116,7 @@ export async function createArtifactSymlinks(opts: {
   switch (type) {
     case "action": {
       // Actions: symlink action directory into actionsDir
-      const actionLinkPath = join(paths.actionsDir, manifest.name);
+      const actionLinkPath = join(arc.actionsDir, manifest.name);
       await linkTracked(installDir, actionLinkPath);
       break;
     }
@@ -145,7 +145,7 @@ export async function createArtifactSymlinks(opts: {
       // pipelinesDir is arc state (host-independent) — pipelines aren't host-installed.
       const pipelineSourceDir = join(installDir, "pipeline");
       const sourceDir = existsSync(pipelineSourceDir) ? pipelineSourceDir : installDir;
-      const pipelineLinkPath = join(paths.pipelinesDir, manifest.name);
+      const pipelineLinkPath = join(arc.pipelinesDir, manifest.name);
       await linkTracked(sourceDir, pipelineLinkPath);
 
       // If the manifest declares CLI entries, the bin shims still go through

--- a/test/commands/audit.test.ts
+++ b/test/commands/audit.test.ts
@@ -33,7 +33,7 @@ describe("audit command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -67,13 +67,13 @@ describe("audit command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoA.url,
       yes: true,
     });
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoB.url,
       yes: true,
@@ -98,7 +98,7 @@ describe("audit command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -124,8 +124,8 @@ describe("audit command", () => {
       },
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: repoA.url, yes: true });
-    await install({ paths: env.paths, db: env.db, repoUrl: repoB.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repoA.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repoB.url, yes: true });
 
     const result = audit(env.db);
     expect(result.warnings.length).toBeGreaterThan(0);

--- a/test/commands/disable.test.ts
+++ b/test/commands/disable.test.ts
@@ -28,7 +28,7 @@ describe("disable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -47,7 +47,7 @@ describe("disable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -65,7 +65,7 @@ describe("disable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -91,7 +91,7 @@ describe("enable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -110,7 +110,7 @@ describe("enable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -129,7 +129,7 @@ describe("enable command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,

--- a/test/commands/info.test.ts
+++ b/test/commands/info.test.ts
@@ -17,7 +17,7 @@ describe("info — installed packages", () => {
     env = await createTestEnv();
     const repo = await createMockSkillRepo(env.root, { name: "test-skill" });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     const result = await info(env.db, "test-skill");
     expect(result.skill).not.toBeNull();
@@ -36,7 +36,7 @@ describe("info — installed packages", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     const result = await info(env.db, "test-lib");
     expect(result.skill).toBeNull();
@@ -55,7 +55,7 @@ describe("info — installed packages", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     const result = await info(env.db, "test-lib:alpha");
     expect(result.skill).not.toBeNull();
@@ -72,7 +72,7 @@ describe("info — installed packages", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     const result = await info(env.db, "test-lib:nope");
     expect(result.error).toContain("not found in library");
@@ -316,7 +316,7 @@ describe("formatInfoJson", () => {
   test("outputs JSON for installed package", async () => {
     env = await createTestEnv();
     const repo = await createMockSkillRepo(env.root, { name: "json-test" });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     const result = await info(env.db, "json-test");
     const json = JSON.parse(formatInfoJson(result));

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -27,7 +27,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -46,7 +46,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -63,7 +63,7 @@ describe("install command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -81,7 +81,7 @@ describe("install command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -99,7 +99,7 @@ describe("install command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -118,7 +118,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -138,7 +138,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -157,7 +157,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -183,7 +183,7 @@ describe("install command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -212,7 +212,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -244,7 +244,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -315,7 +315,7 @@ describe("install command", () => {
     );
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoDir,
       yes: true,
@@ -375,7 +375,7 @@ describe("install command", () => {
     );
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoDir,
       yes: true,
@@ -431,7 +431,7 @@ describe("install command", () => {
     );
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoDir,
       yes: true,
@@ -448,7 +448,7 @@ describe("install command", () => {
 
     // First install
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -456,7 +456,7 @@ describe("install command", () => {
 
     // Second install should fail
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -494,7 +494,7 @@ describe("install command", () => {
 
     // Install pinned to v1.0.0
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -512,7 +512,7 @@ describe("install command", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -536,7 +536,7 @@ describe("install command", () => {
     );
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -639,7 +639,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -659,7 +659,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -681,7 +681,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -709,7 +709,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -737,7 +737,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -764,7 +764,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -803,7 +803,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -840,7 +840,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,
@@ -885,7 +885,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl,
       yes: true,

--- a/test/commands/library-install.test.ts
+++ b/test/commands/library-install.test.ts
@@ -24,7 +24,7 @@ describe("library install", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -57,7 +57,7 @@ describe("library install", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -83,7 +83,7 @@ describe("library install", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -99,7 +99,7 @@ describe("library install", () => {
     const skill = await createMockSkillRepo(env.root, { name: "standalone" });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: skill.url,
       yes: true,
@@ -122,11 +122,11 @@ describe("library install", () => {
         { path: "skills/beta", name: "beta", type: "skill" },
       ],
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Install a standalone
     const standalone = await createMockSkillRepo(env.root, { name: "standalone" });
-    await install({ paths: env.paths, db: env.db, repoUrl: standalone.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: standalone.url, yes: true });
 
     // List all
     const allResult = list(env.db);
@@ -148,7 +148,7 @@ describe("library install", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Remove just alpha
     const removeResult = await remove(env.db, env.paths, "alpha");
@@ -171,7 +171,7 @@ describe("library install", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -197,10 +197,10 @@ describe("library install", () => {
     });
 
     // First install — all
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Second install — should skip already-installed
-    const result2 = await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    const result2 = await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
     expect(result2.success).toBe(true);
     // Both artifacts should be "success" (skipped counts as success)
     expect(result2.artifacts!.every((a) => a.success)).toBe(true);

--- a/test/commands/library-upgrade.test.ts
+++ b/test/commands/library-upgrade.test.ts
@@ -22,7 +22,7 @@ describe("library upgrade", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Bump only alpha's version in the source repo
     const alphaManifest = join(lib.path, "skills/alpha/arc-manifest.yaml");
@@ -59,7 +59,7 @@ describe("library upgrade", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Bump alpha's version
     const alphaManifest = join(lib.path, "skills/alpha/arc-manifest.yaml");
@@ -93,7 +93,7 @@ describe("library upgrade", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Bump both versions
     for (const artifact of ["skills/alpha", "skills/beta"]) {
@@ -137,7 +137,7 @@ describe("library upgrade", () => {
       ],
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // No changes in source repo
     const results = await upgradeLibrary(env.db, env.arc, env.host, "test-lib");
@@ -158,7 +158,7 @@ describe("library upgrade", () => {
     });
 
     // Install library with 2 artifacts
-    await install({ paths: env.paths, db: env.db, repoUrl: lib.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Verify only alpha and beta are installed
     const beforeSkills = env.db

--- a/test/commands/lifecycle-hooks.test.ts
+++ b/test/commands/lifecycle-hooks.test.ts
@@ -34,7 +34,7 @@ describe("install lifecycle hooks", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -59,7 +59,7 @@ describe("install lifecycle hooks", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -86,7 +86,7 @@ describe("install lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -109,7 +109,7 @@ describe("install lifecycle hooks", () => {
     });
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -132,7 +132,7 @@ describe("install lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -154,7 +154,7 @@ describe("upgrade lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -204,7 +204,7 @@ describe("upgrade lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -246,7 +246,7 @@ describe("upgrade lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -286,7 +286,7 @@ describe("upgrade lifecycle hooks", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,

--- a/test/commands/list.test.ts
+++ b/test/commands/list.test.ts
@@ -26,7 +26,7 @@ describe("list command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -45,7 +45,7 @@ describe("list command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -67,7 +67,7 @@ describe("list command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -95,8 +95,8 @@ describe("list command", () => {
       type: "pipeline",
     });
 
-    await install({ paths: env.paths, db: env.db, repoUrl: skillRepo.url, yes: true });
-    await install({ paths: env.paths, db: env.db, repoUrl: pipelineRepo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: skillRepo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: pipelineRepo.url, yes: true });
 
     const all = list(env.db);
     expect(all.skills).toHaveLength(2);

--- a/test/commands/remove.test.ts
+++ b/test/commands/remove.test.ts
@@ -28,7 +28,7 @@ describe("remove command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -47,7 +47,7 @@ describe("remove command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -63,7 +63,7 @@ describe("remove command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -93,7 +93,7 @@ describe("removeLibrary", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -120,7 +120,7 @@ describe("removeLibrary", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,
@@ -146,7 +146,7 @@ describe("removeLibrary", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,

--- a/test/commands/rules.test.ts
+++ b/test/commands/rules.test.ts
@@ -98,7 +98,7 @@ repo_description: "A test project"
   );
 
   const result = await install({
-    paths: env.paths,
+    arc: env.arc, host: env.host,
     db: env.db,
     repoUrl: rulesRepo.url,
     yes: true,
@@ -146,7 +146,7 @@ extra_labels:
   );
 
   const result = await install({
-    paths: env.paths,
+    arc: env.arc, host: env.host,
     db: env.db,
     repoUrl: rulesRepo.url,
     yes: true,
@@ -177,7 +177,7 @@ repo_description: "Test"
   );
 
   await install({
-    paths: env.paths,
+    arc: env.arc, host: env.host,
     db: env.db,
     repoUrl: rulesRepo.url,
     yes: true,

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -32,7 +32,7 @@ describe("checkUpgrades", () => {
       name: "TestSkill",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     // Set up a source with registry advertising v1.1.0
     const registry: RegistryConfig = {
@@ -78,7 +78,7 @@ describe("checkUpgrades", () => {
       name: "UpToDate",
       version: "2.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     const registry: RegistryConfig = {
       registry: {
@@ -116,7 +116,7 @@ describe("upgradePackage", () => {
       name: "Upgradeable",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     // Simulate a new version: update manifest in source repo and commit
     const manifestPath = join(repo.path, "arc-manifest.yaml");
@@ -146,7 +146,7 @@ describe("upgradePackage", () => {
       name: "Current",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     const result = await upgradePackage(env.db, env.arc, env.host, "Current");
     expect(result.success).toBe(true);
@@ -165,7 +165,7 @@ describe("upgradePackage", () => {
       name: "ForceUpgrade",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     // Without force: returns success with same version (short-circuit)
     const normalResult = await upgradePackage(env.db, env.arc, env.host, "ForceUpgrade");
@@ -263,7 +263,7 @@ describe("upgradeAll", () => {
       name: "ForceAll",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     // Without force, upgradeAll would return empty (nothing upgradable)
     const normalResults = await upgradeAll(env.db, env.arc, env.host);
@@ -284,7 +284,7 @@ describe("upgradeLibrary", () => {
       name: "LibArtifact",
       version: "1.0.0",
     });
-    await install({ paths: env.paths, db: env.db, repoUrl: repo.url, yes: true });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
 
     // Set a library_name so upgradeLibrary can find it
     env.db.prepare("UPDATE skills SET library_name = ? WHERE name = ?").run("my-lib", "LibArtifact");

--- a/test/commands/verify.test.ts
+++ b/test/commands/verify.test.ts
@@ -24,7 +24,7 @@ describe("verify command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -45,7 +45,7 @@ describe("verify command", () => {
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -72,7 +72,7 @@ describe("verify command", () => {
       name: "NoHookSkill",
     });
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -125,7 +125,7 @@ describe("verify command", () => {
     );
 
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoDir,
       yes: true,
@@ -179,7 +179,7 @@ describe("verify command", () => {
     );
 
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repoDir,
       yes: true,

--- a/test/e2e/library-lifecycle.test.ts
+++ b/test/e2e/library-lifecycle.test.ts
@@ -35,7 +35,7 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
     });
 
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: lib.url,
       yes: true,

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -56,7 +56,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
     // --- INSTALL ---
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -164,7 +164,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
     // --- INSTALL ---
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -215,7 +215,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
     // --- INSTALL ---
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -281,7 +281,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
     // --- INSTALL ---
     const installResult = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,
@@ -347,13 +347,13 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     });
 
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: networkRepo.url,
       yes: true,
     });
     await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: fileRepo.url,
       yes: true,
@@ -479,7 +479,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     );
 
     const result = await install({
-      paths: env.paths,
+      arc: env.arc, host: env.host,
       db: env.db,
       repoUrl: repo.url,
       yes: true,

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -97,7 +97,7 @@ describe("createArtifactSymlinks null-guard throws", () => {
         createArtifactSymlinks({
           type: "agent",
           manifest,
-          paths,
+          arc: paths,
           host: stub,
           installDir: tmp,
           quiet: true,
@@ -143,7 +143,7 @@ describe("createArtifactSymlinks null-guard throws", () => {
       const result = await createArtifactSymlinks({
         type: "skill",
         manifest,
-        paths,
+        arc: paths,
         host: skillsOnlyHost,
         installDir: tmp,
         quiet: true,


### PR DESCRIPTION
## Summary

Continues the #117 phase 3b sweep. After verify (#122) and upgrade (#123), `install` is the biggest payoff — migrating it kills the inline `PaiPaths` reconstruction bridge in `upgrade.ts:444`.

## Changes

**`src/lib/artifact-installer.ts`**
- `createArtifactSymlinks` accepts `arc: ArcPaths` (was `paths: PaiPaths`)
- Arc-only field accesses (`shimDir`, `actionsDir`, `pipelinesDir`) switch from `paths.X` to `arc.X`. `host.paths.X` lookups unchanged.

**`src/commands/install.ts`**
- `InstallOptions.paths: PaiPaths` → `arc: ArcPaths, host: HostAdapter`. Both required (was `host?: HostAdapter` with a `getDefaultHost({ root: paths.claudeRoot })` fallback).
- Drops the default-host fallback — every caller now passes `host` explicitly.
- `install()` and `installSingleArtifact()` destructure `{ arc, host, db }`.
- Internal `paths.reposDir` → `arc.reposDir`, `paths.claudeRoot` → `host.paths.root`, `paths.settingsPath` → `host.paths.settingsPath`.
- Recursive dependency install passes `{ arc, host, ... }`.

**`src/commands/upgrade.ts`**
- Deletes the transitional `PaiPaths`-reconstruction bridge at `upgradeLibrary` → `installSingleArtifact`. Now passes `{ arc, host }` directly. Net: −10 lines, one less spot where the deprecated `PaiPaths` shape needed to be hand-assembled.

**`src/cli.ts`**
- `install` command action derives `host = getDefaultHost({ root: paths.claudeRoot })` once near the top, then passes `arc: paths, host` to all three `install({...})` call sites (registry, direct git, name-based).

**Tests**
- `env.paths` → `env.arc, env.host` across all 15 `install()` call sites in test files.
- Non-`install` callers (`login`, `logout`, `publish`, `review`, `bundle`) continue to use `env.paths` — they still take `paths: PaiPaths` and will migrate in their own slices.
- `test/unit/hosts-dispatch.test.ts` updates two `createArtifactSymlinks` calls to use `arc: paths`.

## Verification

- `bun test`: **704/704 passing**
- `bunx tsc --noEmit`: clean
- The `installSingleArtifact still takes PaiPaths today` comment is gone, along with its 7-line PaiPaths reconstruction in `upgrade.ts`.

## Remaining for #117

After this lands: migrate `remove`, `enable`, `disable`, `catalog` (~4 more slices), then Phase 3d deletes `PaiPaths`, `createPaths`, and `TestEnv.paths`.

## Test plan

- [x] `bun test` — 704/704 green
- [x] `bunx tsc --noEmit` — clean
- [x] Manual review: no `paths: PaiPaths` left on `install` / `installSingleArtifact` / `createArtifactSymlinks`
- [x] `upgrade.ts` bridge removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)