### PR TITLE
refactor(enable): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/5)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -407,7 +407,8 @@ program
   .action(async (name: string) => {
     const paths = createPaths();
     const db = openDatabase(paths.dbPath);
-    const result = await enable(db, paths, name);
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await enable(db, paths, host, name);
 
     if (result.success) {
       console.log(`✅ Enabled ${result.name}`);

--- a/src/commands/enable.ts
+++ b/src/commands/enable.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { existsSync } from "fs";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths, HostAdapter } from "../types.js";
 import { getSkill, updateSkillStatus } from "../lib/db.js";
 import { readManifest } from "../lib/manifest.js";
 import { createSymlink, createCliShim, extractAllCliInfo } from "../lib/symlinks.js";
@@ -19,7 +19,8 @@ export interface EnableResult {
  */
 export async function enable(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<EnableResult> {
   const skill = getSkill(db, name);
@@ -40,18 +41,18 @@ export async function enable(
     // Pipelines: re-create pipeline symlink
     const pipelineSourceDir = join(skill.install_path, "pipeline");
     const sourceDir = existsSync(pipelineSourceDir) ? pipelineSourceDir : skill.install_path;
-    await createSymlink(sourceDir, join(paths.pipelinesDir, name));
+    await createSymlink(sourceDir, join(arc.pipelinesDir, name));
   } else if (isTool) {
     // Tools: re-create bin symlinks for all CLI entries
     if (manifest) {
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
-        await createSymlink(skill.install_path, join(paths.binDir, entry.binName));
+        await createSymlink(skill.install_path, join(host.paths.binDir, entry.binName));
       }
       if (!cliEntries.length) {
-        await createSymlink(skill.install_path, join(paths.binDir, name));
+        await createSymlink(skill.install_path, join(host.paths.binDir, name));
       }
-      await createCliShim(paths.shimDir, paths.binDir, manifest);
+      await createCliShim(arc.shimDir, host.paths.binDir, manifest);
     }
   } else if (isAgent) {
     // Agents: re-create .md file symlink for Claude auto-discovery
@@ -59,12 +60,12 @@ export async function enable(
     const sourceDir = existsSync(agentSourceDir) ? agentSourceDir : skill.install_path;
     const mdFile = `${name}.md`;
     const sourcePath = join(sourceDir, mdFile);
-    const linkPath = join(paths.agentsDir, mdFile);
+    const linkPath = join(host.paths.agentsDir, mdFile);
 
     if (existsSync(sourcePath)) {
       await createSymlink(sourcePath, linkPath);
     } else {
-      await createSymlink(sourceDir, join(paths.agentsDir, name));
+      await createSymlink(sourceDir, join(host.paths.agentsDir, name));
     }
   } else if (isPrompt) {
     // Prompts: re-create .md file symlink for Claude auto-discovery
@@ -72,17 +73,17 @@ export async function enable(
     const sourceDir = existsSync(promptSourceDir) ? promptSourceDir : skill.install_path;
     const mdFile = `${name}.md`;
     const sourcePath = join(sourceDir, mdFile);
-    const linkPath = join(paths.promptsDir, mdFile);
+    const linkPath = join(host.paths.promptsDir, mdFile);
 
     if (existsSync(sourcePath)) {
       await createSymlink(sourcePath, linkPath);
     } else {
-      await createSymlink(sourceDir, join(paths.promptsDir, name));
+      await createSymlink(sourceDir, join(host.paths.promptsDir, name));
     }
   } else {
     // Skills: re-create skill symlink
     const skillSourceDir = join(skill.install_path, "skill");
-    const skillLinkPath = join(paths.skillsDir, name);
+    const skillLinkPath = join(host.paths.skillsDir, name);
 
     if (existsSync(skillSourceDir)) {
       await createSymlink(skillSourceDir, skillLinkPath);
@@ -94,24 +95,24 @@ export async function enable(
     if (manifest) {
       const cliEntries = extractAllCliInfo(manifest);
       for (const entry of cliEntries) {
-        await createSymlink(skill.install_path, join(paths.binDir, entry.binName));
+        await createSymlink(skill.install_path, join(host.paths.binDir, entry.binName));
       }
       if (cliEntries.length) {
-        await createCliShim(paths.shimDir, paths.binDir, manifest);
+        await createCliShim(arc.shimDir, host.paths.binDir, manifest);
       }
     }
   }
 
   // Re-register hooks when enabling (consent was given at install time).
-  // paths.claudeRoot is threaded as $PAI_DIR expansion target — see install.ts.
+  // host.paths.root is threaded as $PAI_DIR expansion target — see install.ts.
   const resolvedHooks = resolveHooksFromManifest(
     manifest?.provides?.hooks,
     skill.install_path,
     name,
-    paths.claudeRoot,
+    host.paths.root,
   );
   if (resolvedHooks?.length) {
-    const settingsPath = paths.settingsPath;
+    const settingsPath = host.paths.settingsPath;
     await registerHooks(name, resolvedHooks, settingsPath);
   }
 

--- a/test/commands/disable.test.ts
+++ b/test/commands/disable.test.ts
@@ -98,7 +98,7 @@ describe("enable command", () => {
     });
 
     await disable(env.db, env.paths, "TestSkill");
-    await enable(env.db, env.paths, "TestSkill");
+    await enable(env.db, env.arc, env.host, "TestSkill");
 
     const skillLink = join(env.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(true);
@@ -117,7 +117,7 @@ describe("enable command", () => {
     });
 
     await disable(env.db, env.paths, "TestSkill");
-    await enable(env.db, env.paths, "TestSkill");
+    await enable(env.db, env.arc, env.host, "TestSkill");
 
     const skill = getSkill(env.db, "TestSkill");
     expect(skill!.status).toBe("active");
@@ -135,7 +135,7 @@ describe("enable command", () => {
       yes: true,
     });
 
-    const result = await enable(env.db, env.paths, "TestSkill");
+    const result = await enable(env.db, env.arc, env.host, "TestSkill");
     expect(result.success).toBe(false);
     expect(result.error).toContain("already active");
   });

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -126,7 +126,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(listAfterDisable.skills[0].status).toBe("disabled");
 
     // --- ENABLE ---
-    const enableResult = await enable(env.db, env.paths, "_JIRA");
+    const enableResult = await enable(env.db, env.arc, env.host, "_JIRA");
     expect(enableResult.success).toBe(true);
 
     // Symlink re-created
@@ -193,7 +193,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(getSkill(env.db, "mytool")!.status).toBe("disabled");
 
     // --- ENABLE ---
-    const enableResult = await enable(env.db, env.paths, "mytool");
+    const enableResult = await enable(env.db, env.arc, env.host, "mytool");
     expect(enableResult.success).toBe(true);
     expect(existsSync(binLink)).toBe(true);
     expect(getSkill(env.db, "mytool")!.status).toBe("active");
@@ -256,7 +256,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(getSkill(env.db, "TestArchitect")!.status).toBe("disabled");
 
     // --- ENABLE ---
-    const enableResult = await enable(env.db, env.paths, "TestArchitect");
+    const enableResult = await enable(env.db, env.arc, env.host, "TestArchitect");
     expect(enableResult.success).toBe(true);
     expect(existsSync(agentLink)).toBe(true);
     expect(lstatSync(agentLink).isSymbolicLink()).toBe(true);
@@ -313,7 +313,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(existsSync(promptLink)).toBe(false);
 
     // --- ENABLE ---
-    const enableResult = await enable(env.db, env.paths, "task-router");
+    const enableResult = await enable(env.db, env.arc, env.host, "task-router");
     expect(enableResult.success).toBe(true);
     expect(existsSync(promptLink)).toBe(true);
     expect(lstatSync(promptLink).isSymbolicLink()).toBe(true);
@@ -513,7 +513,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(false);
 
     // --- ENABLE restores all ---
-    const enableResult = await enable(env.db, env.paths, "multitool");
+    const enableResult = await enable(env.db, env.arc, env.host, "multitool");
     expect(enableResult.success).toBe(true);
     expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(true);
     expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(true);


### PR DESCRIPTION
## Summary

Continues the #117 phase 3b sweep, following verify (#122), upgrade (#123), install (#124), and remove (#125).

## Changes

**`src/commands/enable.ts`**
- `enable()` signature: `paths: PaiPaths` → `arc: ArcPaths, host: HostAdapter`.
- Internal field accesses split:
  - arc-state: `paths.pipelinesDir`, `paths.shimDir` → `arc.X`
  - host-paths: `paths.binDir`, `paths.agentsDir`, `paths.promptsDir`, `paths.skillsDir`, `paths.settingsPath`, `paths.claudeRoot` → `host.paths.X` (`claudeRoot` → `host.paths.root`).
- 13 host-side accesses + 2 arc-side, all mechanical.

**`src/cli.ts`**
- `enable` command action derives `host = getDefaultHost({ root: paths.claudeRoot })` once, then passes `host` to the `enable()` call.

**Tests**
- `enable(env.db, env.paths, name)` → `enable(env.db, env.arc, env.host, name)` across 8 call sites in 2 test files (disable.test.ts × 3, lifecycle.test.ts × 5).

## Verification

- `bun test`: **718/718 passing**
- `bunx tsc --noEmit`: clean

## Remaining for #117

After this: migrate `disable`, `catalog` (~2 more slices), then Phase 3d deletes `PaiPaths`, `createPaths`, and `TestEnv.paths`.

## Test plan

- [x] `bun test` — 718/718 green
- [x] `bunx tsc --noEmit` — clean
- [x] No `paths: PaiPaths` left on `enable` or its callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)