### PR TITLE
refactor(catalog): migrate from PaiPaths to ArcPaths + HostAdapter (#117 phase 3b/7 — final command slice)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -976,8 +976,9 @@ catalog
   .description("List catalog entries with install status")
   .action(async () => {
     const paths = createPaths();
+    const host = getDefaultHost({ root: paths.claudeRoot });
     const db = openDatabase(paths.dbPath);
-    const result = await catalogList(paths, db);
+    const result = await catalogList(paths, host, db);
     console.log(formatCatalogList(result));
     db.close();
   });
@@ -987,7 +988,8 @@ catalog
   .description("Search catalog (omit keyword to list all)")
   .action(async (keyword?: string) => {
     const paths = createPaths();
-    const result = await catalogSearch(paths, keyword ?? "");
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await catalogSearch(paths, host, keyword ?? "");
     console.log(formatCatalogSearch(result));
   });
 
@@ -1015,6 +1017,7 @@ catalog
       }
     ) => {
       const paths = createPaths();
+      const host = getDefaultHost({ root: paths.claudeRoot });
 
       if (opts.fromRegistry) {
         // Search all configured sources for the named package
@@ -1079,6 +1082,7 @@ catalog
         };
         const result = await catalogAdd(
           paths,
+          host,
           entry,
           opts.artifact as ArtifactType
         );
@@ -1097,7 +1101,8 @@ catalog
   .description("Remove an entry from the catalog")
   .action(async (name: string) => {
     const paths = createPaths();
-    const result = await catalogRemove(paths, name);
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await catalogRemove(paths, host, name);
     if (result.success) {
       console.log(`Removed ${result.name} from catalog`);
     } else {
@@ -1111,9 +1116,10 @@ catalog
   .description("Install a catalog entry (resolves dependencies)")
   .action(async (name: string) => {
     const paths = createPaths();
+    const host = getDefaultHost({ root: paths.claudeRoot });
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);
-    const result = await catalogUse(paths, db, name);
+    const result = await catalogUse(paths, host, db, name);
 
     if (result.success) {
       for (const item of result.installed!) {
@@ -1132,9 +1138,10 @@ catalog
   .description("Re-pull all installed catalog entries from source")
   .action(async () => {
     const paths = createPaths();
+    const host = getDefaultHost({ root: paths.claudeRoot });
     await ensureDirectories(paths);
     const db = openDatabase(paths.dbPath);
-    const result = await catalogSync(paths, db);
+    const result = await catalogSync(paths, host, db);
 
     if (result.success) {
       if (!result.synced?.length) {
@@ -1158,7 +1165,8 @@ catalog
   .description("Push local changes to a catalog entry back to its source")
   .action(async (name: string) => {
     const paths = createPaths();
-    const result = await catalogPush(paths, name);
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await catalogPush(paths, host, name);
     if (result.success) {
       console.log(`Pushed ${result.name} back to source`);
     } else {
@@ -1172,7 +1180,8 @@ catalog
   .description("Commit and push catalog.yaml to git remote")
   .action(async () => {
     const paths = createPaths();
-    const result = await catalogPushCatalog(paths);
+    const host = getDefaultHost({ root: paths.claudeRoot });
+    const result = await catalogPushCatalog(paths, host);
     if (result.success) {
       console.log("Catalog pushed to remote.");
     } else {

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -720,6 +720,10 @@ async function installAgentEntry(
   }
 }
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency.
+ *   Forwarded as-is to installAgentEntry, which also doesn't read it.
+ */
 async function installPromptEntry(
   arc: ArcPaths,
   host: HostAdapter,

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import { mkdir, cp, rm } from "fs/promises";
 import { homedir } from "os";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths, CatalogEntry, ArtifactType } from "../types.js";
+import type { ArcPaths, HostAdapter, CatalogEntry, ArtifactType } from "../types.js";
 import { MANIFEST_FILENAMES } from "../lib/manifest.js";
 import {
   loadCatalog,
@@ -68,11 +68,16 @@ export interface CatalogSyncResult {
 
 // ── Commands ──────────────────────────────────────────────────
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency. catalogList only
+ *   reads the catalog file (arc state) and per-skill install status from db.
+ */
 export async function catalogList(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   db: Database
 ): Promise<CatalogListResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -81,11 +86,16 @@ export async function catalogList(
   return { success: true, items };
 }
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency. catalogSearch
+ *   reads the catalog file (arc state) only.
+ */
 export async function catalogSearch(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   keyword: string
 ): Promise<CatalogSearchResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -94,30 +104,40 @@ export async function catalogSearch(
   return { success: true, results };
 }
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency. catalogAdd
+ *   only mutates the catalog file (arc state).
+ */
 export async function catalogAdd(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   entry: CatalogEntry,
   artifactType: ArtifactType
 ): Promise<CatalogAddResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
 
   try {
     addEntry(config, entry, artifactType);
-    await saveCatalog(paths.catalogPath, config);
+    await saveCatalog(arc.catalogPath, config);
     return { success: true, name: entry.name, artifactType };
   } catch (err: any) {
     return { success: false, error: err.message };
   }
 }
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency. catalogRemove
+ *   only mutates the catalog file (arc state).
+ */
 export async function catalogRemove(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<CatalogRemoveResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -127,7 +147,7 @@ export async function catalogRemove(
     return { success: false, error: `Entry "${name}" not found in catalog` };
   }
 
-  await saveCatalog(paths.catalogPath, config);
+  await saveCatalog(arc.catalogPath, config);
   return { success: true, name };
 }
 
@@ -139,11 +159,12 @@ export async function catalogRemove(
  * For prompts: copies .md file to prompts dir.
  */
 export async function catalogUse(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   db: Database,
   name: string
 ): Promise<CatalogUseResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -159,7 +180,7 @@ export async function catalogUse(
   const installed: Array<{ name: string; artifactType: ArtifactType }> = [];
 
   for (const { entry, artifactType } of ordered) {
-    const result = await installEntry(paths, db, entry, artifactType, config);
+    const result = await installEntry(arc, host, db, entry, artifactType, config);
     if (!result.success) {
       return {
         success: false,
@@ -177,10 +198,11 @@ export async function catalogUse(
  * Re-pull all installed catalog entries from source.
  */
 export async function catalogSync(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   db: Database
 ): Promise<CatalogSyncResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -196,7 +218,8 @@ export async function catalogSync(
 
   for (const item of installedItems) {
     const result = await installEntry(
-      paths,
+      arc,
+      host,
       db,
       item.entry,
       item.artifactType,
@@ -217,10 +240,11 @@ export async function catalogSync(
  * Local sources: copy back. GitHub sources: clone, overlay, commit, push.
  */
 export async function catalogPush(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   name: string
 ): Promise<CatalogPushResult> {
-  const config = await loadCatalog(paths.catalogPath);
+  const config = await loadCatalog(arc.catalogPath);
   if (!config) {
     return { success: false, error: "No catalog.yaml found" };
   }
@@ -236,7 +260,7 @@ export async function catalogPush(
   // Determine local installed path
   const localPath =
     artifactType === "skill"
-      ? join(paths.skillsDir, entry.name)
+      ? join(host.paths.skillsDir, entry.name)
       : artifactType === "agent"
         ? join(
             config.defaults.agents_dir.replace(/^~/, homedir()),
@@ -264,7 +288,7 @@ export async function catalogPush(
   }
 
   // GitHub source: clone, overlay, commit, push
-  const tmpDir = join(paths.reposDir, `_push_${name}_${Date.now()}`);
+  const tmpDir = join(arc.reposDir, `_push_${name}_${Date.now()}`);
   try {
     let cloneResult = Bun.spawnSync(
       ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
@@ -353,11 +377,15 @@ export async function catalogPush(
 
 /**
  * Commit and push catalog.yaml to git remote.
+ *
+ * @param host Unused today; threaded for #117 signature consistency. catalogPushCatalog
+ *   only invokes git against the catalog file (arc state).
  */
 export async function catalogPushCatalog(
-  paths: PaiPaths
+  arc: ArcPaths,
+  host: HostAdapter
 ): Promise<{ success: boolean; error?: string }> {
-  const catalogDir = join(paths.catalogPath, "..");
+  const catalogDir = join(arc.catalogPath, "..");
 
   const statusResult = Bun.spawnSync(
     ["git", "status", "--porcelain", "catalog.yaml"],
@@ -448,37 +476,39 @@ interface EntryInstallResult {
 }
 
 async function installEntry(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   db: Database,
   entry: CatalogEntry,
   artifactType: ArtifactType,
   config: { defaults: { skills_dir: string; agents_dir: string; prompts_dir: string } }
 ): Promise<EntryInstallResult> {
   if (artifactType === "skill") {
-    return installSkillEntry(paths, db, entry);
+    return installSkillEntry(arc, host, db, entry);
   }
 
   if (artifactType === "agent") {
-    return installAgentEntry(paths, entry, config.defaults.agents_dir);
+    return installAgentEntry(arc, host, entry, config.defaults.agents_dir);
   }
 
   if (artifactType === "prompt") {
-    return installPromptEntry(paths, entry, config.defaults.prompts_dir);
+    return installPromptEntry(arc, host, entry, config.defaults.prompts_dir);
   }
 
   return { success: false, error: `Unknown artifact type: ${artifactType}` };
 }
 
 async function installSkillEntry(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   db: Database,
   entry: CatalogEntry
 ): Promise<EntryInstallResult> {
   const resolved = resolveSource(entry.source);
   const isCli = entry.has_cli || entry.bundle;
-  const baseDir = isCli ? paths.reposDir : paths.skillsDir;
+  const baseDir = isCli ? arc.reposDir : host.paths.skillsDir;
   const installDir = join(baseDir, entry.name);
-  const skillLinkDir = join(paths.skillsDir, entry.name);
+  const skillLinkDir = join(host.paths.skillsDir, entry.name);
 
   // Path traversal guard — ensure installDir stays inside the target directory
   if (!join(installDir).startsWith(join(baseDir) + "/")) {
@@ -498,11 +528,11 @@ async function installSkillEntry(
     if (existsSync(installDir)) {
       await rm(installDir, { recursive: true, force: true });
     }
-    await mkdir(isCli ? paths.reposDir : paths.skillsDir, { recursive: true });
+    await mkdir(isCli ? arc.reposDir : host.paths.skillsDir, { recursive: true });
     await cp(sourceDir, installDir, { recursive: true });
   } else {
     // GitHub source: clone to temp, extract
-    const tmpDir = join(paths.reposDir, `_tmp_${entry.name}_${Date.now()}`);
+    const tmpDir = join(arc.reposDir, `_tmp_${entry.name}_${Date.now()}`);
     try {
       let cloneResult = Bun.spawnSync(
         ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
@@ -534,7 +564,7 @@ async function installSkillEntry(
       if (existsSync(installDir)) {
         await rm(installDir, { recursive: true, force: true });
       }
-      await mkdir(isCli ? paths.reposDir : paths.skillsDir, { recursive: true });
+      await mkdir(isCli ? arc.reposDir : host.paths.skillsDir, { recursive: true });
       await cp(sourceDir, installDir, { recursive: true });
     } finally {
       if (existsSync(tmpDir)) {
@@ -570,7 +600,7 @@ async function installSkillEntry(
       });
     }
     if (manifest) {
-      await createCliShim(paths.shimDir, paths.binDir, manifest);
+      await createCliShim(arc.shimDir, host.paths.binDir, manifest);
     }
   }
 
@@ -630,8 +660,14 @@ function findRepoRoot(startDir: string): string {
   return startDir;
 }
 
+/**
+ * @param host Unused today; threaded for #117 signature consistency. installAgentEntry
+ *   writes to `agentsDir` passed by the caller (catalogUse), which already resolved
+ *   it from config defaults — not from host.paths.agentsDir.
+ */
 async function installAgentEntry(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   entry: CatalogEntry,
   agentsDir: string
 ): Promise<EntryInstallResult> {
@@ -647,7 +683,7 @@ async function installAgentEntry(
   }
 
   // GitHub: clone, extract the single file
-  const tmpDir = join(paths.reposDir, `_tmp_${entry.name}_${Date.now()}`);
+  const tmpDir = join(arc.reposDir, `_tmp_${entry.name}_${Date.now()}`);
   try {
     let cloneResult = Bun.spawnSync(
       ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
@@ -685,10 +721,11 @@ async function installAgentEntry(
 }
 
 async function installPromptEntry(
-  paths: PaiPaths,
+  arc: ArcPaths,
+  host: HostAdapter,
   entry: CatalogEntry,
   promptsDir: string
 ): Promise<EntryInstallResult> {
   // Same logic as agent — single file copy
-  return installAgentEntry(paths, entry, promptsDir);
+  return installAgentEntry(arc, host, entry, promptsDir);
 }

--- a/test/commands/catalog.test.ts
+++ b/test/commands/catalog.test.ts
@@ -120,7 +120,7 @@ afterEach(async () => {
 
 describe("catalogList", () => {
   test("returns error when no catalog exists", async () => {
-    const result = await catalogList(env.paths, env.db);
+    const result = await catalogList(env.arc, env.host, env.db);
     expect(result.success).toBe(false);
     expect(result.error).toContain("No catalog.yaml");
   });
@@ -128,7 +128,7 @@ describe("catalogList", () => {
   test("lists all entries with install status", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogList(env.paths, env.db);
+    const result = await catalogList(env.arc, env.host, env.db);
     expect(result.success).toBe(true);
     expect(result.items).toHaveLength(4); // 3 skills + 1 agent
     expect(result.items!.every((i) => !i.installed)).toBe(true);
@@ -137,7 +137,7 @@ describe("catalogList", () => {
   test("formatCatalogList shows entries", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogList(env.paths, env.db);
+    const result = await catalogList(env.arc, env.host, env.db);
     const output = formatCatalogList(result);
     expect(output).toContain("Research");
     expect(output).toContain("Architect");
@@ -150,7 +150,7 @@ describe("catalogSearch", () => {
   test("finds entries by name", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogSearch(env.paths, "research");
+    const result = await catalogSearch(env.arc, env.host, "research");
     expect(result.success).toBe(true);
     expect(result.results).toHaveLength(1);
     expect(result.results![0].entry.name).toBe("Research");
@@ -159,7 +159,7 @@ describe("catalogSearch", () => {
   test("finds entries by description", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogSearch(env.paths, "debate");
+    const result = await catalogSearch(env.arc, env.host, "debate");
     expect(result.success).toBe(true);
     expect(result.results).toHaveLength(1);
     expect(result.results![0].entry.name).toBe("Council");
@@ -168,7 +168,7 @@ describe("catalogSearch", () => {
   test("returns empty for no match", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogSearch(env.paths, "zzzznotfound");
+    const result = await catalogSearch(env.arc, env.host, "zzzznotfound");
     expect(result.success).toBe(true);
     expect(result.results).toHaveLength(0);
   });
@@ -176,7 +176,7 @@ describe("catalogSearch", () => {
   test("formatCatalogSearch shows results", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogSearch(env.paths, "design");
+    const result = await catalogSearch(env.arc, env.host, "design");
     const output = formatCatalogSearch(result);
     expect(output).toContain("Architect");
     expect(output).toContain("source:");
@@ -195,12 +195,12 @@ describe("catalogAdd", () => {
       has_cli: true,
     };
 
-    const result = await catalogAdd(env.paths, entry, "skill");
+    const result = await catalogAdd(env.arc, env.host, entry, "skill");
     expect(result.success).toBe(true);
     expect(result.name).toBe("SpecFlow");
 
     // Verify persisted
-    const listResult = await catalogList(env.paths, env.db);
+    const listResult = await catalogList(env.arc, env.host, env.db);
     expect(listResult.items!.some((i) => i.entry.name === "SpecFlow")).toBe(true);
   });
 
@@ -214,7 +214,7 @@ describe("catalogAdd", () => {
       type: "custom",
     };
 
-    const result = await catalogAdd(env.paths, entry, "skill");
+    const result = await catalogAdd(env.arc, env.host, entry, "skill");
     expect(result.success).toBe(false);
     expect(result.error).toContain("already exists");
   });
@@ -224,10 +224,10 @@ describe("catalogRemove", () => {
   test("removes entry from catalog", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogRemove(env.paths, "Research");
+    const result = await catalogRemove(env.arc, env.host, "Research");
     expect(result.success).toBe(true);
 
-    const listResult = await catalogList(env.paths, env.db);
+    const listResult = await catalogList(env.arc, env.host, env.db);
     expect(listResult.items!.some((i) => i.entry.name === "Research")).toBe(
       false
     );
@@ -236,7 +236,7 @@ describe("catalogRemove", () => {
   test("returns error for non-existent entry", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogRemove(env.paths, "NonExistent");
+    const result = await catalogRemove(env.arc, env.host, "NonExistent");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not found");
   });
@@ -247,7 +247,7 @@ describe("catalogUse", () => {
     await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogUse(env.paths, env.db, "Research");
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
     expect(result.success).toBe(true);
     expect(result.installed).toHaveLength(1);
     expect(result.installed![0].name).toBe("Research");
@@ -269,7 +269,7 @@ describe("catalogUse", () => {
     await createMockAgentFile(env.root, "mock-agents", "Architect");
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogUse(env.paths, env.db, "Architect");
+    const result = await catalogUse(env.arc, env.host, env.db, "Architect");
     expect(result.success).toBe(true);
     expect(result.installed).toHaveLength(1);
     expect(result.installed![0].artifactType).toBe("agent");
@@ -284,7 +284,7 @@ describe("catalogUse", () => {
     await createMockSkillDir(env.root, "mock-skills/Thinking/Council", { name: "Council" });
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogUse(env.paths, env.db, "Council");
+    const result = await catalogUse(env.arc, env.host, env.db, "Council");
     expect(result.success).toBe(true);
     expect(result.installed).toHaveLength(2);
     // Thinking (dep) installed first, then Council
@@ -299,9 +299,9 @@ describe("catalogUse", () => {
     await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    await catalogUse(env.paths, env.db, "Research");
+    await catalogUse(env.arc, env.host, env.db, "Research");
 
-    const listResult = await catalogList(env.paths, env.db);
+    const listResult = await catalogList(env.arc, env.host, env.db);
     const researchItem = listResult.items!.find(
       (i) => i.entry.name === "Research"
     );
@@ -314,13 +314,13 @@ describe("catalogUse", () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
     // Install first time
-    await catalogUse(env.paths, env.db, "Research");
+    await catalogUse(env.arc, env.host, env.db, "Research");
     expect(existsSync(join(env.paths.skillsDir, "Research", "SKILL.md"))).toBe(
       true
     );
 
     // Install again (refresh)
-    const result = await catalogUse(env.paths, env.db, "Research");
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
     expect(result.success).toBe(true);
     expect(existsSync(join(env.paths.skillsDir, "Research", "SKILL.md"))).toBe(
       true
@@ -330,7 +330,7 @@ describe("catalogUse", () => {
   test("returns error for unknown entry", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogUse(env.paths, env.db, "NonExistent");
+    const result = await catalogUse(env.arc, env.host, env.db, "NonExistent");
     expect(result.success).toBe(false);
     expect(result.error).toContain("not found");
   });
@@ -340,7 +340,7 @@ describe("catalogSync", () => {
   test("returns empty when nothing installed", async () => {
     await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
 
-    const result = await catalogSync(env.paths, env.db);
+    const result = await catalogSync(env.arc, env.host, env.db);
     expect(result.success).toBe(true);
     expect(result.synced).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Completes the per-command migration sweep for #117. Following verify (#122), upgrade (#123), install (#124), remove (#125), enable (#126), and disable (#127), `catalog` is the **last production command** still on `PaiPaths`. After this merges, Phase 3d can delete `PaiPaths`, `createPaths`, and `TestEnv.paths`.

## Changes

**`src/commands/catalog.ts`**
- All 8 exported commands + 4 internal helpers migrate from `paths: PaiPaths` to `arc: ArcPaths, host: HostAdapter`:
  - Exports: `catalogList`, `catalogSearch`, `catalogAdd`, `catalogRemove`, `catalogUse`, `catalogSync`, `catalogPush`, `catalogPushCatalog`
  - Internal: `installEntry`, `installSkillEntry`, `installAgentEntry`, `installPromptEntry`
- Internal field accesses split:
  - arc-state: `paths.catalogPath`, `paths.reposDir`, `paths.shimDir` → `arc.X`
  - host-paths: `paths.skillsDir`, `paths.binDir` → `host.paths.X`
- Internal helper calls thread `arc, host` correctly between catalog functions.
- Pure catalog-state operations (`catalogList`, `catalogSearch`, `catalogAdd`, `catalogRemove`, `catalogPushCatalog`, `installAgentEntry`) accept `host` for signature consistency but don't read it. Each has a `@param host` JSDoc note explaining why it's threaded but unused (mirrors the pattern Echo accepted on `verify` in #122 and `upgrade.checkUpgrades` in #123).

**`src/cli.ts`**
- All 8 catalog command actions derive `host = getDefaultHost({ root: paths.claudeRoot })` alongside `paths = createPaths();` and thread it into the catalog calls.

**Tests**
- `catalogX(env.paths, ...)` → `catalogX(env.arc, env.host, ...)` across all call sites in `test/commands/catalog.test.ts`.

## Verification

- `bun test`: **718/718 passing**
- `bunx tsc --noEmit`: clean
- No `paths: PaiPaths` left on catalog exports or internal helpers
- Grep confirms zero `paths.X` accesses remain in `catalog.ts`

## What unlocks next

This is the last production command. After merge, **Phase 3d** is mechanical:
1. Delete `PaiPaths` type from `src/types.ts`
2. Delete `createPaths()` from `src/lib/paths.ts`
3. Delete `paths` field + `createPaths` import from `test/helpers/test-env.ts`
4. Migrate the 5 remaining non-command callers (`login`, `logout`, `publish`, `review`, `bundle`) that still take `paths: PaiPaths` — they touch arc-only state and the migration is a one-line type rename per file.
5. **`#117 closes`.**

## Test plan

- [x] `bun test` — 718/718 green
- [x] `bunx tsc --noEmit` — clean
- [x] No `paths: PaiPaths` left on catalog exports / helpers / CLI callers / test sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)