### PR TITLE
refactor(disable): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/6)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -389,7 +389,8 @@ program
   .action(async (name: string) => {
     const paths = createPaths();
     const db = openDatabase(paths.dbPath);
-    const result = await disable(db, paths, name);
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await disable(db, paths, host, name);
 
     if (result.success) {
       console.log(`⏸️  Disabled ${result.name}`);

--- a/src/commands/disable.ts
+++ b/src/commands/disable.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths, HostAdapter } from "../types.js";
 import { getSkill, updateSkillStatus } from "../lib/db.js";
 import { removeSymlink, removeCliShim, extractAllCliInfo } from "../lib/symlinks.js";
 import { readManifest } from "../lib/manifest.js";
@@ -18,7 +18,8 @@ export interface DisableResult {
  */
 export async function disable(
   db: Database,
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<DisableResult> {
   const skill = getSkill(db, name);
@@ -38,25 +39,25 @@ export async function disable(
 
   if (isPipeline) {
     // Pipelines: remove pipeline symlink
-    const pipelineLink = join(paths.pipelinesDir, name);
+    const pipelineLink = join(arc.pipelinesDir, name);
     await removeSymlink(pipelineLink);
   } else if (isAgent) {
     // Agents: remove .md file symlink (or legacy directory symlink)
-    const mdLink = join(paths.agentsDir, `${name}.md`);
-    const dirLink = join(paths.agentsDir, name);
+    const mdLink = join(host.paths.agentsDir, `${name}.md`);
+    const dirLink = join(host.paths.agentsDir, name);
     if (!await removeSymlink(mdLink)) {
       await removeSymlink(dirLink);
     }
   } else if (isPrompt) {
     // Prompts: remove .md file symlink (or legacy directory symlink)
-    const mdLink = join(paths.promptsDir, `${name}.md`);
-    const dirLink = join(paths.promptsDir, name);
+    const mdLink = join(host.paths.promptsDir, `${name}.md`);
+    const dirLink = join(host.paths.promptsDir, name);
     if (!await removeSymlink(mdLink)) {
       await removeSymlink(dirLink);
     }
   } else if (!isTool) {
     // Skills: remove skill symlink
-    const skillLink = join(paths.skillsDir, name);
+    const skillLink = join(host.paths.skillsDir, name);
     await removeSymlink(skillLink);
   }
 
@@ -64,17 +65,17 @@ export async function disable(
   if (!isAgent && !isPrompt && manifest) {
     const cliEntries = extractAllCliInfo(manifest);
     for (const entry of cliEntries) {
-      await removeCliShim(paths.shimDir, entry.binName);
-      await removeSymlink(join(paths.binDir, entry.binName));
+      await removeCliShim(arc.shimDir, entry.binName);
+      await removeSymlink(join(host.paths.binDir, entry.binName));
     }
     if (!cliEntries.length) {
       const fallbackName = isTool ? name.toLowerCase() : name.replace(/^_/, "").toLowerCase();
-      await removeCliShim(paths.shimDir, fallbackName);
-      await removeSymlink(join(paths.binDir, fallbackName));
+      await removeCliShim(arc.shimDir, fallbackName);
+      await removeSymlink(join(host.paths.binDir, fallbackName));
     }
   }
   if (hasHooks(manifest?.provides?.hooks)) {
-    const settingsPath = paths.settingsPath;
+    const settingsPath = host.paths.settingsPath;
     await removeHooks(name, settingsPath);
   }
 

--- a/test/commands/disable.test.ts
+++ b/test/commands/disable.test.ts
@@ -37,7 +37,7 @@ describe("disable command", () => {
     const skillLink = join(env.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(true);
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
     expect(existsSync(skillLink)).toBe(false);
   });
 
@@ -53,7 +53,7 @@ describe("disable command", () => {
       yes: true,
     });
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
 
     const skill = getSkill(env.db, "TestSkill");
     expect(skill!.status).toBe("disabled");
@@ -71,14 +71,14 @@ describe("disable command", () => {
       yes: true,
     });
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
 
     const repoDir = join(env.paths.reposDir, "mock-TestSkill");
     expect(existsSync(repoDir)).toBe(true);
   });
 
   test("rejects non-installed skill", async () => {
-    const result = await disable(env.db, env.paths, "NonExistent");
+    const result = await disable(env.db, env.arc, env.host, "NonExistent");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not installed");
   });
@@ -97,7 +97,7 @@ describe("enable command", () => {
       yes: true,
     });
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
     await enable(env.db, env.arc, env.host, "TestSkill");
 
     const skillLink = join(env.paths.skillsDir, "TestSkill");
@@ -116,7 +116,7 @@ describe("enable command", () => {
       yes: true,
     });
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
     await enable(env.db, env.arc, env.host, "TestSkill");
 
     const skill = getSkill(env.db, "TestSkill");

--- a/test/commands/list.test.ts
+++ b/test/commands/list.test.ts
@@ -51,7 +51,7 @@ describe("list command", () => {
       yes: true,
     });
 
-    await disable(env.db, env.paths, "TestSkill");
+    await disable(env.db, env.arc, env.host, "TestSkill");
 
     const result = list(env.db);
     expect(result.skills[0].status).toBe("disabled");

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -107,7 +107,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(auditResult.surface.secret).toBe(2);
 
     // --- DISABLE ---
-    const disableResult = await disable(env.db, env.paths, "_JIRA");
+    const disableResult = await disable(env.db, env.arc, env.host, "_JIRA");
     expect(disableResult.success).toBe(true);
 
     // Symlink removed
@@ -187,7 +187,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(dbEntry!.artifact_type).toBe("tool");
 
     // --- DISABLE ---
-    const disableResult = await disable(env.db, env.paths, "mytool");
+    const disableResult = await disable(env.db, env.arc, env.host, "mytool");
     expect(disableResult.success).toBe(true);
     expect(existsSync(binLink)).toBe(false);
     expect(getSkill(env.db, "mytool")!.status).toBe("disabled");
@@ -250,7 +250,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(infoResult.skill).not.toBeNull();
 
     // --- DISABLE ---
-    const disableResult = await disable(env.db, env.paths, "TestArchitect");
+    const disableResult = await disable(env.db, env.arc, env.host, "TestArchitect");
     expect(disableResult.success).toBe(true);
     expect(existsSync(agentLink)).toBe(false);
     expect(getSkill(env.db, "TestArchitect")!.status).toBe("disabled");
@@ -308,7 +308,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(dbEntry!.artifact_type).toBe("prompt");
 
     // --- DISABLE ---
-    const disableResult = await disable(env.db, env.paths, "task-router");
+    const disableResult = await disable(env.db, env.arc, env.host, "task-router");
     expect(disableResult.success).toBe(true);
     expect(existsSync(promptLink)).toBe(false);
 
@@ -505,7 +505,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(mainShimContent).toContain("bun run");
 
     // --- DISABLE removes all ---
-    const disableResult = await disable(env.db, env.paths, "multitool");
+    const disableResult = await disable(env.db, env.arc, env.host, "multitool");
     expect(disableResult.success).toBe(true);
     expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(false);
     expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(false);


### PR DESCRIPTION
## Summary

Continues the #117 phase 3b sweep, following verify (#122), upgrade (#123), install (#124), remove (#125), and enable (#126).

## Changes

**`src/commands/disable.ts`**
- `disable()` signature: `paths: PaiPaths` → `arc: ArcPaths, host: HostAdapter`.
- Internal field accesses split:
  - arc-state: `paths.pipelinesDir`, `paths.shimDir` → `arc.X`
  - host-paths: `paths.binDir`, `paths.agentsDir`, `paths.promptsDir`, `paths.skillsDir`, `paths.settingsPath` → `host.paths.X`.
- 8 host-side accesses + 2 arc-side, all mechanical.

**`src/cli.ts`**
- `disable` command action derives `host = getDefaultHost({ root: paths.claudeRoot })` once, then passes `host` to the `disable()` call.

**Tests**
- `disable(env.db, env.paths, name)` → `disable(env.db, env.arc, env.host, name)` across 12 call sites in 3 test files (disable.test.ts × 6, lifecycle.test.ts × 5, list.test.ts × 1).

## Verification

- `bun test`: **718/718 passing**
- `bunx tsc --noEmit`: clean

## Remaining for #117

After this: migrate `catalog` (~1 more slice), then Phase 3d deletes `PaiPaths`, `createPaths`, and `TestEnv.paths`.

## Test plan

- [x] `bun test` — 718/718 green
- [x] `bunx tsc --noEmit` — clean
- [x] No `paths: PaiPaths` left on `disable` or its callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)