### PR TITLE
refactor(remove): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/4)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -426,6 +426,7 @@ program
   .action(async (name: string, opts: { library?: string }) => {
     const paths = createPaths();
     const db = openDatabase(paths.dbPath);
+    const host = getDefaultHost({ root: paths.claudeRoot });
 
     if (opts.library) {
       // Remove all artifacts from a library
@@ -433,7 +434,7 @@ program
       const libArtifacts = listByLibrary(db, opts.library);
       if (libArtifacts.length) {
         for (const art of libArtifacts) {
-          const result = await remove(db, paths, art.name);
+          const result = await remove(db, paths, host, art.name);
           if (result.success) {
             console.log(`🗑️  Removed ${result.name}`);
           }
@@ -447,13 +448,13 @@ program
       const libRef = parseLibraryRef(name);
       const removeName = libRef?.artifactName ?? name;
 
-      const result = await remove(db, paths, removeName);
+      const result = await remove(db, paths, host, removeName);
 
       if (result.success) {
         console.log(`🗑️  Removed ${result.name}`);
       } else {
         // Artifact not found — check if name matches a library
-        const libResult = await removeLibrary(db, paths, removeName);
+        const libResult = await removeLibrary(db, paths, host, removeName);
         if (libResult.success) {
           console.log(`🗑️  Removed ${libResult.removedCount} artifact(s) from library '${removeName}'`);
         } else {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { rm } from "fs/promises";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths, HostAdapter } from "../types.js";
 import { getSkill, removeSkill, listByLibrary } from "../lib/db.js";
 import { removeSymlink, removeCliShim, extractAllCliInfo } from "../lib/symlinks.js";
 import { readManifest } from "../lib/manifest.js";
@@ -22,7 +22,8 @@ export interface RemoveResult {
  */
 export async function remove(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<RemoveResult> {
   const skill = getSkill(db, name);
@@ -38,33 +39,33 @@ export async function remove(
 
   if (isAction) {
     // Actions: remove action symlink
-    const actionLink = join(paths.actionsDir, name);
+    const actionLink = join(arc.actionsDir, name);
     await removeSymlink(actionLink);
   } else if (isPipeline) {
     // Pipelines: remove pipeline symlink
-    const pipelineLink = join(paths.pipelinesDir, name);
+    const pipelineLink = join(arc.pipelinesDir, name);
     await removeSymlink(pipelineLink);
   } else if (isTool) {
     // Tools: remove bin symlink (repo root linked to binDir)
-    const binLink = join(paths.binDir, name);
+    const binLink = join(host.paths.binDir, name);
     await removeSymlink(binLink);
   } else if (isAgent) {
     // Agents: remove .md file symlink (or legacy directory symlink)
-    const mdLink = join(paths.agentsDir, `${name}.md`);
-    const dirLink = join(paths.agentsDir, name);
+    const mdLink = join(host.paths.agentsDir, `${name}.md`);
+    const dirLink = join(host.paths.agentsDir, name);
     if (!await removeSymlink(mdLink)) {
       await removeSymlink(dirLink);
     }
   } else if (isPrompt) {
     // Prompts: remove .md file symlink (or legacy directory symlink)
-    const mdLink = join(paths.promptsDir, `${name}.md`);
-    const dirLink = join(paths.promptsDir, name);
+    const mdLink = join(host.paths.promptsDir, `${name}.md`);
+    const dirLink = join(host.paths.promptsDir, name);
     if (!await removeSymlink(mdLink)) {
       await removeSymlink(dirLink);
     }
   } else {
     // Skills: remove skill symlink
-    const skillLink = join(paths.skillsDir, name);
+    const skillLink = join(host.paths.skillsDir, name);
     await removeSymlink(skillLink);
   }
 
@@ -75,26 +76,26 @@ export async function remove(
   if (!isAgent && !isPrompt && manifest) {
     const cliEntries = extractAllCliInfo(manifest);
     for (const entry of cliEntries) {
-      await removeCliShim(paths.shimDir, entry.binName);
-      await removeSymlink(join(paths.binDir, entry.binName));
+      await removeCliShim(arc.shimDir, entry.binName);
+      await removeSymlink(join(host.paths.binDir, entry.binName));
     }
     if (!cliEntries.length) {
       // Fallback: remove by conventional name
       const fallbackName = isTool ? name.toLowerCase() : name.replace(/^_/, "").toLowerCase();
-      await removeCliShim(paths.shimDir, fallbackName);
-      await removeSymlink(join(paths.binDir, fallbackName));
+      await removeCliShim(arc.shimDir, fallbackName);
+      await removeSymlink(join(host.paths.binDir, fallbackName));
     }
   }
 
   // Remove hooks from settings.json (before deleting repo)
   if (hasHooks(manifest?.provides?.hooks)) {
-    const settingsPath = paths.settingsPath;
+    const settingsPath = host.paths.settingsPath;
     await removeHooks(name, settingsPath);
   }
 
   // Remove extensions (before deleting repo)
   if (manifest?.extensions) {
-    await unwireExtensions(manifest, paths.claudeRoot);
+    await unwireExtensions(manifest, host.paths.root);
   }
 
   // Remove from database (CASCADE deletes capabilities) — before repo removal
@@ -127,7 +128,8 @@ export async function remove(
  */
 export async function removeLibrary(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   libraryName: string
 ): Promise<RemoveResult> {
   const artifacts = listByLibrary(db, libraryName);
@@ -140,7 +142,7 @@ export async function removeLibrary(
 
   const results: RemoveResult[] = [];
   for (const artifact of artifacts) {
-    const result = await remove(db, paths, artifact.name);
+    const result = await remove(db, arc, host, artifact.name);
     results.push(result);
   }
 

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -196,7 +196,7 @@ describe("install command", () => {
     expect(existsSync(binLink)).toBe(true);
 
     // Remove
-    const result = await remove(env.db, env.paths, "P_CLI_PIPE");
+    const result = await remove(env.db, env.arc, env.host, "P_CLI_PIPE");
     expect(result.success).toBe(true);
 
     // Verify cleaned up
@@ -230,7 +230,7 @@ describe("install command", () => {
     expect(skill!.artifact_type).toBe("action");
 
     // Remove
-    const removeResult = await remove(env.db, env.paths, "A_DISCOVER_REPOS");
+    const removeResult = await remove(env.db, env.arc, env.host, "A_DISCOVER_REPOS");
     expect(removeResult.success).toBe(true);
     expect(existsSync(actionLink)).toBe(false);
     expect(getSkill(env.db, "A_DISCOVER_REPOS")).toBeNull();

--- a/test/commands/library-install.test.ts
+++ b/test/commands/library-install.test.ts
@@ -151,7 +151,7 @@ describe("library install", () => {
     await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
 
     // Remove just alpha
-    const removeResult = await remove(env.db, env.paths, "alpha");
+    const removeResult = await remove(env.db, env.arc, env.host, "alpha");
     expect(removeResult.success).toBe(true);
 
     // Beta should still be installed

--- a/test/commands/remove.test.ts
+++ b/test/commands/remove.test.ts
@@ -37,7 +37,7 @@ describe("remove command", () => {
     const repoDir = join(env.paths.reposDir, "mock-TestSkill");
     expect(existsSync(repoDir)).toBe(true);
 
-    await remove(env.db, env.paths, "TestSkill");
+    await remove(env.db, env.arc, env.host, "TestSkill");
     expect(existsSync(repoDir)).toBe(false);
   });
 
@@ -53,7 +53,7 @@ describe("remove command", () => {
       yes: true,
     });
 
-    await remove(env.db, env.paths, "TestSkill");
+    await remove(env.db, env.arc, env.host, "TestSkill");
     expect(getSkill(env.db, "TestSkill")).toBeNull();
   });
 
@@ -69,14 +69,14 @@ describe("remove command", () => {
       yes: true,
     });
 
-    await remove(env.db, env.paths, "TestSkill");
+    await remove(env.db, env.arc, env.host, "TestSkill");
 
     const skillLink = join(env.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(false);
   });
 
   test("rejects removing non-installed skill", async () => {
-    const result = await remove(env.db, env.paths, "NonExistent");
+    const result = await remove(env.db, env.arc, env.host, "NonExistent");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not installed");
   });
@@ -103,7 +103,7 @@ describe("removeLibrary", () => {
     expect(getSkill(env.db, "alpha")).not.toBeNull();
     expect(getSkill(env.db, "beta")).not.toBeNull();
 
-    const result = await removeLibrary(env.db, env.paths, "test-lib");
+    const result = await removeLibrary(env.db, env.arc, env.host, "test-lib");
     expect(result.success).toBe(true);
     expect(result.removedCount).toBe(2);
     expect(getSkill(env.db, "alpha")).toBeNull();
@@ -132,7 +132,7 @@ describe("removeLibrary", () => {
 
     expect(existsSync(repoDir)).toBe(true);
 
-    await removeLibrary(env.db, env.paths, "test-lib");
+    await removeLibrary(env.db, env.arc, env.host, "test-lib");
     expect(existsSync(repoDir)).toBe(false);
   });
 
@@ -153,7 +153,7 @@ describe("removeLibrary", () => {
     });
 
     // Remove only alpha
-    const result = await remove(env.db, env.paths, "alpha");
+    const result = await remove(env.db, env.arc, env.host, "alpha");
     expect(result.success).toBe(true);
 
     // Beta should still exist
@@ -163,7 +163,7 @@ describe("removeLibrary", () => {
   });
 
   test("returns error for unknown name (not artifact, not library)", async () => {
-    const result = await removeLibrary(env.db, env.paths, "nonexistent");
+    const result = await removeLibrary(env.db, env.arc, env.host, "nonexistent");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not installed");
   });

--- a/test/e2e/library-lifecycle.test.ts
+++ b/test/e2e/library-lifecycle.test.ts
@@ -85,7 +85,7 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
     expect(reviewDb.version).toBe("1.1.0");
 
     // --- REMOVE ONE ---
-    const removeResult = await remove(env.db, env.paths, "review");
+    const removeResult = await remove(env.db, env.arc, env.host, "review");
     expect(removeResult.success).toBe(true);
 
     // Verify review is gone but deploy remains
@@ -105,7 +105,7 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
     expect(libArtifacts[0].name).toBe("deploy");
 
     // --- REMOVE LAST ---
-    const removeLastResult = await remove(env.db, env.paths, "deploy");
+    const removeLastResult = await remove(env.db, env.arc, env.host, "deploy");
     expect(removeLastResult.success).toBe(true);
 
     // Everything gone

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -137,7 +137,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(enabledSkill!.status).toBe("active");
 
     // --- REMOVE ---
-    const removeResult = await remove(env.db, env.paths, "_JIRA");
+    const removeResult = await remove(env.db, env.arc, env.host, "_JIRA");
     expect(removeResult.success).toBe(true);
 
     // Everything gone
@@ -199,7 +199,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(getSkill(env.db, "mytool")!.status).toBe("active");
 
     // --- REMOVE ---
-    const removeResult = await remove(env.db, env.paths, "mytool");
+    const removeResult = await remove(env.db, env.arc, env.host, "mytool");
     expect(removeResult.success).toBe(true);
     expect(existsSync(binLink)).toBe(false);
     expect(getSkill(env.db, "mytool")).toBeNull();
@@ -263,7 +263,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(getSkill(env.db, "TestArchitect")!.status).toBe("active");
 
     // --- REMOVE ---
-    const removeResult = await remove(env.db, env.paths, "TestArchitect");
+    const removeResult = await remove(env.db, env.arc, env.host, "TestArchitect");
     expect(removeResult.success).toBe(true);
     expect(existsSync(agentLink)).toBe(false);
     const repoDir = join(env.paths.reposDir, "mock-TestArchitect");
@@ -319,7 +319,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(lstatSync(promptLink).isSymbolicLink()).toBe(true);
 
     // --- REMOVE ---
-    const removeResult = await remove(env.db, env.paths, "task-router");
+    const removeResult = await remove(env.db, env.arc, env.host, "task-router");
     expect(removeResult.success).toBe(true);
     expect(existsSync(promptLink)).toBe(false);
     expect(getSkill(env.db, "task-router")).toBeNull();
@@ -521,7 +521,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(true);
 
     // --- REMOVE cleans up all ---
-    const removeResult = await remove(env.db, env.paths, "multitool");
+    const removeResult = await remove(env.db, env.arc, env.host, "multitool");
     expect(removeResult.success).toBe(true);
     expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(false);
     expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(false);


### PR DESCRIPTION
## Summary

Continues the #117 phase 3b sweep, following verify (#122), upgrade (#123), and install (#124).

## Changes

**`src/commands/remove.ts`**
- `remove()` and `removeLibrary()` signatures: `paths: PaiPaths` → `arc: ArcPaths, host: HostAdapter`.
- Internal field accesses split:
  - arc-state: `paths.actionsDir`, `paths.pipelinesDir`, `paths.shimDir` → `arc.X`
  - host-paths: `paths.binDir`, `paths.agentsDir`, `paths.promptsDir`, `paths.skillsDir`, `paths.settingsPath`, `paths.claudeRoot` → `host.paths.X` (`claudeRoot` → `host.paths.root`).
- `removeLibrary` threads `arc, host` into its inner `remove()` call.

**`src/cli.ts`**
- `remove` command action derives `host = getDefaultHost({ root: paths.claudeRoot })` once near the top, then passes `host` to all three `remove`/`removeLibrary` call sites.

**Tests**
- `remove(env.db, env.paths, name)` → `remove(env.db, env.arc, env.host, name)` across 14 call sites in 5 test files.
- Same shape for `removeLibrary` → 3 sites in `test/commands/remove.test.ts`.

## Verification

- `bun test`: **718/718 passing**
- `bunx tsc --noEmit`: clean

## Remaining for #117

After this: migrate `enable`, `disable`, `catalog` (~3 more slices), then Phase 3d deletes `PaiPaths`, `createPaths`, and `TestEnv.paths`.

## Test plan

- [x] `bun test` — 718/718 green
- [x] `bunx tsc --noEmit` — clean
- [x] No `paths: PaiPaths` left on `remove` / `removeLibrary` / their callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)