### PR TITLE
refactor: delete PaiPaths, close #117 (phase 3d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.24.0
+
+### Changed
+
+- **Multi-backend host adapter foundation (closes [#117](https://github.com/the-metafactory/arc/issues/117)).** 12-PR series ([#118–#129](https://github.com/the-metafactory/arc/pull/129)) splits the monolithic `PaiPaths` into two concerns: `ArcPaths` for arc's own host-independent state (config, db, repos, catalog) and `HostAdapter` + `HostPaths` for per-backend install dirs (Claude Code, Cortex). Phase 1 added the types and the Claude-Code adapter; Phase 2 introduced `hostPathFor()`/`requireHostDir()` dispatch and the Cortex adapter; Phase 3b migrated every production command (`verify`, `upgrade`, `install`, `remove`, `enable`, `disable`, `catalog`) command-by-command; this release (Phase 3d) deletes the deprecated `PaiPaths` type, `createPaths()` factory, and `TestEnv.paths` back-compat field, plus migrates the 5 remaining non-command callers (`info`, `login`, `logout`, `publish`, `review`, `bundle`).
+
+### Removed
+
+- **Breaking (TS only):** `PaiPaths` type, `createPaths()` factory, `TestEnv.paths` field. Replace with `ArcPaths` + `HostAdapter`. See `src/types.ts` and `test/helpers/test-env.ts` for the new shape.
+
+### Notes
+
+- Runtime behavior unchanged. Multi-host dispatch is wired but Claude Code remains the only default; future host adapters (Codex, Cursor) plug in via the `HostAdapter` interface without further surgery to commands.
+- `ensureDirectories()` signature changed from `(paths: PaiPaths)` to `(arc: ArcPaths, host: HostAdapter)`.
+
 ## 0.22.0
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Agentic Component Package Manager — CLI package manager for agentic skills, to
 
 ### Types
 
-- `src/types.ts` — All core types: `ArcManifest`, `ArtifactType`, `Capabilities`, `InstalledSkill`, `PaiPaths`, `RegistryEntry`, `CatalogEntry`, and more.
+- `src/types.ts` — All core types: `ArcManifest`, `ArtifactType`, `Capabilities`, `InstalledSkill`, `ArcPaths`, `HostAdapter`, `HostPaths`, `RegistryEntry`, `CatalogEntry`, and more.
 
 ### Data Flow
 
@@ -315,7 +315,7 @@ bun test:e2e                # End-to-end lifecycle tests (test/e2e/)
 All tests use `createTestEnv()` from `test/helpers/test-env.ts`. This creates:
 - Isolated temp directories simulating the full arc directory structure
 - A fresh SQLite database
-- Configurable `PaiPaths` pointing to the temp dirs
+- Configurable `ArcPaths` + `HostAdapter` pointing to the temp dirs
 - A `cleanup()` function that closes the DB and removes the temp dir
 
 Mock skill repos are created via `createMockSkillRepo()` which scaffolds a git-initialized repo with arc-manifest.yaml.

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.23.0
+version: 0.24.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/docs/agents-md/architecture.md
+++ b/docs/agents-md/architecture.md
@@ -40,7 +40,7 @@
 
 ### Types
 
-- `src/types.ts` — All core types: `ArcManifest`, `ArtifactType`, `Capabilities`, `InstalledSkill`, `PaiPaths`, `RegistryEntry`, `CatalogEntry`, and more.
+- `src/types.ts` — All core types: `ArcManifest`, `ArtifactType`, `Capabilities`, `InstalledSkill`, `ArcPaths`, `HostAdapter`, `HostPaths`, `RegistryEntry`, `CatalogEntry`, and more.
 
 ### Data Flow
 

--- a/docs/agents-md/testing.md
+++ b/docs/agents-md/testing.md
@@ -25,7 +25,7 @@ bun test:e2e                # End-to-end lifecycle tests (test/e2e/)
 All tests use `createTestEnv()` from `test/helpers/test-env.ts`. This creates:
 - Isolated temp directories simulating the full arc directory structure
 - A fresh SQLite database
-- Configurable `PaiPaths` pointing to the temp dirs
+- Configurable `ArcPaths` + `HostAdapter` pointing to the temp dirs
 - A `cleanup()` function that closes the DB and removes the temp dir
 
 Mock skill repos are created via `createMockSkillRepo()` which scaffolds a git-initialized repo with arc-manifest.yaml.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
-import { createPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
+import { createArcPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
 import { openDatabase } from "./lib/db.js";
 import { install, parseNameVersion } from "./commands/install.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
@@ -110,10 +110,10 @@ program
       process.exit(1);
     }
 
-    const paths = createPaths();
-    await ensureDirectories(paths);
+    const paths = createArcPaths();
+    const host = getDefaultHost();
+    await ensureDirectories(paths, host);
     const db = openDatabase(paths.dbPath);
-    const host = getDefaultHost({ root: paths.claudeRoot });
 
     // Check if input is a registry package ref (@scope/name[@version])
     const pkgRef = parsePackageRef(nameOrUrl);
@@ -352,7 +352,7 @@ program
       console.error(`\n❌ Unknown type "${opts.type}". Valid types: ${validTypes.join(", ")}`);
       process.exit(1);
     }
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
     const result = list(db, { type: opts.type as ArtifactType | undefined, library: opts.library });
     console.log(opts.json ? formatListJson(result) : formatList(result));
@@ -364,7 +364,7 @@ program
   .description("Show details about a package (installed or from registry)")
   .option("--json", "Output as JSON")
   .action(async (name: string, opts: { json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
     const result = await info(db, name, paths);
     console.log(opts.json ? formatInfoJson(result) : formatInfo(result));
@@ -376,7 +376,7 @@ program
   .description("Audit total capability surface of installed skills")
   .option("--verbose", "Show all pairwise capability warnings")
   .action((opts: { verbose?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
     const result = audit(db);
     console.log(formatAudit(result, opts.verbose));
@@ -387,9 +387,9 @@ program
   .command("disable <name>")
   .description("Disable an installed skill (preserves repo)")
   .action(async (name: string) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const host = getDefaultHost();
     const result = await disable(db, paths, host, name);
 
     if (result.success) {
@@ -406,9 +406,9 @@ program
   .command("enable <name>")
   .description("Re-enable a disabled skill")
   .action(async (name: string) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const host = getDefaultHost();
     const result = await enable(db, paths, host, name);
 
     if (result.success) {
@@ -426,9 +426,9 @@ program
   .description("Completely uninstall a skill (supports library:artifact syntax)")
   .option("--library <name>", "Remove all artifacts from a library")
   .action(async (name: string, opts: { library?: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const db = openDatabase(paths.dbPath);
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const host = getDefaultHost();
 
     if (opts.library) {
       // Remove all artifacts from a library
@@ -473,8 +473,8 @@ program
   .command("verify <name>")
   .description("Verify integrity of an installed skill")
   .action(async (name: string) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const db = openDatabase(paths.dbPath);
     const result = await verify(db, paths, host, name);
     console.log(formatVerify(result));
@@ -487,9 +487,9 @@ program
   .option("--check", "Only check for available upgrades, don't install")
   .option("--force", "Re-run upgrade pipeline even if already at latest version")
   .action(async (name: string | undefined, opts: { check?: boolean; force?: boolean }) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
-    await ensureDirectories(paths);
+    const paths = createArcPaths();
+    const host = getDefaultHost();
+    await ensureDirectories(paths, host);
     const db = openDatabase(paths.dbPath);
 
     if (opts.check || (!name && !opts.force)) {
@@ -639,7 +639,7 @@ program
       }
     ) => {
       const home = homedir();
-      const paths = createPaths();
+      const paths = createArcPaths();
       const db = openDatabase(paths.dbPath);
 
       const result = await upgradeCore(
@@ -680,7 +680,7 @@ program
   .option("--type <type>", "Filter by artifact type (skill, tool, agent, prompt, component, pipeline, action)")
   .option("--tier <tier>", "Filter by source tier (official, community, custom)")
   .action(async (keyword: string | undefined, opts: { json?: boolean; type?: string; tier?: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const sources = await loadSources(paths.sourcesPath);
 
     // Validate filters
@@ -728,7 +728,7 @@ source
   .command("list")
   .description("List configured registry sources")
   .action(async () => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const config = await loadSources(paths.sourcesPath);
     console.log(formatSourceList(config));
   });
@@ -739,7 +739,7 @@ source
   .option("-t, --tier <tier>", "Trust tier (official|community|custom)", "community")
   .option("--type <type>", "Source type (registry|metafactory)", "registry")
   .action(async (name: string, url: string, opts: { tier: string; type: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const config = await loadSources(paths.sourcesPath);
 
     const newSource: RegistrySource = {
@@ -770,7 +770,7 @@ source
   .command("update")
   .description("Refresh cached package indexes from all sources (like apt update)")
   .action(async () => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const sources = await loadSources(paths.sourcesPath);
     const results = await updateAllSources(sources, paths.cachePath);
 
@@ -787,7 +787,7 @@ source
   .command("remove <name>")
   .description("Remove a registry source")
   .action(async (name: string) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const config = await loadSources(paths.sourcesPath);
 
     try {
@@ -808,7 +808,7 @@ program
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .option("-f, --force", "Re-authenticate even if already logged in")
   .action(async (opts: { source?: string; force?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await login({ paths, sourceName: opts.source, force: opts.force });
 
     if (result.success) {
@@ -826,7 +826,7 @@ program
   .description("Remove authentication from metafactory source (only affects publishing)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .action(async (opts: { source?: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await logout({ paths, sourceName: opts.source });
 
     if (result.success) {
@@ -844,7 +844,7 @@ program
   .description("Create a distributable tarball from a package directory. For monorepos, pass a subdirectory (e.g. `arc bundle packages/my-pkg`) or use the library pattern at the repo root.")
   .option("-o, --output <path>", "Output path for the tarball")
   .action(async (path: string | undefined, opts: { output?: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await bundle({
       paths,
       packageDir: path ?? process.cwd(),
@@ -863,7 +863,7 @@ program
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--scope <namespace>", "Override publish scope/namespace")
   .action(async (path: string | undefined, opts: { tarball?: string; dryRun?: boolean; source?: string; scope?: string }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await publish({
       paths,
       packageDir: path ?? process.cwd(),
@@ -891,7 +891,7 @@ review
   .option("--per-page <number>", "Items per page (max 100)", "20")
   .option("--json", "Output raw JSON")
   .action(async (opts: { source?: string; page: string; perPage: string; json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await reviewList({
       paths,
       sourceName: opts.source,
@@ -909,7 +909,7 @@ review
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--json", "Output raw JSON")
   .action(async (id: string, opts: { source?: string; json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await reviewShow({ paths, sourceName: opts.source, id, json: opts.json });
     console.log(formatReviewShow(result));
     if (!result.success) process.exit(1);
@@ -921,7 +921,7 @@ review
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--json", "Output raw JSON")
   .action(async (id: string, opts: { source?: string; json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await reviewApprove({ paths, sourceName: opts.source, id, json: opts.json });
     console.log(formatReviewAction(result));
     if (!result.success) process.exit(1);
@@ -934,7 +934,7 @@ review
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--json", "Output raw JSON")
   .action(async (id: string, opts: { source?: string; reason: string; json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await reviewReject({
       paths,
       sourceName: opts.source,
@@ -953,7 +953,7 @@ review
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--json", "Output raw JSON")
   .action(async (id: string, opts: { source?: string; message: string; json?: boolean }) => {
-    const paths = createPaths();
+    const paths = createArcPaths();
     const result = await reviewRequestChanges({
       paths,
       sourceName: opts.source,
@@ -975,8 +975,8 @@ catalog
   .command("list")
   .description("List catalog entries with install status")
   .action(async () => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const db = openDatabase(paths.dbPath);
     const result = await catalogList(paths, host, db);
     console.log(formatCatalogList(result));
@@ -987,8 +987,8 @@ catalog
   .command("search [keyword]")
   .description("Search catalog (omit keyword to list all)")
   .action(async (keyword?: string) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const result = await catalogSearch(paths, host, keyword ?? "");
     console.log(formatCatalogSearch(result));
   });
@@ -1016,8 +1016,8 @@ catalog
         bundle?: boolean;
       }
     ) => {
-      const paths = createPaths();
-      const host = getDefaultHost({ root: paths.claudeRoot });
+      const paths = createArcPaths();
+      const host = getDefaultHost();
 
       if (opts.fromRegistry) {
         // Search all configured sources for the named package
@@ -1100,8 +1100,8 @@ catalog
   .command("remove <name>")
   .description("Remove an entry from the catalog")
   .action(async (name: string) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const result = await catalogRemove(paths, host, name);
     if (result.success) {
       console.log(`Removed ${result.name} from catalog`);
@@ -1115,9 +1115,9 @@ catalog
   .command("use <name>")
   .description("Install a catalog entry (resolves dependencies)")
   .action(async (name: string) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
-    await ensureDirectories(paths);
+    const paths = createArcPaths();
+    const host = getDefaultHost();
+    await ensureDirectories(paths, host);
     const db = openDatabase(paths.dbPath);
     const result = await catalogUse(paths, host, db, name);
 
@@ -1137,9 +1137,9 @@ catalog
   .command("sync")
   .description("Re-pull all installed catalog entries from source")
   .action(async () => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
-    await ensureDirectories(paths);
+    const paths = createArcPaths();
+    const host = getDefaultHost();
+    await ensureDirectories(paths, host);
     const db = openDatabase(paths.dbPath);
     const result = await catalogSync(paths, host, db);
 
@@ -1164,8 +1164,8 @@ catalog
   .command("push <name>")
   .description("Push local changes to a catalog entry back to its source")
   .action(async (name: string) => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const result = await catalogPush(paths, host, name);
     if (result.success) {
       console.log(`Pushed ${result.name} back to source`);
@@ -1179,8 +1179,8 @@ catalog
   .command("push-catalog")
   .description("Commit and push catalog.yaml to git remote")
   .action(async () => {
-    const paths = createPaths();
-    const host = getDefaultHost({ root: paths.claudeRoot });
+    const paths = createArcPaths();
+    const host = getDefaultHost();
     const result = await catalogPushCatalog(paths, host);
     if (result.success) {
       console.log("Catalog pushed to remote.");

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -1,9 +1,9 @@
 import { resolve } from "path";
 import { createBundle } from "../lib/bundle.js";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths } from "../types.js";
 
 export interface BundleOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   packageDir: string;
   outputPath?: string;
 }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -10,7 +10,7 @@ import { loadSources, getSourceType } from "../lib/sources.js";
 import { findInAllSources } from "../lib/remote-registry.js";
 import { parsePackageRef } from "../lib/registry-install.js";
 import { fetchMetafactoryPackageDetail } from "../lib/metafactory-api.js";
-import type { InstalledSkill, ArcManifest, PaiPaths, MetafactoryPackageDetail } from "../types.js";
+import type { InstalledSkill, ArcManifest, ArcPaths, MetafactoryPackageDetail } from "../types.js";
 
 export interface InfoResult {
   skill: InstalledSkill | null;
@@ -36,7 +36,7 @@ export interface InfoResult {
 export async function info(
   db: Database,
   name: string,
-  paths?: PaiPaths
+  paths?: ArcPaths
 ): Promise<InfoResult> {
   // Check if input is a scoped package ref (@scope/name)
   const pkgRef = parsePackageRef(name);
@@ -128,7 +128,7 @@ async function resolveRemote(
   originalName: string,
   lookupName: string,
   artifactFilter: string | undefined,
-  paths: PaiPaths
+  paths: ArcPaths
 ): Promise<InfoResult> {
   const sources = await loadSources(paths.sourcesPath);
   const found = await findInAllSources(sources, lookupName, paths.cachePath);
@@ -190,7 +190,7 @@ async function resolveRemoteLibraryArtifact(
 async function resolveMetafactoryInfo(
   scope: string,
   name: string,
-  paths: PaiPaths,
+  paths: ArcPaths,
 ): Promise<InfoResult> {
   const sources = await loadSources(paths.sourcesPath);
   const mfSources = sources.sources.filter((s) => s.enabled && getSourceType(s) === "metafactory");

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,9 +1,9 @@
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths } from "../types.js";
 import { loadSources, saveSources, findMetafactorySource } from "../lib/sources.js";
 import { initiateDeviceCode, pollForToken, openBrowser } from "../lib/device-auth.js";
 
 export interface LoginOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   sourceName?: string;
   force?: boolean;
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,8 +1,8 @@
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths } from "../types.js";
 import { loadSources, saveSources, findMetafactorySource } from "../lib/sources.js";
 
 export interface LogoutOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   sourceName?: string;
 }
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -10,10 +10,10 @@ import {
 } from "../lib/publish.js";
 import { loadSources, findMetafactorySource } from "../lib/sources.js";
 import { readManifest } from "../lib/manifest.js";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths } from "../types.js";
 
 export interface PublishOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   packageDir: string;
   tarballPath?: string;
   dryRun?: boolean;

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -8,10 +8,10 @@ import {
   type PendingSubmission,
   type SubmissionDetail,
 } from "../lib/review.js";
-import type { PaiPaths } from "../types.js";
+import type { ArcPaths } from "../types.js";
 
 export interface ReviewListOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   sourceName?: string;
   page?: number;
   perPage?: number;
@@ -29,7 +29,7 @@ export interface ReviewListResult {
 }
 
 async function resolveSource(
-  paths: PaiPaths,
+  paths: ArcPaths,
   sourceName?: string,
 ): Promise<{ source: import("../types.js").RegistrySource } | { error: string }> {
   const sourcesConfig = await loadSources(paths.sourcesPath);
@@ -64,7 +64,7 @@ export async function reviewList(opts: ReviewListOptions): Promise<ReviewListRes
 }
 
 export interface ReviewShowOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   sourceName?: string;
   id: string;
   json?: boolean;
@@ -86,7 +86,7 @@ export async function reviewShow(opts: ReviewShowOptions): Promise<ReviewShowRes
 }
 
 export interface ReviewActionOptions {
-  paths: PaiPaths;
+  paths: ArcPaths;
   sourceName?: string;
   id: string;
   reason?: string;

--- a/src/commands/upgrade-core.ts
+++ b/src/commands/upgrade-core.ts
@@ -2,7 +2,6 @@ import { join, dirname, basename } from "path";
 import { existsSync, readdirSync, lstatSync, readlinkSync } from "fs";
 import { mkdir, readdir } from "fs/promises";
 import type { Database } from "bun:sqlite";
-import type { PaiPaths } from "../types.js";
 import { listSkills } from "../lib/db.js";
 import { createSymlink, isValidSymlink, getSymlinkTarget } from "../lib/symlinks.js";
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,7 +1,7 @@
 import { join, dirname } from "path";
 import { homedir } from "os";
 import { existsSync, renameSync } from "fs";
-import type { ArcPaths, HostAdapter, PaiPaths } from "../types.js";
+import type { ArcPaths, HostAdapter } from "../types.js";
 import { createClaudeCodeHost } from "./hosts/claude-code.js";
 
 // TODO: Remove migration logic after 2026-Q3. Only 2 users (founders) on arc currently,
@@ -85,45 +85,23 @@ export function getDefaultHost(opts?: { root?: string }): HostAdapter {
 }
 
 /**
- * Create PaiPaths with default production paths. Override any field for testing.
- *
- * @deprecated Use createArcPaths() + getDefaultHost() instead. Kept for
- *   backward compatibility during the multi-backend migration (#117). Will be
- *   removed in Phase 3.
+ * Ensure all required directories exist — arc state + host-managed dirs.
  */
-export function createPaths(overrides?: Partial<PaiPaths>): PaiPaths {
-  const home = homedir();
-  const claudeRoot = overrides?.claudeRoot ?? join(home, ".claude");
-
-  const arc = createArcPaths(overrides);
-  const host = createClaudeCodeHost({ root: claudeRoot });
-
-  return {
-    ...arc,
-    claudeRoot,
-    skillsDir: overrides?.skillsDir ?? host.paths.skillsDir,
-    agentsDir: overrides?.agentsDir ?? host.paths.agentsDir,
-    promptsDir: overrides?.promptsDir ?? host.paths.promptsDir,
-    binDir: overrides?.binDir ?? host.paths.binDir,
-    settingsPath: overrides?.settingsPath ?? host.paths.settingsPath,
-  };
-}
-
-/**
- * Ensure all required directories exist.
- */
-export async function ensureDirectories(paths: PaiPaths): Promise<void> {
+export async function ensureDirectories(
+  arc: ArcPaths,
+  host: HostAdapter,
+): Promise<void> {
   const dirs = [
-    paths.skillsDir,
-    paths.agentsDir,
-    paths.promptsDir,
-    paths.binDir,
-    paths.reposDir,
-    paths.configRoot,
-    paths.secretsDir,
-    paths.runtimeDir,
-    paths.pipelinesDir,
-    paths.actionsDir,
+    arc.reposDir,
+    arc.configRoot,
+    arc.secretsDir,
+    arc.runtimeDir,
+    arc.pipelinesDir,
+    arc.actionsDir,
+    host.paths.skillsDir,
+    host.paths.agentsDir,
+    host.paths.promptsDir,
+    host.paths.binDir,
   ];
 
   for (const dir of dirs) {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -86,6 +86,16 @@ export function getDefaultHost(opts?: { root?: string }): HostAdapter {
 
 /**
  * Ensure all required directories exist — arc state + host-managed dirs.
+ *
+ * Intentionally NOT in this list:
+ * - `arc.cachePath` — file path, not a directory; remote-registry lazy-creates the parent.
+ * - `arc.dbPath` / `arc.sourcesPath` / `arc.catalogPath` / `arc.registryPath` — file
+ *   paths created on first write (`openDatabase`, `saveSources`, etc.).
+ * - `arc.shimDir` — created on first `arc install` of a CLI artifact (createCliShim).
+ * - `host.paths.settingsPath` — host-owned file; we never pre-create it.
+ *
+ * When adding a new directory-shaped field to `ArcPaths` or `HostPaths`, also
+ * add it here. Files belong elsewhere.
  */
 export async function ensureDirectories(
   arc: ArcPaths,

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,7 +417,7 @@ export interface AuditWarning {
 }
 
 // ── Host adapter types (multi-backend support, see issue #117) ─────
-// Split of legacy PaiPaths into two concerns:
+// Two concerns:
 //   - ArcPaths: arc's own state, host-independent
 //   - HostPaths + HostAdapter: per-backend install dirs and behavior
 
@@ -520,28 +520,6 @@ export interface HostAdapter {
    */
   supports(type: ArtifactType): boolean;
 }
-
-/**
- * Configurable paths — injected for test isolation.
- *
- * @deprecated Use ArcPaths + HostAdapter instead. Will be removed in Phase 3 of #117.
- *   Today kept as an intersection alias so existing call sites keep compiling while
- *   the migration runs incrementally.
- */
-export type PaiPaths = ArcPaths & {
-  /** @deprecated Use HostAdapter.paths.root */
-  claudeRoot: string;
-  /** @deprecated Use HostAdapter.paths.skillsDir */
-  skillsDir: string;
-  /** @deprecated Use HostAdapter.paths.agentsDir */
-  agentsDir: string;
-  /** @deprecated Use HostAdapter.paths.promptsDir */
-  promptsDir: string;
-  /** @deprecated Use HostAdapter.paths.binDir */
-  binDir: string;
-  /** @deprecated Use HostAdapter.paths.settingsPath */
-  settingsPath: string;
-};
 
 // ── Bundle and publish types ─────────────────────────────────
 

--- a/test/commands/bundle.test.ts
+++ b/test/commands/bundle.test.ts
@@ -29,7 +29,7 @@ describe("arc bundle command", () => {
       capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
     });
 
-    const result = await bundle({ paths: env.paths, packageDir: pkgDir });
+    const result = await bundle({ paths: env.arc, packageDir: pkgDir });
 
     expect(result.success).toBe(true);
     expect(result.name).toBe("my-skill");
@@ -53,7 +53,7 @@ describe("arc bundle command", () => {
     });
 
     const outputPath = join(testDir, "custom.tar.gz");
-    const result = await bundle({ paths: env.paths, packageDir: pkgDir, outputPath });
+    const result = await bundle({ paths: env.arc, packageDir: pkgDir, outputPath });
 
     expect(result.success).toBe(true);
     expect(result.tarballPath).toBe(outputPath);
@@ -66,7 +66,7 @@ describe("arc bundle command", () => {
     const emptyDir = join(testDir, "empty");
     await mkdir(emptyDir, { recursive: true });
 
-    const result = await bundle({ paths: env.paths, packageDir: emptyDir });
+    const result = await bundle({ paths: env.arc, packageDir: emptyDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain("arc-manifest.yaml");
   });
@@ -79,7 +79,7 @@ describe("arc bundle command", () => {
       capabilities: { filesystem: { read: [], write: [] }, network: [], bash: { allowed: false }, secrets: [] },
     });
 
-    const result = await bundle({ paths: env.paths, packageDir: pkgDir });
+    const result = await bundle({ paths: env.arc, packageDir: pkgDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain("validation failed");
   });

--- a/test/commands/catalog.test.ts
+++ b/test/commands/catalog.test.ts
@@ -126,7 +126,7 @@ describe("catalogList", () => {
   });
 
   test("lists all entries with install status", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogList(env.arc, env.host, env.db);
     expect(result.success).toBe(true);
@@ -135,7 +135,7 @@ describe("catalogList", () => {
   });
 
   test("formatCatalogList shows entries", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogList(env.arc, env.host, env.db);
     const output = formatCatalogList(result);
@@ -148,7 +148,7 @@ describe("catalogList", () => {
 
 describe("catalogSearch", () => {
   test("finds entries by name", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogSearch(env.arc, env.host, "research");
     expect(result.success).toBe(true);
@@ -157,7 +157,7 @@ describe("catalogSearch", () => {
   });
 
   test("finds entries by description", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogSearch(env.arc, env.host, "debate");
     expect(result.success).toBe(true);
@@ -166,7 +166,7 @@ describe("catalogSearch", () => {
   });
 
   test("returns empty for no match", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogSearch(env.arc, env.host, "zzzznotfound");
     expect(result.success).toBe(true);
@@ -174,7 +174,7 @@ describe("catalogSearch", () => {
   });
 
   test("formatCatalogSearch shows results", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogSearch(env.arc, env.host, "design");
     const output = formatCatalogSearch(result);
@@ -185,7 +185,7 @@ describe("catalogSearch", () => {
 
 describe("catalogAdd", () => {
   test("adds entry to catalog", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const entry: CatalogEntry = {
       name: "SpecFlow",
@@ -205,7 +205,7 @@ describe("catalogAdd", () => {
   });
 
   test("rejects duplicate name", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const entry: CatalogEntry = {
       name: "Research",
@@ -222,7 +222,7 @@ describe("catalogAdd", () => {
 
 describe("catalogRemove", () => {
   test("removes entry from catalog", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogRemove(env.arc, env.host, "Research");
     expect(result.success).toBe(true);
@@ -234,7 +234,7 @@ describe("catalogRemove", () => {
   });
 
   test("returns error for non-existent entry", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogRemove(env.arc, env.host, "NonExistent");
     expect(result.success).toBe(false);
@@ -245,7 +245,7 @@ describe("catalogRemove", () => {
 describe("catalogUse", () => {
   test("installs local skill entry and records in DB", async () => {
     await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogUse(env.arc, env.host, env.db, "Research");
     expect(result.success).toBe(true);
@@ -253,7 +253,7 @@ describe("catalogUse", () => {
     expect(result.installed![0].name).toBe("Research");
 
     // Verify the skill dir was created
-    const skillDir = join(env.paths.skillsDir, "Research");
+    const skillDir = join(env.host.paths.skillsDir, "Research");
     expect(existsSync(skillDir)).toBe(true);
     expect(existsSync(join(skillDir, "SKILL.md"))).toBe(true);
 
@@ -267,7 +267,7 @@ describe("catalogUse", () => {
 
   test("installs local agent entry", async () => {
     await createMockAgentFile(env.root, "mock-agents", "Architect");
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogUse(env.arc, env.host, env.db, "Architect");
     expect(result.success).toBe(true);
@@ -282,7 +282,7 @@ describe("catalogUse", () => {
   test("resolves dependencies before installing", async () => {
     await createMockSkillDir(env.root, "mock-skills/Thinking", { name: "Thinking" });
     await createMockSkillDir(env.root, "mock-skills/Thinking/Council", { name: "Council" });
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogUse(env.arc, env.host, env.db, "Council");
     expect(result.success).toBe(true);
@@ -291,13 +291,13 @@ describe("catalogUse", () => {
     expect(result.installed![0].name).toBe("Thinking");
     expect(result.installed![1].name).toBe("Council");
 
-    expect(existsSync(join(env.paths.skillsDir, "Thinking"))).toBe(true);
-    expect(existsSync(join(env.paths.skillsDir, "Council"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "Thinking"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "Council"))).toBe(true);
   });
 
   test("catalog list shows installed status after use", async () => {
     await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     await catalogUse(env.arc, env.host, env.db, "Research");
 
@@ -311,24 +311,24 @@ describe("catalogUse", () => {
 
   test("refreshes already-installed skill (overwrites)", async () => {
     await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     // Install first time
     await catalogUse(env.arc, env.host, env.db, "Research");
-    expect(existsSync(join(env.paths.skillsDir, "Research", "SKILL.md"))).toBe(
+    expect(existsSync(join(env.host.paths.skillsDir, "Research", "SKILL.md"))).toBe(
       true
     );
 
     // Install again (refresh)
     const result = await catalogUse(env.arc, env.host, env.db, "Research");
     expect(result.success).toBe(true);
-    expect(existsSync(join(env.paths.skillsDir, "Research", "SKILL.md"))).toBe(
+    expect(existsSync(join(env.host.paths.skillsDir, "Research", "SKILL.md"))).toBe(
       true
     );
   });
 
   test("returns error for unknown entry", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogUse(env.arc, env.host, env.db, "NonExistent");
     expect(result.success).toBe(false);
@@ -338,7 +338,7 @@ describe("catalogUse", () => {
 
 describe("catalogSync", () => {
   test("returns empty when nothing installed", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog(env.root));
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
 
     const result = await catalogSync(env.arc, env.host, env.db);
     expect(result.success).toBe(true);

--- a/test/commands/disable.test.ts
+++ b/test/commands/disable.test.ts
@@ -34,7 +34,7 @@ describe("disable command", () => {
       yes: true,
     });
 
-    const skillLink = join(env.paths.skillsDir, "TestSkill");
+    const skillLink = join(env.host.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(true);
 
     await disable(env.db, env.arc, env.host, "TestSkill");
@@ -73,7 +73,7 @@ describe("disable command", () => {
 
     await disable(env.db, env.arc, env.host, "TestSkill");
 
-    const repoDir = join(env.paths.reposDir, "mock-TestSkill");
+    const repoDir = join(env.arc.reposDir, "mock-TestSkill");
     expect(existsSync(repoDir)).toBe(true);
   });
 
@@ -100,7 +100,7 @@ describe("enable command", () => {
     await disable(env.db, env.arc, env.host, "TestSkill");
     await enable(env.db, env.arc, env.host, "TestSkill");
 
-    const skillLink = join(env.paths.skillsDir, "TestSkill");
+    const skillLink = join(env.host.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(true);
   });
 

--- a/test/commands/info.test.ts
+++ b/test/commands/info.test.ts
@@ -128,9 +128,9 @@ describe("info — remote packages", () => {
         enabled: true,
       }],
     });
-    await writeFile(env.paths.sourcesPath, sourcesContent);
+    await writeFile(env.arc.sourcesPath, sourcesContent);
 
-    const result = await info(env.db, "remote-skill", env.paths);
+    const result = await info(env.db, "remote-skill", env.arc);
 
     expect(result.error).toBeUndefined();
     expect(result.manifest).not.toBeNull();
@@ -174,11 +174,11 @@ describe("info — remote packages", () => {
 
     const registryFile = join(env.root, "test-registry.yaml");
     await writeFile(registryFile, registryContent);
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{ name: "test-source", url: `file://${registryFile}`, tier: "community", enabled: true }],
     }));
 
-    const result = await info(env.db, "remote-lib", env.paths);
+    const result = await info(env.db, "remote-lib", env.arc);
 
     expect(result.error).toBeUndefined();
     expect(result.manifest).not.toBeNull();
@@ -205,11 +205,11 @@ describe("info — remote packages", () => {
         agents: [], prompts: [], tools: [], components: [], rules: [],
       },
     }));
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{ name: "test-source", url: `file://${registryFile}`, tier: "community", enabled: true }],
     }));
 
-    const result = await info(env.db, "remote-lib:alpha", env.paths);
+    const result = await info(env.db, "remote-lib:alpha", env.arc);
 
     expect(result.error).toBeUndefined();
     expect(result.manifest).not.toBeNull();
@@ -234,11 +234,11 @@ describe("info — remote packages", () => {
         agents: [], prompts: [], tools: [], components: [], rules: [],
       },
     }));
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{ name: "test-source", url: `file://${registryFile}`, tier: "community", enabled: true }],
     }));
 
-    const result = await info(env.db, "remote-lib:nope", env.paths);
+    const result = await info(env.db, "remote-lib:nope", env.arc);
 
     expect(result.error).toContain("not found in library");
   });
@@ -250,11 +250,11 @@ describe("info — remote packages", () => {
     await writeFile(registryFile, YAML.stringify({
       registry: { skills: [], agents: [], prompts: [], tools: [], components: [], rules: [] },
     }));
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{ name: "test-source", url: `file://${registryFile}`, tier: "community", enabled: true }],
     }));
 
-    const result = await info(env.db, "nonexistent", env.paths);
+    const result = await info(env.db, "nonexistent", env.arc);
 
     expect(result.error).toContain("not found");
     expect(result.error).toContain("not installed and not in any configured source");
@@ -383,7 +383,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
     env = await createTestEnv();
 
     // Configure a metafactory source
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{
         name: "mf-test",
         url: "https://api.example.com",
@@ -414,7 +414,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
       updated_at: 1700000000,
     });
 
-    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+    const result = await info(env.db, "@jcfischer/demo-skill", env.arc);
 
     expect(result.error).toBeUndefined();
     expect(result.manifest).not.toBeNull();
@@ -433,7 +433,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
   test("returns error when @scope/name not found in any API source", async () => {
     env = await createTestEnv();
 
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{
         name: "mf-test",
         url: "https://api.example.com",
@@ -447,7 +447,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
     savedFetch = globalThis.fetch;
     (globalThis as any).fetch = async () => new Response('{"error":"Not found"}', { status: 404 });
 
-    const result = await info(env.db, "@jcfischer/nonexistent", env.paths);
+    const result = await info(env.db, "@jcfischer/nonexistent", env.arc);
 
     expect(result.error).toContain("not found");
   });
@@ -479,7 +479,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
   test("formats @scope/name in install hint for API packages", async () => {
     env = await createTestEnv();
 
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{
         name: "mf-test",
         url: "https://api.example.com",
@@ -505,7 +505,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
       updated_at: 1700000000,
     });
 
-    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+    const result = await info(env.db, "@jcfischer/demo-skill", env.arc);
     const formatted = formatInfo(result);
 
     expect(formatted).toContain("arc install @jcfischer/demo-skill");
@@ -514,7 +514,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
   test("JSON output includes API metadata", async () => {
     env = await createTestEnv();
 
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{
         name: "mf-test",
         url: "https://api.example.com",
@@ -540,7 +540,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
       updated_at: 1700000000,
     });
 
-    const result = await info(env.db, "@jcfischer/demo-skill", env.paths);
+    const result = await info(env.db, "@jcfischer/demo-skill", env.arc);
     const json = JSON.parse(formatInfoJson(result));
 
     expect(json.installed).toBe(false);
@@ -554,7 +554,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
   test("JSON output includes sponsor when present", async () => {
     env = await createTestEnv();
 
-    await writeFile(env.paths.sourcesPath, YAML.stringify({
+    await writeFile(env.arc.sourcesPath, YAML.stringify({
       sources: [{
         name: "mf-test",
         url: "https://api.example.com",
@@ -580,7 +580,7 @@ describe("info — metafactory API packages (@scope/name)", () => {
       updated_at: 1700000000,
     });
 
-    const result = await info(env.db, "@jcfischer/sponsored-skill", env.paths);
+    const result = await info(env.db, "@jcfischer/sponsored-skill", env.arc);
     const json = JSON.parse(formatInfoJson(result));
 
     expect(json.sponsor).toBeDefined();

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -35,7 +35,7 @@ describe("install command", () => {
 
     expect(result.success).toBe(true);
 
-    const repoDir = join(env.paths.reposDir, `mock-TestSkill`);
+    const repoDir = join(env.arc.reposDir, `mock-TestSkill`);
     expect(existsSync(repoDir)).toBe(true);
   });
 
@@ -69,7 +69,7 @@ describe("install command", () => {
       yes: true,
     });
 
-    const skillLink = join(env.paths.skillsDir, "TestSkill");
+    const skillLink = join(env.host.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(true);
     expect(lstatSync(skillLink).isSymbolicLink()).toBe(true);
   });
@@ -87,7 +87,7 @@ describe("install command", () => {
       yes: true,
     });
 
-    const binLink = join(env.paths.binDir, "jira");
+    const binLink = join(env.host.paths.binDir, "jira");
     expect(existsSync(binLink)).toBe(true);
     expect(lstatSync(binLink).isSymbolicLink()).toBe(true);
   });
@@ -166,7 +166,7 @@ describe("install command", () => {
     expect(result.success).toBe(true);
     expect(result.name).toBe("P_RSS_DIGEST");
 
-    const pipelineLink = join(env.paths.pipelinesDir, "P_RSS_DIGEST");
+    const pipelineLink = join(env.arc.pipelinesDir, "P_RSS_DIGEST");
     expect(existsSync(pipelineLink)).toBe(true);
     expect(lstatSync(pipelineLink).isSymbolicLink()).toBe(true);
 
@@ -190,9 +190,9 @@ describe("install command", () => {
     });
 
     // Verify installed
-    const pipelineLink = join(env.paths.pipelinesDir, "P_CLI_PIPE");
+    const pipelineLink = join(env.arc.pipelinesDir, "P_CLI_PIPE");
     expect(existsSync(pipelineLink)).toBe(true);
-    const binLink = join(env.paths.binDir, "p_cli_pipe");
+    const binLink = join(env.host.paths.binDir, "p_cli_pipe");
     expect(existsSync(binLink)).toBe(true);
 
     // Remove
@@ -221,7 +221,7 @@ describe("install command", () => {
     expect(result.success).toBe(true);
     expect(result.name).toBe("A_DISCOVER_REPOS");
 
-    const actionLink = join(env.paths.actionsDir, "A_DISCOVER_REPOS");
+    const actionLink = join(env.arc.actionsDir, "A_DISCOVER_REPOS");
     expect(existsSync(actionLink)).toBe(true);
     expect(lstatSync(actionLink).isSymbolicLink()).toBe(true);
 
@@ -255,7 +255,7 @@ describe("install command", () => {
 
     // Bundle landed at the canonical reposDir path (the user-facing
     // contract from arc#102: `~/.config/metafactory/pkg/repos/<name>/`).
-    const repoDir = join(env.paths.reposDir, "mock-TestAgent");
+    const repoDir = join(env.arc.reposDir, "mock-TestAgent");
     expect(existsSync(repoDir)).toBe(true);
     expect(existsSync(join(repoDir, "arc-manifest.yaml"))).toBe(true);
 
@@ -271,7 +271,7 @@ describe("install command", () => {
     // contract owned by the host (grove) does not depend on this, but
     // we keep the link-shape check so future regressions to the
     // artifact-installer agent case surface here.
-    expect(existsSync(join(env.paths.agentsDir, "TestAgent.md"))).toBe(true);
+    expect(existsSync(join(env.host.paths.agentsDir, "TestAgent.md"))).toBe(true);
   });
 
   // Persona-driven agent shape (arc#100 § 12) — no `capabilities` block.
@@ -386,7 +386,7 @@ describe("install command", () => {
 
     // Bundle landed at canonical reposDir; manifest accessible at
     // <bundle>/agent/arc-manifest.yaml (matches arc#102 smoke test).
-    const bundleRoot = join(env.paths.reposDir, "mock-NestedAgent");
+    const bundleRoot = join(env.arc.reposDir, "mock-NestedAgent");
     expect(existsSync(join(bundleRoot, "agent", "arc-manifest.yaml"))).toBe(true);
     expect(existsSync(join(bundleRoot, "agent", "persona.md"))).toBe(true);
 
@@ -691,8 +691,8 @@ describe("install provides.files (issue #84)", () => {
     expect(result.error).toContain("hooks");
     expect(result.error).toContain(missingHandler);
     // settings.json must not have been written with the broken hook
-    if (existsSync(env.paths.settingsPath)) {
-      const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    if (existsSync(env.host.paths.settingsPath)) {
+      const settings = JSON.parse(await Bun.file(env.host.paths.settingsPath).text());
       const stopHooks = settings.hooks?.Stop ?? [];
       const ghostFound = stopHooks.some((g: { _pai_pkg?: string }) => g._pai_pkg === "GhostHookSkill");
       expect(ghostFound).toBe(false);
@@ -716,7 +716,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     expect(result.success).toBe(true);
-    const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    const settings = JSON.parse(await Bun.file(env.host.paths.settingsPath).text());
     const stopHooks = settings.hooks?.Stop ?? [];
     const ours = stopHooks.find((g: { _pai_pkg?: string }) => g._pai_pkg === "GoodHookSkill");
     expect(ours).toBeDefined();
@@ -746,7 +746,7 @@ describe("install provides.files (issue #84)", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("hooks");
     // Diagnostic should reference the resolved absolute path, not the literal ${PAI_DIR}.
-    expect(result.error).toContain(env.paths.claudeRoot);
+    expect(result.error).toContain(env.host.paths.root);
     expect(result.error).toContain("SkillNudge.ts");
   });
 
@@ -776,7 +776,7 @@ describe("install provides.files (issue #84)", () => {
     // anywhere — neither the partial provides.files entry nor the skill dir.
     expect(existsSync(presentTarget)).toBe(false);
     expect(existsSync(missingTarget)).toBe(false);
-    expect(existsSync(join(env.paths.skillsDir, "RollbackPreValidate"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "RollbackPreValidate"))).toBe(false);
   });
 
   test("hook gate failure rolls back per-type symlinks + provides.files targets + CLI shims", async () => {
@@ -785,7 +785,7 @@ describe("install provides.files (issue #84)", () => {
     // gets created. Then the hook gate trips on a separate
     // ${PAI_DIR}/Ghost.ts entry. Install must fail AND clean up everything
     // that was placed before the gate ran.
-    const filesTarget = join(env.paths.claudeRoot, "handlers", "Live.ts");
+    const filesTarget = join(env.host.paths.root, "handlers", "Live.ts");
     const repoUrl = await buildRepoWithProvides({
       name: "RollbackOnHookGate",
       extraFiles: {
@@ -812,11 +812,11 @@ describe("install provides.files (issue #84)", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("hooks");
     // Every artifact placed before the gate must be gone.
-    expect(existsSync(join(env.paths.skillsDir, "RollbackOnHookGate"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "RollbackOnHookGate"))).toBe(false);
     expect(existsSync(filesTarget)).toBe(false);
     // bin symlink + PATH shim for the declared CLI
-    expect(existsSync(join(env.paths.binDir, "rollbackgate"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "rollbackgate"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "rollbackgate"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "rollbackgate"))).toBe(false);
   });
 
   // Issue #97: postinstall script failure leaves the same partial-state shape
@@ -824,7 +824,7 @@ describe("install provides.files (issue #84)", () => {
   // settings.json (registerHooks runs before postinstall). Install must tear
   // down both before returning.
   test("postinstall failure rolls back symlinks AND unregisters hooks", async () => {
-    const filesTarget = join(env.paths.claudeRoot, "handlers", "Live.ts");
+    const filesTarget = join(env.host.paths.root, "handlers", "Live.ts");
     const repoUrl = await buildRepoWithProvides({
       name: "PostinstallRollback",
       extraFiles: { "handlers/Live.ts": "// live\n" },
@@ -850,18 +850,18 @@ describe("install provides.files (issue #84)", () => {
     expect(result.error).toContain("Postinstall script failed");
 
     // Symlink rollback assertions (same shape as #89 hook-gate test).
-    expect(existsSync(join(env.paths.skillsDir, "PostinstallRollback"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "PostinstallRollback"))).toBe(false);
     expect(existsSync(filesTarget)).toBe(false);
-    expect(existsSync(join(env.paths.binDir, "postrollback"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "postrollback"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "postrollback"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "postrollback"))).toBe(false);
 
     // Hook unregistration assertion: settings.json was written by
     // registerHooks earlier in the install flow, then the package's group
     // was removed by removeHooks on postinstall failure. The file must
     // exist (otherwise we'd be silently passing the assertion when
     // registerHooks didn't run) AND not contain our group.
-    expect(existsSync(env.paths.settingsPath)).toBe(true);
-    const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    expect(existsSync(env.host.paths.settingsPath)).toBe(true);
+    const settings = JSON.parse(await Bun.file(env.host.paths.settingsPath).text());
     const stopHooks = settings.hooks?.Stop ?? [];
     const ours = stopHooks.find(
       (g: { _pai_pkg?: string }) => g._pai_pkg === "PostinstallRollback",
@@ -874,7 +874,7 @@ describe("install provides.files (issue #84)", () => {
   });
 
   test("install succeeds when ${PAI_DIR} hook target is landed via provides.files", async () => {
-    const targetPath = join(env.paths.claudeRoot, "hooks", "handlers", "Live.ts");
+    const targetPath = join(env.host.paths.root, "hooks", "handlers", "Live.ts");
     const repoUrl = await buildRepoWithProvides({
       name: "PaiDirLiveHook",
       extraFiles: { "hooks/handlers/Live.ts": "// live\n" },
@@ -892,7 +892,7 @@ describe("install provides.files (issue #84)", () => {
     });
 
     expect(result.success).toBe(true);
-    const settings = JSON.parse(await Bun.file(env.paths.settingsPath).text());
+    const settings = JSON.parse(await Bun.file(env.host.paths.settingsPath).text());
     const stopHooks = settings.hooks?.Stop ?? [];
     const ours = stopHooks.find((g: { _pai_pkg?: string }) => g._pai_pkg === "PaiDirLiveHook");
     expect(ours).toBeDefined();

--- a/test/commands/library-install.test.ts
+++ b/test/commands/library-install.test.ts
@@ -43,7 +43,7 @@ describe("library install", () => {
     expect(installed.skills[0].library_name).toBe("test-lib");
 
     // Verify symlink exists
-    expect(existsSync(join(env.paths.skillsDir, "alpha"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "alpha"))).toBe(true);
   });
 
   test("installs all artifacts from a library", async () => {

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -56,22 +56,22 @@ function registrySource(): SourcesConfig {
 
 describe("login - source finding", () => {
   test("returns error when no metafactory source configured", async () => {
-    await saveSources(env.paths.sourcesPath, registrySource());
-    const result = await login({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, registrySource());
+    const result = await login({ paths: env.arc });
     expect(result.success).toBe(false);
     expect(result.error).toContain("No metafactory source configured");
   });
 
   test("returns error when --source name not found", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
-    const result = await login({ paths: env.paths, sourceName: "nonexistent" });
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const result = await login({ paths: env.arc, sourceName: "nonexistent" });
     expect(result.success).toBe(false);
     expect(result.error).toContain('"nonexistent" not found');
   });
 
   test("returns error when source is type registry", async () => {
-    await saveSources(env.paths.sourcesPath, registrySource());
-    const result = await login({ paths: env.paths, sourceName: "my-registry" });
+    await saveSources(env.arc.sourcesPath, registrySource());
+    const result = await login({ paths: env.arc, sourceName: "my-registry" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("registry");
     expect(result.error).toContain("not \"metafactory\"");
@@ -84,26 +84,26 @@ describe("login - source finding", () => {
         { name: "mf", url: "https://meta-factory.ai", tier: "official", enabled: true, type: "metafactory" },
       ],
     };
-    await saveSources(env.paths.sourcesPath, config);
+    await saveSources(env.arc.sourcesPath, config);
     // Mocked device-auth returns a failed poll — proves it found the right source
     // and reached the auth flow (not "no source" error)
-    const result = await login({ paths: env.paths });
+    const result = await login({ paths: env.arc });
     expect(result.error).not.toContain("No metafactory source configured");
   });
 });
 
 describe("login - already logged in", () => {
   test("returns error when token exists and no --force", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource("existing-token"));
-    const result = await login({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, metafactorySource("existing-token"));
+    const result = await login({ paths: env.arc });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Already logged in");
   });
 
   test("proceeds when token exists and --force", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource("existing-token"));
+    await saveSources(env.arc.sourcesPath, metafactorySource("existing-token"));
     // Mocked device-auth returns a failed poll — proves it bypassed "already logged in"
-    const result = await login({ paths: env.paths, force: true });
+    const result = await login({ paths: env.arc, force: true });
     expect(result.error).not.toContain("Already logged in");
   });
 });

--- a/test/commands/logout.test.ts
+++ b/test/commands/logout.test.ts
@@ -40,22 +40,22 @@ function registrySource(): SourcesConfig {
 
 describe("logout - source finding", () => {
   test("returns error when no metafactory source configured", async () => {
-    await saveSources(env.paths.sourcesPath, registrySource());
-    const result = await logout({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, registrySource());
+    const result = await logout({ paths: env.arc });
     expect(result.success).toBe(false);
     expect(result.error).toContain("No metafactory source configured");
   });
 
   test("returns error when --source name not found", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource("token"));
-    const result = await logout({ paths: env.paths, sourceName: "nonexistent" });
+    await saveSources(env.arc.sourcesPath, metafactorySource("token"));
+    const result = await logout({ paths: env.arc, sourceName: "nonexistent" });
     expect(result.success).toBe(false);
     expect(result.error).toContain('"nonexistent" not found');
   });
 
   test("returns error when source is type registry", async () => {
-    await saveSources(env.paths.sourcesPath, registrySource());
-    const result = await logout({ paths: env.paths, sourceName: "my-registry" });
+    await saveSources(env.arc.sourcesPath, registrySource());
+    const result = await logout({ paths: env.arc, sourceName: "my-registry" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("registry");
     expect(result.error).toContain("not \"metafactory\"");
@@ -64,30 +64,30 @@ describe("logout - source finding", () => {
 
 describe("logout - token removal", () => {
   test("returns error when not logged in", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
-    const result = await logout({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const result = await logout({ paths: env.arc });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Not logged in");
   });
 
   test("removes token on success", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource("my-secret-token"));
-    const result = await logout({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, metafactorySource("my-secret-token"));
+    const result = await logout({ paths: env.arc });
     expect(result.success).toBe(true);
     expect(result.sourceName).toBe("mf-test");
 
     // Verify token removed from disk
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     const source = config.sources.find((s) => s.name === "mf-test");
     expect(source).toBeDefined();
     expect(source!.token).toBeUndefined();
   });
 
   test("source still exists after logout", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource("token-to-remove"));
-    await logout({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, metafactorySource("token-to-remove"));
+    await logout({ paths: env.arc });
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources.find((s) => s.name === "mf-test")).toBeDefined();
   });
 
@@ -98,10 +98,10 @@ describe("logout - token removal", () => {
         { name: "other", url: "https://example.com/R.yaml", tier: "community", enabled: true },
       ],
     };
-    await saveSources(env.paths.sourcesPath, config);
-    await logout({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, config);
+    await logout({ paths: env.arc });
 
-    const reloaded = await loadSources(env.paths.sourcesPath);
+    const reloaded = await loadSources(env.arc.sourcesPath);
     expect(reloaded.sources).toHaveLength(2);
     expect(reloaded.sources[1].name).toBe("other");
     expect(reloaded.sources[1].url).toBe("https://example.com/R.yaml");

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -48,16 +48,16 @@ const validManifest = {
 
 describe("arc publish command", () => {
   test("fails without metafactory source", async () => {
-    await saveSources(env.paths.sourcesPath, { sources: [] });
+    await saveSources(env.arc.sourcesPath, { sources: [] });
     const pkgDir = await createPackageDir(testDir, validManifest);
 
-    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain("metafactory");
   });
 
   test("fails without authentication", async () => {
-    await saveSources(env.paths.sourcesPath, {
+    await saveSources(env.arc.sourcesPath, {
       sources: [{
         name: "mf-test",
         url: "https://meta-factory.test",
@@ -68,17 +68,17 @@ describe("arc publish command", () => {
     });
     const pkgDir = await createPackageDir(testDir, validManifest);
 
-    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain("login");
   });
 
   test("dry-run validates without uploading", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
+    await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);
 
     // No fetch mock needed — dry run should not make any HTTP calls
-    const result = await publish({ paths: env.paths, packageDir: pkgDir, dryRun: true });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, dryRun: true });
     expect(result.success).toBe(true);
     expect(result.dryRun).toBe(true);
     expect(result.name).toBe("my-skill");
@@ -87,11 +87,11 @@ describe("arc publish command", () => {
   });
 
   test("scope override via --scope flag", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
+    await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);
 
     const result = await publish({
-      paths: env.paths,
+      paths: env.arc,
       packageDir: pkgDir,
       dryRun: true,
       scope: "custom-ns",
@@ -101,7 +101,7 @@ describe("arc publish command", () => {
   });
 
   test("full publish flow with mocked API", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
+    await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);
 
     let uploadCalled = false;
@@ -132,7 +132,7 @@ describe("arc publish command", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir });
     expect(result.success).toBe(true);
     expect(result.name).toBe("my-skill");
     expect(result.version).toBe("1.0.0");
@@ -142,7 +142,7 @@ describe("arc publish command", () => {
   });
 
   test("version exists error (409)", async () => {
-    await saveSources(env.paths.sourcesPath, metafactorySource());
+    await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);
 
     mockFetch(async (url: any) => {
@@ -169,7 +169,7 @@ describe("arc publish command", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const result = await publish({ paths: env.paths, packageDir: pkgDir });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain("immutable");
   });

--- a/test/commands/remove.test.ts
+++ b/test/commands/remove.test.ts
@@ -34,7 +34,7 @@ describe("remove command", () => {
       yes: true,
     });
 
-    const repoDir = join(env.paths.reposDir, "mock-TestSkill");
+    const repoDir = join(env.arc.reposDir, "mock-TestSkill");
     expect(existsSync(repoDir)).toBe(true);
 
     await remove(env.db, env.arc, env.host, "TestSkill");
@@ -71,7 +71,7 @@ describe("remove command", () => {
 
     await remove(env.db, env.arc, env.host, "TestSkill");
 
-    const skillLink = join(env.paths.skillsDir, "TestSkill");
+    const skillLink = join(env.host.paths.skillsDir, "TestSkill");
     expect(existsSync(skillLink)).toBe(false);
   });
 

--- a/test/commands/review.test.ts
+++ b/test/commands/review.test.ts
@@ -72,21 +72,21 @@ const submissionFixture = {
 
 describe("arc review list", () => {
   test("fails without metafactory source", async () => {
-    await saveSources(env.paths.sourcesPath, { sources: [] });
-    const r = await reviewList({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, { sources: [] });
+    const r = await reviewList({ paths: env.arc });
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/metafactory/i);
   });
 
   test("fails without authentication", async () => {
-    await saveSources(env.paths.sourcesPath, mfSourceNoToken());
-    const r = await reviewList({ paths: env.paths });
+    await saveSources(env.arc.sourcesPath, mfSourceNoToken());
+    const r = await reviewList({ paths: env.arc });
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/login/);
   });
 
   test("returns submissions from server", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     mockFetch(async (url: any) => {
       expect(String(url)).toContain("/api/v1/review/pending");
       return new Response(
@@ -94,24 +94,24 @@ describe("arc review list", () => {
         { status: 200 },
       );
     });
-    const r = await reviewList({ paths: env.paths });
+    const r = await reviewList({ paths: env.arc });
     expect(r.success).toBe(true);
     expect(r.submissions?.length).toBe(1);
     expect(r.total).toBe(1);
   });
 
   test("surfaces server error message on 403", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     mockFetch(async () =>
       new Response(JSON.stringify({ error: "Forbidden", message: "Not authorised" }), { status: 403 }),
     );
-    const r = await reviewList({ paths: env.paths });
+    const r = await reviewList({ paths: env.arc });
     expect(r.success).toBe(false);
     expect(r.error).toBe("Not authorised");
   });
 
   test("clamps --per-page client-side above 100", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     let capturedUrl = "";
     mockFetch(async (url: any) => {
       capturedUrl = String(url);
@@ -120,7 +120,7 @@ describe("arc review list", () => {
         { status: 200 },
       );
     });
-    const r = await reviewList({ paths: env.paths, perPage: 500 });
+    const r = await reviewList({ paths: env.arc, perPage: 500 });
     expect(r.success).toBe(true);
     expect(capturedUrl).toContain("per_page=100");
   });
@@ -142,20 +142,20 @@ describe("arc review list", () => {
 
 describe("arc review show", () => {
   test("returns detail for a known id", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     mockFetch(async (url: any) => {
       expect(String(url)).toContain("/api/v1/review/sub-1");
       return new Response(JSON.stringify({ submission: submissionFixture }), { status: 200 });
     });
-    const r = await reviewShow({ paths: env.paths, id: "sub-1" });
+    const r = await reviewShow({ paths: env.arc, id: "sub-1" });
     expect(r.success).toBe(true);
     expect(r.submission?.id).toBe("sub-1");
   });
 
   test("404 surfaces server error", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     mockFetch(async () => new Response(JSON.stringify({ error: "Not found" }), { status: 404 }));
-    const r = await reviewShow({ paths: env.paths, id: "nope" });
+    const r = await reviewShow({ paths: env.arc, id: "nope" });
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/Not found|HTTP 404/);
   });
@@ -177,7 +177,7 @@ describe("arc review show", () => {
 
 describe("arc review approve", () => {
   test("posts to /approve and surfaces submission", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     let posted = false;
     mockFetch(async (url: any, init: any) => {
       posted = true;
@@ -188,21 +188,21 @@ describe("arc review approve", () => {
         { status: 200 },
       );
     });
-    const r = await reviewApprove({ paths: env.paths, id: "sub-1" });
+    const r = await reviewApprove({ paths: env.arc, id: "sub-1" });
     expect(posted).toBe(true);
     expect(r.success).toBe(true);
     expect(r.submission?.status).toBe("approved");
   });
 
   test("DD-9 self-review 403 surfaces server message", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     mockFetch(async () =>
       new Response(
         JSON.stringify({ error: "Forbidden", message: "Cannot review your own submission (DD-9)" }),
         { status: 403 },
       ),
     );
-    const r = await reviewApprove({ paths: env.paths, id: "sub-1" });
+    const r = await reviewApprove({ paths: env.arc, id: "sub-1" });
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/DD-9/);
   });
@@ -222,21 +222,21 @@ describe("arc review approve", () => {
 
 describe("arc review reject", () => {
   test("rejects without --reason client-side", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
-    const r = await reviewReject({ paths: env.paths, id: "sub-1" });
+    await saveSources(env.arc.sourcesPath, mfSource());
+    const r = await reviewReject({ paths: env.arc, id: "sub-1" });
     expect(r.success).toBe(false);
     expect(r.error).toContain("--reason");
   });
 
   test("rejects with whitespace-only reason", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
-    const r = await reviewReject({ paths: env.paths, id: "sub-1", reason: "   " });
+    await saveSources(env.arc.sourcesPath, mfSource());
+    const r = await reviewReject({ paths: env.arc, id: "sub-1", reason: "   " });
     expect(r.success).toBe(false);
     expect(r.error).toContain("--reason");
   });
 
   test("sends trimmed reason in POST body", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     let body = "";
     mockFetch(async (_url: any, init: any) => {
       body = init?.body ?? "";
@@ -245,7 +245,7 @@ describe("arc review reject", () => {
         { status: 200 },
       );
     });
-    const r = await reviewReject({ paths: env.paths, id: "sub-1", reason: "  breaks convention  " });
+    const r = await reviewReject({ paths: env.arc, id: "sub-1", reason: "  breaks convention  " });
     expect(r.success).toBe(true);
     expect(JSON.parse(body)).toEqual({ reason: "breaks convention" });
   });
@@ -253,14 +253,14 @@ describe("arc review reject", () => {
 
 describe("arc review request-changes", () => {
   test("rejects without --message", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
-    const r = await reviewRequestChanges({ paths: env.paths, id: "sub-1" });
+    await saveSources(env.arc.sourcesPath, mfSource());
+    const r = await reviewRequestChanges({ paths: env.arc, id: "sub-1" });
     expect(r.success).toBe(false);
     expect(r.error).toContain("--message");
   });
 
   test("sends comment in POST body", async () => {
-    await saveSources(env.paths.sourcesPath, mfSource());
+    await saveSources(env.arc.sourcesPath, mfSource());
     let body = "";
     mockFetch(async (url: any, init: any) => {
       expect(String(url)).toContain("/request-changes");
@@ -270,7 +270,7 @@ describe("arc review request-changes", () => {
         { status: 200 },
       );
     });
-    const r = await reviewRequestChanges({ paths: env.paths, id: "sub-1", comment: "tweak manifest" });
+    const r = await reviewRequestChanges({ paths: env.arc, id: "sub-1", comment: "tweak manifest" });
     expect(r.success).toBe(true);
     expect(JSON.parse(body)).toEqual({ comment: "tweak manifest" });
   });

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -26,7 +26,7 @@ afterEach(async () => {
 
 // Helper: create a REGISTRY.yaml file and return file:// URL
 async function createLocalRegistry(content: object): Promise<string> {
-  const path = join(env.paths.reposDir, `reg-${Math.random()}.yaml`);
+  const path = join(env.arc.reposDir, `reg-${Math.random()}.yaml`);
   await writeFile(path, YAML.stringify(content));
   return `file://${path}`;
 }
@@ -73,7 +73,7 @@ describe("parsePackageTier", () => {
 describe("searchAcrossSources", () => {
   test("returns empty result with zero sources when none configured", async () => {
     const config: SourcesConfig = { sources: [] };
-    const result = await searchAcrossSources(config, env.paths.cachePath);
+    const result = await searchAcrossSources(config, env.arc.cachePath);
     expect(result.results).toEqual([]);
     expect(result.totalSources).toBe(0);
     expect(result.successfulSources).toBe(0);
@@ -96,9 +96,9 @@ describe("searchAcrossSources", () => {
     const config: SourcesConfig = {
       sources: [{ name: "local", url, tier: "community", enabled: true }],
     };
-    await saveSources(env.paths.sourcesPath, config);
+    await saveSources(env.arc.sourcesPath, config);
 
-    const result = await searchAcrossSources(config, env.paths.cachePath);
+    const result = await searchAcrossSources(config, env.arc.cachePath);
     expect(result.results.length).toBe(2);
     expect(result.successfulSources).toBe(1);
     expect(result.totalSources).toBe(1);
@@ -119,7 +119,7 @@ describe("searchAcrossSources", () => {
       sources: [{ name: "local", url, tier: "community", enabled: true }],
     };
 
-    const result = await searchAcrossSources(config, env.paths.cachePath, { keyword: "research" });
+    const result = await searchAcrossSources(config, env.arc.cachePath, { keyword: "research" });
     expect(result.results.length).toBe(1);
     expect(result.results[0].entry.name).toBe("research");
   });
@@ -137,11 +137,11 @@ describe("searchAcrossSources", () => {
       sources: [{ name: "local", url, tier: "community", enabled: true }],
     };
 
-    const skillsOnly = await searchAcrossSources(config, env.paths.cachePath, { type: "skill" });
+    const skillsOnly = await searchAcrossSources(config, env.arc.cachePath, { type: "skill" });
     expect(skillsOnly.results.length).toBe(1);
     expect(skillsOnly.results[0].artifactType).toBe("skill");
 
-    const toolsOnly = await searchAcrossSources(config, env.paths.cachePath, { type: "tool" });
+    const toolsOnly = await searchAcrossSources(config, env.arc.cachePath, { type: "tool" });
     expect(toolsOnly.results.length).toBe(1);
     expect(toolsOnly.results[0].artifactType).toBe("tool");
   });
@@ -167,7 +167,7 @@ describe("searchAcrossSources", () => {
       ],
     };
 
-    const officialOnly = await searchAcrossSources(config, env.paths.cachePath, { tier: "official" });
+    const officialOnly = await searchAcrossSources(config, env.arc.cachePath, { tier: "official" });
     expect(officialOnly.results.length).toBe(1);
     expect(officialOnly.results[0].sourceTier).toBe("official");
   });
@@ -184,12 +184,12 @@ describe("searchAcrossSources", () => {
       sources: [{ name: "local", url, tier: "official", enabled: true }],
     };
 
-    const result = await searchAcrossSources(config, env.paths.cachePath, { type: "skill", tier: "official" });
+    const result = await searchAcrossSources(config, env.arc.cachePath, { type: "skill", tier: "official" });
     expect(result.results.length).toBe(1);
     expect(result.results[0].artifactType).toBe("skill");
     expect(result.results[0].sourceTier).toBe("official");
 
-    const emptyResult = await searchAcrossSources(config, env.paths.cachePath, { type: "skill", tier: "community" });
+    const emptyResult = await searchAcrossSources(config, env.arc.cachePath, { type: "skill", tier: "community" });
     expect(emptyResult.results.length).toBe(0);
   });
 
@@ -203,7 +203,7 @@ describe("searchAcrossSources", () => {
     const originalWrite = process.stderr.write;
     process.stderr.write = (() => true) as any;
     try {
-      const result = await searchAcrossSources(config, env.paths.cachePath);
+      const result = await searchAcrossSources(config, env.arc.cachePath);
       expect(result.warnings.length).toBe(1);
       expect(result.warnings[0].sourceName).toBe("missing");
       expect(result.warnings[0].reason).toBe("unreachable");
@@ -231,7 +231,7 @@ describe("searchAcrossSources", () => {
     const originalWrite = process.stderr.write;
     process.stderr.write = (() => true) as any;
     try {
-      const result = await searchAcrossSources(config, env.paths.cachePath);
+      const result = await searchAcrossSources(config, env.arc.cachePath);
       expect(result.results.length).toBe(1);
       expect(result.successfulSources).toBe(1);
       expect(result.warnings.length).toBe(1);
@@ -251,7 +251,7 @@ describe("searchAcrossSources", () => {
       sources: [{ name: "local", url, tier: "community", enabled: false }],
     };
 
-    const result = await searchAcrossSources(config, env.paths.cachePath);
+    const result = await searchAcrossSources(config, env.arc.cachePath);
     expect(result.totalSources).toBe(0);
     expect(result.results.length).toBe(0);
   });

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -63,7 +63,7 @@ describe("checkUpgrades", () => {
         { name: "test", url: `file://${regPath}`, tier: "community", enabled: true },
       ],
     };
-    await saveSources(env.paths.sourcesPath, sources);
+    await saveSources(env.arc.sourcesPath, sources);
 
     const results = await checkUpgrades(env.db, env.arc, env.host);
     expect(results).toHaveLength(1);
@@ -101,7 +101,7 @@ describe("checkUpgrades", () => {
 
     const regPath = join(env.root, "test-registry.yaml");
     await writeFile(regPath, YAML.stringify(registry));
-    await saveSources(env.paths.sourcesPath, {
+    await saveSources(env.arc.sourcesPath, {
       sources: [{ name: "test", url: `file://${regPath}`, tier: "community", enabled: true }],
     });
 

--- a/test/e2e/library-lifecycle.test.ts
+++ b/test/e2e/library-lifecycle.test.ts
@@ -45,8 +45,8 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
     expect(installResult.artifacts).toHaveLength(2);
 
     // Verify symlinks exist
-    expect(existsSync(join(env.paths.skillsDir, "review"))).toBe(true);
-    expect(existsSync(join(env.paths.skillsDir, "deploy"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "review"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "deploy"))).toBe(true);
 
     // --- LIST ---
     const allList = list(env.db);
@@ -95,9 +95,9 @@ describe("Library lifecycle: install → list → upgrade → remove", () => {
     expect(remaining.skills[0].library_name).toBe("my-lib");
 
     // Symlink removed for review
-    expect(existsSync(join(env.paths.skillsDir, "review"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "review"))).toBe(false);
     // Symlink still exists for deploy
-    expect(existsSync(join(env.paths.skillsDir, "deploy"))).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "deploy"))).toBe(true);
 
     // Library artifacts query returns only deploy
     const libArtifacts = listByLibrary(env.db, "my-lib");

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -67,11 +67,11 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(installResult.version).toBe("1.1.0");
 
     // Verify filesystem state
-    const skillLink = join(env.paths.skillsDir, "_JIRA");
+    const skillLink = join(env.host.paths.skillsDir, "_JIRA");
     expect(existsSync(skillLink)).toBe(true);
     expect(lstatSync(skillLink).isSymbolicLink()).toBe(true);
 
-    const binLink = join(env.paths.binDir, "jira");
+    const binLink = join(env.host.paths.binDir, "jira");
     expect(existsSync(binLink)).toBe(true);
 
     // Verify database state
@@ -118,7 +118,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(disabledSkill!.status).toBe("disabled");
 
     // Repo preserved
-    const repoDir = join(env.paths.reposDir, "mock-_JIRA");
+    const repoDir = join(env.arc.reposDir, "mock-_JIRA");
     expect(existsSync(repoDir)).toBe(true);
 
     // List shows disabled
@@ -175,12 +175,12 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(installResult.manifest!.type).toBe("tool");
 
     // Tool symlinked to binDir (not skillsDir)
-    const binLink = join(env.paths.binDir, "mytool");
+    const binLink = join(env.host.paths.binDir, "mytool");
     expect(existsSync(binLink)).toBe(true);
     expect(lstatSync(binLink).isSymbolicLink()).toBe(true);
 
     // NOT in skillsDir
-    expect(existsSync(join(env.paths.skillsDir, "mytool"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "mytool"))).toBe(false);
 
     // DB records correct artifact_type
     const dbEntry = getSkill(env.db, "mytool");
@@ -226,15 +226,15 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(installResult.manifest!.type).toBe("agent");
 
     // Agent .md file symlinked directly to agentsDir for auto-discovery
-    const agentLink = join(env.paths.agentsDir, "TestArchitect.md");
+    const agentLink = join(env.host.paths.agentsDir, "TestArchitect.md");
     expect(existsSync(agentLink)).toBe(true);
     expect(lstatSync(agentLink).isSymbolicLink()).toBe(true);
 
     // NOT in skillsDir or binDir
-    expect(existsSync(join(env.paths.skillsDir, "TestArchitect"))).toBe(false);
-    expect(existsSync(join(env.paths.binDir, "TestArchitect"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "TestArchitect"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "TestArchitect"))).toBe(false);
     // NOT as directory symlink (old format)
-    expect(existsSync(join(env.paths.agentsDir, "TestArchitect"))).toBe(false);
+    expect(existsSync(join(env.host.paths.agentsDir, "TestArchitect"))).toBe(false);
 
     // DB records correct artifact_type
     const dbEntry = getSkill(env.db, "TestArchitect");
@@ -266,7 +266,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     const removeResult = await remove(env.db, env.arc, env.host, "TestArchitect");
     expect(removeResult.success).toBe(true);
     expect(existsSync(agentLink)).toBe(false);
-    const repoDir = join(env.paths.reposDir, "mock-TestArchitect");
+    const repoDir = join(env.arc.reposDir, "mock-TestArchitect");
     expect(existsSync(repoDir)).toBe(false);
     expect(getSkill(env.db, "TestArchitect")).toBeNull();
   });
@@ -292,16 +292,16 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(installResult.manifest!.type).toBe("prompt");
 
     // Prompt .md file symlinked directly to promptsDir for auto-discovery
-    const promptLink = join(env.paths.promptsDir, "task-router.md");
+    const promptLink = join(env.host.paths.promptsDir, "task-router.md");
     expect(existsSync(promptLink)).toBe(true);
     expect(lstatSync(promptLink).isSymbolicLink()).toBe(true);
 
     // NOT in skillsDir or binDir or agentsDir
-    expect(existsSync(join(env.paths.skillsDir, "task-router"))).toBe(false);
-    expect(existsSync(join(env.paths.binDir, "task-router"))).toBe(false);
-    expect(existsSync(join(env.paths.agentsDir, "task-router"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "task-router"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "task-router"))).toBe(false);
+    expect(existsSync(join(env.host.paths.agentsDir, "task-router"))).toBe(false);
     // NOT as directory symlink (old format)
-    expect(existsSync(join(env.paths.promptsDir, "task-router"))).toBe(false);
+    expect(existsSync(join(env.host.paths.promptsDir, "task-router"))).toBe(false);
 
     // DB records correct artifact_type
     const dbEntry = getSkill(env.db, "task-router");
@@ -378,7 +378,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
   test("multi-source search finds results from cached remote registry", async () => {
     // Pre-populate cache with a remote registry
-    await mkdir(env.paths.cachePath, { recursive: true });
+    await mkdir(env.arc.cachePath, { recursive: true });
     const remoteRegistry: RegistryConfig = {
       registry: {
         skills: [
@@ -407,7 +407,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     };
 
     await writeFile(
-      join(env.paths.cachePath, "test-hub.yaml"),
+      join(env.arc.cachePath, "test-hub.yaml"),
       YAML.stringify(remoteRegistry)
     );
 
@@ -426,7 +426,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     const docResults = await searchAllSources(
       sources,
       "doc",
-      env.paths.cachePath
+      env.arc.cachePath
     );
     expect(docResults.length).toBe(1);
     expect(docResults[0].entry.name).toBe("_DOC");
@@ -438,7 +438,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     const agentResults = await searchAllSources(
       sources,
       "architect",
-      env.paths.cachePath
+      env.arc.cachePath
     );
     expect(agentResults.length).toBe(1);
     expect(agentResults[0].entry.name).toBe("CustomArchitect");
@@ -453,11 +453,11 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
   test("tests never touch real ~/.claude or ~/.config", () => {
     // Verify test paths don't point to real directories
-    expect(env.paths.claudeRoot).not.toContain(Bun.env.HOME + "/.claude");
-    expect(env.paths.configRoot).not.toContain(
+    expect(env.host.paths.root).not.toContain(Bun.env.HOME + "/.claude");
+    expect(env.arc.configRoot).not.toContain(
       Bun.env.HOME + "/.config/metafactory"
     );
-    expect(env.paths.claudeRoot).toContain("arc-test-");
+    expect(env.host.paths.root).toContain("arc-test-");
   });
 
   test("tool with multiple CLI entries creates shims for all", async () => {
@@ -488,44 +488,44 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(result.success).toBe(true);
 
     // Both bin symlinks exist
-    expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(true);
+    expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(true);
 
     // Both shims exist
-    expect(existsSync(join(env.paths.shimDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(true);
 
     // Second shim uses direct exec (not bun) for non-bun command
-    const altShimContent = await Bun.file(join(env.paths.shimDir, "multi-alt")).text();
+    const altShimContent = await Bun.file(join(env.arc.shimDir, "multi-alt")).text();
     expect(altShimContent).toContain("exec ./bin/multi-alt");
     expect(altShimContent).not.toContain("bun run");
 
     // First shim uses bun run
-    const mainShimContent = await Bun.file(join(env.paths.shimDir, "multitool")).text();
+    const mainShimContent = await Bun.file(join(env.arc.shimDir, "multitool")).text();
     expect(mainShimContent).toContain("bun run");
 
     // --- DISABLE removes all ---
     const disableResult = await disable(env.db, env.arc, env.host, "multitool");
     expect(disableResult.success).toBe(true);
-    expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(false);
 
     // --- ENABLE restores all ---
     const enableResult = await enable(env.db, env.arc, env.host, "multitool");
     expect(enableResult.success).toBe(true);
-    expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(true);
-    expect(existsSync(join(env.paths.shimDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(true);
+    expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(true);
 
     // --- REMOVE cleans up all ---
     const removeResult = await remove(env.db, env.arc, env.host, "multitool");
     expect(removeResult.success).toBe(true);
-    expect(existsSync(join(env.paths.binDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.paths.binDir, "multi-alt"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.paths.shimDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(false);
+    expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(false);
   });
 });

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -12,24 +12,15 @@ import { Database } from "bun:sqlite";
 import YAML from "yaml";
 import {
   createArcPaths,
-  createPaths,
   ensureDirectories,
   getDefaultHost,
 } from "../../src/lib/paths.js";
 import { openDatabase } from "../../src/lib/db.js";
-import type { ArcPaths, HostAdapter, PaiPaths } from "../../src/types.js";
+import type { ArcPaths, HostAdapter } from "../../src/types.js";
 
 export interface TestEnv {
   /** Root temp directory for this test */
   root: string;
-  /**
-   * Combined arc + host paths for back-compat.
-   *
-   * @deprecated Use `env.arc` for arc state paths and `env.host.paths` for
-   *   host install paths. Kept during the #117 migration so existing tests
-   *   keep passing; will be removed once all test sites migrate.
-   */
-  paths: PaiPaths;
   /** arc's host-independent state paths (configRoot, dbPath, …). */
   arc: ArcPaths;
   /** Target host adapter (Claude Code by default, with paths rooted at the temp dir). */
@@ -65,34 +56,11 @@ export async function createTestEnv(): Promise<TestEnv> {
   });
   const host = getDefaultHost({ root: claudeRoot });
 
-  // Compose the legacy PaiPaths object from arc + host for back-compat
-  // consumers. Once tests migrate to env.arc / env.host.paths this can go.
-  const paths = createPaths({
-    claudeRoot,
-    configRoot,
-    skillsDir: host.paths.skillsDir,
-    agentsDir: host.paths.agentsDir,
-    promptsDir: host.paths.promptsDir,
-    binDir: host.paths.binDir,
-    shimDir: arc.shimDir,
-    reposDir: arc.reposDir,
-    dbPath: arc.dbPath,
-    secretsDir: arc.secretsDir,
-    runtimeDir: arc.runtimeDir,
-    catalogPath: arc.catalogPath,
-    registryPath: arc.registryPath,
-    sourcesPath: arc.sourcesPath,
-    cachePath: arc.cachePath,
-    actionsDir: arc.actionsDir,
-    settingsPath: host.paths.settingsPath,
-  });
-
-  await ensureDirectories(paths);
+  await ensureDirectories(arc, host);
   const db = openDatabase(arc.dbPath);
 
   return {
     root,
-    paths,
     arc,
     host,
     db,

--- a/test/unit/catalog.test.ts
+++ b/test/unit/catalog.test.ts
@@ -69,9 +69,9 @@ afterEach(async () => {
 
 describe("loadCatalog", () => {
   test("loads valid catalog.yaml", async () => {
-    await saveCatalog(env.paths.catalogPath, sampleCatalog());
+    await saveCatalog(env.arc.catalogPath, sampleCatalog());
 
-    const config = await loadCatalog(env.paths.catalogPath);
+    const config = await loadCatalog(env.arc.catalogPath);
     expect(config).not.toBeNull();
     expect(config!.catalog.skills).toHaveLength(3);
     expect(config!.catalog.agents).toHaveLength(1);
@@ -80,20 +80,20 @@ describe("loadCatalog", () => {
   });
 
   test("returns null for missing file", async () => {
-    const config = await loadCatalog(env.paths.catalogPath);
+    const config = await loadCatalog(env.arc.catalogPath);
     expect(config).toBeNull();
   });
 
   test("throws for invalid catalog (missing sections)", async () => {
-    await Bun.write(env.paths.catalogPath, "foo: bar\n");
-    await expect(loadCatalog(env.paths.catalogPath)).rejects.toThrow(
+    await Bun.write(env.arc.catalogPath, "foo: bar\n");
+    await expect(loadCatalog(env.arc.catalogPath)).rejects.toThrow(
       "missing required sections"
     );
   });
 
   test("handles catalog with null arrays gracefully", async () => {
     await Bun.write(
-      env.paths.catalogPath,
+      env.arc.catalogPath,
       `defaults:
   skills_dir: ~/.claude/skills/
   agents_dir: ~/.claude/agents/
@@ -106,7 +106,7 @@ catalog:
   tools: null
 `
     );
-    const config = await loadCatalog(env.paths.catalogPath);
+    const config = await loadCatalog(env.arc.catalogPath);
     expect(config).not.toBeNull();
     expect(config!.catalog.skills).toEqual([]);
     expect(config!.catalog.agents).toEqual([]);
@@ -118,9 +118,9 @@ catalog:
 describe("saveCatalog", () => {
   test("round-trips catalog through YAML", async () => {
     const original = sampleCatalog();
-    await saveCatalog(env.paths.catalogPath, original);
+    await saveCatalog(env.arc.catalogPath, original);
 
-    const loaded = await loadCatalog(env.paths.catalogPath);
+    const loaded = await loadCatalog(env.arc.catalogPath);
     expect(loaded!.catalog.skills).toHaveLength(3);
     expect(loaded!.catalog.skills[0].name).toBe("Research");
     expect(loaded!.catalog.skills[2].requires).toEqual(["skill:Thinking"]);

--- a/test/unit/cosign-verify.test.ts
+++ b/test/unit/cosign-verify.test.ts
@@ -39,7 +39,7 @@ describe("downloadSigstoreBundle", () => {
         status: 200,
       }),
     );
-    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.arc.reposDir);
     expect(result.path).toBeDefined();
     expect(result.error).toBeUndefined();
   });
@@ -47,7 +47,7 @@ describe("downloadSigstoreBundle", () => {
   test("returns error on 404", async () => {
     env = await createTestEnv();
     globalThis.fetch = mockFetch(async () => new Response("not found", { status: 404 }));
-    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.arc.reposDir);
     expect(result.error).toMatch(/not found/i);
     expect(result.path).toBeUndefined();
   });
@@ -57,7 +57,7 @@ describe("downloadSigstoreBundle", () => {
     globalThis.fetch = mockFetch(async () => {
       throw new Error("boom");
     });
-    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    const result = await downloadSigstoreBundle("https://reg.test/bundle", env.arc.reposDir);
     expect(result.error).toBeDefined();
     expect(result.path).toBeUndefined();
   });
@@ -69,7 +69,7 @@ describe("downloadSigstoreBundle", () => {
       authSeen = new Headers(init?.headers).get("Authorization");
       return new Response("{}", { status: 200 });
     });
-    await downloadSigstoreBundle("https://reg.test/bundle", env.paths.reposDir);
+    await downloadSigstoreBundle("https://reg.test/bundle", env.arc.reposDir);
     expect(authSeen).toBeNull();
   });
 });
@@ -86,7 +86,7 @@ describe("verifyPackageSigstore", () => {
       sha256: "abc",
       signing: { signature_bundle_key: null, signer_identity: null },
       artifactPath: "/tmp/fake.tgz",
-      tempDir: env.paths.reposDir,
+      tempDir: env.arc.reposDir,
     });
     expect(result.verified).toBeNull();
     expect(result.reason).toMatch(/not sigstore-signed/i);
@@ -99,7 +99,7 @@ describe("verifyPackageSigstore", () => {
       sha256: "abc",
       signing: { signature_bundle_key: "packages/abc.bundle", signer_identity: null },
       artifactPath: "/tmp/fake.tgz",
-      tempDir: env.paths.reposDir,
+      tempDir: env.arc.reposDir,
     });
     expect(result.verified).toBe(false);
     expect(result.reason).toMatch(/signer_identity/i);
@@ -116,7 +116,7 @@ describe("verifyPackageSigstore", () => {
         signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
       },
       artifactPath: "/tmp/fake.tgz",
-      tempDir: env.paths.reposDir,
+      tempDir: env.arc.reposDir,
     });
     expect(result.verified).toBe(false);
     expect(result.reason).toMatch(/bundle/i);
@@ -128,7 +128,7 @@ describe("verifyPackageSigstore", () => {
     globalThis.fetch = mockFetch(async () => new Response(bundleBody, { status: 200 }));
 
     // Create a real artifact file so verifier receives a valid path
-    const artifactPath = join(env.paths.reposDir, "artifact.tgz");
+    const artifactPath = join(env.arc.reposDir, "artifact.tgz");
     await writeFile(artifactPath, "fake-contents");
 
     const result = await verifyPackageSigstore({
@@ -139,7 +139,7 @@ describe("verifyPackageSigstore", () => {
         signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
       },
       artifactPath,
-      tempDir: env.paths.reposDir,
+      tempDir: env.arc.reposDir,
       verifier: async (artifact: string, bundle: string, identity: string, issuer: string) => {
         expect(artifact).toBe(artifactPath);
         expect(bundle).toMatch(/\.bundle$/);
@@ -156,7 +156,7 @@ describe("verifyPackageSigstore", () => {
     globalThis.fetch = mockFetch(async () =>
       new Response('{"mediaType":"application/vnd.dev.sigstore.bundle+json"}', { status: 200 }),
     );
-    const artifactPath = join(env.paths.reposDir, "artifact.tgz");
+    const artifactPath = join(env.arc.reposDir, "artifact.tgz");
     await writeFile(artifactPath, "fake");
 
     const result = await verifyPackageSigstore({
@@ -167,7 +167,7 @@ describe("verifyPackageSigstore", () => {
         signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
       },
       artifactPath,
-      tempDir: env.paths.reposDir,
+      tempDir: env.arc.reposDir,
       verifier: async () => ({ valid: false, error: "signature mismatch" }),
     });
     expect(result.verified).toBe(false);

--- a/test/unit/hosts-dispatch.test.ts
+++ b/test/unit/hosts-dispatch.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { hostPathFor, requireHostDir } from "../../src/lib/hosts/dispatch.js";
-import { createPaths, getDefaultHost } from "../../src/lib/paths.js";
+import { createArcPaths, getDefaultHost } from "../../src/lib/paths.js";
 import { createArtifactSymlinks } from "../../src/lib/artifact-installer.js";
 import type { ArcManifest, HostAdapter } from "../../src/types.js";
 
@@ -82,8 +82,7 @@ describe("createArtifactSymlinks null-guard throws", () => {
   test("createArtifactSymlinks throws when the host has no agent directory", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "arc-guard-test-"));
     try {
-      const paths = createPaths({
-        claudeRoot: join(tmp, ".claude"),
+      const arc = createArcPaths({
         configRoot: join(tmp, ".config", "metafactory"),
       });
       const stub = makeEmptyPathHost();
@@ -97,7 +96,7 @@ describe("createArtifactSymlinks null-guard throws", () => {
         createArtifactSymlinks({
           type: "agent",
           manifest,
-          arc: paths,
+          arc,
           host: stub,
           installDir: tmp,
           quiet: true,
@@ -116,17 +115,17 @@ describe("createArtifactSymlinks null-guard throws", () => {
     // skills successfully.
     const tmp = mkdtempSync(join(tmpdir(), "arc-skill-nocli-"));
     try {
-      const paths = createPaths({
-        claudeRoot: join(tmp, ".claude"),
+      const arc = createArcPaths({
         configRoot: join(tmp, ".config", "metafactory"),
       });
+      const claudeRoot = join(tmp, ".claude");
       // Host that exposes skillsDir but no binDir.
       const skillsOnlyHost: HostAdapter = {
         id: "claude-code",
         detect: () => true,
         paths: {
-          root: paths.claudeRoot,
-          skillsDir: join(paths.claudeRoot, "skills"),
+          root: claudeRoot,
+          skillsDir: join(claudeRoot, "skills"),
           agentsDir: "",
           promptsDir: "",
           binDir: "",
@@ -143,7 +142,7 @@ describe("createArtifactSymlinks null-guard throws", () => {
       const result = await createArtifactSymlinks({
         type: "skill",
         manifest,
-        arc: paths,
+        arc,
         host: skillsOnlyHost,
         installDir: tmp,
         quiet: true,

--- a/test/unit/metafactory-api.test.ts
+++ b/test/unit/metafactory-api.test.ts
@@ -125,7 +125,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => mockFetchResponse([sampleApiPackage()]));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath);
       expect(result).not.toBeNull();
       expect(result!.registry.skills.length).toBe(1);
       expect(result!.registry.skills[0].name).toBe("@mellanon/research");
@@ -143,7 +143,7 @@ describe("fetchMetafactoryRegistry", () => {
     });
 
     try {
-      await fetchMetafactoryRegistry(metafactorySource("my-secret-token"), env.paths.cachePath, true);
+      await fetchMetafactoryRegistry(metafactorySource("my-secret-token"), env.arc.cachePath, true);
       expect(capturedHeaders?.get("Authorization")).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
@@ -155,7 +155,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => new Response("Internal Server Error", { status: 500 }));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
@@ -167,7 +167,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => { throw new Error("ECONNREFUSED"); });
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
@@ -184,12 +184,12 @@ describe("fetchMetafactoryRegistry", () => {
 
     try {
       // First call fetches
-      const result1 = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result1 = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result1).not.toBeNull();
       expect(fetchCount).toBe(1);
 
       // Second call uses cache (not forceRefresh)
-      const result2 = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath);
+      const result2 = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath);
       expect(result2).not.toBeNull();
       expect(fetchCount).toBe(1); // no additional fetch
     } finally {
@@ -202,7 +202,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => mockFetchResponse([sampleApiPackage({ type: "tool" })]));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result!.registry.tools.length).toBe(1);
       expect(result!.registry.skills.length).toBe(0);
     } finally {
@@ -215,7 +215,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => new Response("Unauthorized", { status: 401 }));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource("expired-token"), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource("expired-token"), env.arc.cachePath, true);
       // Returns null (or stale cache) -- not a crash
       expect(result).toBeNull();
     } finally {
@@ -228,7 +228,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => new Response("Too Many Requests", { status: 429 }));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
@@ -240,7 +240,7 @@ describe("fetchMetafactoryRegistry", () => {
     globalThis.fetch = mockFetch(async () => new Response("<html>not json</html>", { status: 200 }));
 
     try {
-      const result = await fetchMetafactoryRegistry(metafactorySource(), env.paths.cachePath, true);
+      const result = await fetchMetafactoryRegistry(metafactorySource(), env.arc.cachePath, true);
       expect(result).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect } from "bun:test";
 import {
-  createPaths,
   createArcPaths,
   getDefaultHost,
   migrateConfigIfNeeded,
@@ -11,35 +10,12 @@ import { mkdirSync, existsSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
 
-describe("createPaths", () => {
-  test("returns default paths based on homedir", () => {
-    const paths = createPaths();
-    const home = homedir();
-
-    expect(paths.claudeRoot).toBe(join(home, ".claude"));
-    expect(paths.skillsDir).toBe(join(home, ".claude", "skills"));
-    expect(paths.binDir).toBe(join(home, ".claude", "bin"));
-    expect(paths.configRoot).toBe(join(home, ".config", "metafactory"));
-    expect(paths.dbPath).toBe(join(home, ".config", "metafactory", "packages.db"));
-  });
-
-  test("accepts overrides for test isolation", () => {
-    const paths = createPaths({
-      claudeRoot: "/tmp/test/.claude",
-      configRoot: "/tmp/test/.config/metafactory",
-    });
-
-    expect(paths.claudeRoot).toBe("/tmp/test/.claude");
-    expect(paths.skillsDir).toBe("/tmp/test/.claude/skills");
-    expect(paths.configRoot).toBe("/tmp/test/.config/metafactory");
-    expect(paths.dbPath).toBe("/tmp/test/.config/metafactory/packages.db");
-  });
-
+describe("createArcPaths env-var handling", () => {
   test("ARC_CONFIG_ROOT env var overrides default configRoot", () => {
     const original = process.env.ARC_CONFIG_ROOT;
     try {
       process.env.ARC_CONFIG_ROOT = "/custom/arc-config";
-      const paths = createPaths();
+      const paths = createArcPaths();
       expect(paths.configRoot).toBe("/custom/arc-config");
       expect(paths.dbPath).toBe("/custom/arc-config/packages.db");
     } finally {
@@ -52,24 +28,12 @@ describe("createPaths", () => {
     const original = process.env.ARC_CONFIG_ROOT;
     try {
       process.env.ARC_CONFIG_ROOT = "/env/override";
-      const paths = createPaths({ configRoot: "/explicit/override" });
+      const paths = createArcPaths({ configRoot: "/explicit/override" });
       expect(paths.configRoot).toBe("/explicit/override");
     } finally {
       if (original === undefined) delete process.env.ARC_CONFIG_ROOT;
       else process.env.ARC_CONFIG_ROOT = original;
     }
-  });
-
-  test("specific overrides take precedence over derived paths", () => {
-    const paths = createPaths({
-      claudeRoot: "/tmp/test/.claude",
-      skillsDir: "/custom/skills",
-    });
-
-    expect(paths.claudeRoot).toBe("/tmp/test/.claude");
-    expect(paths.skillsDir).toBe("/custom/skills");
-    // binDir should derive from claudeRoot
-    expect(paths.binDir).toBe("/tmp/test/.claude/bin");
   });
 });
 

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -103,7 +103,7 @@ describe("formatPackageRef", () => {
 describe("verifyChecksum", () => {
   test("returns valid for matching hash", async () => {
     const content = "test package content";
-    const filePath = join(env.paths.reposDir, "test-verify.bin");
+    const filePath = join(env.arc.reposDir, "test-verify.bin");
     await writeFile(filePath, content);
 
     // Compute expected hash
@@ -118,7 +118,7 @@ describe("verifyChecksum", () => {
   });
 
   test("returns invalid for mismatched hash", async () => {
-    const filePath = join(env.paths.reposDir, "test-bad.bin");
+    const filePath = join(env.arc.reposDir, "test-bad.bin");
     await writeFile(filePath, "actual content");
 
     const result = await verifyChecksum(filePath, "0000000000000000000000000000000000000000000000000000000000000000");
@@ -129,7 +129,7 @@ describe("verifyChecksum", () => {
 
   test("handles case-insensitive comparison", async () => {
     const content = "case test";
-    const filePath = join(env.paths.reposDir, "test-case.bin");
+    const filePath = join(env.arc.reposDir, "test-case.bin");
     await writeFile(filePath, content);
 
     const hasher = new Bun.CryptoHasher("sha256");
@@ -141,7 +141,7 @@ describe("verifyChecksum", () => {
   });
 
   test("empty file has deterministic hash", async () => {
-    const filePath = join(env.paths.reposDir, "test-empty.bin");
+    const filePath = join(env.arc.reposDir, "test-empty.bin");
     await writeFile(filePath, "");
 
     const result = await verifyChecksum(filePath, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
@@ -155,10 +155,10 @@ describe("verifyChecksum", () => {
 
 describe("extractPackage", () => {
   test("fails on invalid tarball", async () => {
-    const badTarball = join(env.paths.reposDir, "bad.tar.gz");
+    const badTarball = join(env.arc.reposDir, "bad.tar.gz");
     await writeFile(badTarball, "this is not a tarball");
 
-    const result = await extractPackage(badTarball, env.paths.reposDir, "test-pkg");
+    const result = await extractPackage(badTarball, env.arc.reposDir, "test-pkg");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Extraction failed");
   });
@@ -359,7 +359,7 @@ describe("downloadPackage", () => {
     globalThis.fetch = mockFetch(async () => new Response(new ArrayBuffer(1024), { status: 200 }));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(true);
       expect(result.bytesDownloaded).toBe(1024);
       expect(result.tempPath).toBeDefined();
@@ -378,7 +378,7 @@ describe("downloadPackage", () => {
     });
 
     try {
-      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(capturedAuth).toBeNull();
     } finally {
       globalThis.fetch = originalFetch;
@@ -390,7 +390,7 @@ describe("downloadPackage", () => {
     globalThis.fetch = mockFetch(async () => new Response("Unauthorized", { status: 401 }));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.error).toContain("Access denied");
     } finally {
@@ -403,7 +403,7 @@ describe("downloadPackage", () => {
     globalThis.fetch = mockFetch(async () => new Response("Not found", { status: 404 }));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.error).toContain("not found");
     } finally {
@@ -420,7 +420,7 @@ describe("downloadPackage", () => {
     });
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(attempts).toBe(2); // original + 1 retry
       expect(result.error).toContain("network");
@@ -444,7 +444,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage(
         "https://example.com/pkg.tar.gz",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource("test-token-abc"),
       );
       expect(result.success).toBe(true);
@@ -466,7 +466,7 @@ describe("downloadPackage", () => {
     try {
       await downloadPackage(
         "https://example.com/pkg.tar.gz",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource(),
       );
       expect(capturedAuth).toBeNull();
@@ -497,7 +497,7 @@ describe("downloadPackage", () => {
       };
       await downloadPackage(
         "https://example.com/pkg.tar.gz",
-        env.paths.reposDir,
+        env.arc.reposDir,
         registrySource,
       );
       expect(capturedAuth).toBeNull();
@@ -515,7 +515,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage(
         "https://example.com/pkg.tar.gz",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource("expired-token"),
       );
       expect(result.success).toBe(false);
@@ -546,7 +546,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage(
         "https://meta-factory.test/api/v1/storage/download/abc",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource("super-secret-token"),
       );
       expect(result.success).toBe(true);
@@ -581,7 +581,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage(
         "https://meta-factory.test/api/v1/storage/download/abc",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource("super-secret-token"),
       );
       // downloadPackage's retry loop catches the thrown "too many redirects"
@@ -617,7 +617,7 @@ describe("downloadPackage", () => {
     try {
       const result = await downloadPackage(
         "https://meta-factory.test/v1/storage/download/abc",
-        env.paths.reposDir,
+        env.arc.reposDir,
         metafactorySource("super-secret-token"),
       );
       expect(result.success).toBe(true);
@@ -653,7 +653,7 @@ describe("downloadPackage", () => {
     ));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.quarantine).toBeDefined();
       expect(result.quarantine!.reasonCode).toBe("QUARANTINED_SECURITY");
@@ -673,7 +673,7 @@ describe("downloadPackage", () => {
       ));
 
       try {
-        const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+        const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
         expect(result.success).toBe(false);
         expect(result.quarantine?.reasonCode).toBe(code);
       } finally {
@@ -692,7 +692,7 @@ describe("downloadPackage", () => {
     ));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.quarantine?.reasonCode).toBe("QUARANTINED_LEGAL");
       expect(result.quarantine?.reason).toBe("DMCA");
     } finally {
@@ -710,7 +710,7 @@ describe("downloadPackage", () => {
     ));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.quarantine?.reasonCode).toBe("QUARANTINED_OTHER");
     } finally {
       globalThis.fetch = originalFetch;
@@ -727,7 +727,7 @@ describe("downloadPackage", () => {
     ));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.quarantine?.reasonCode).toBe("QUARANTINED_POLICY");
       expect(result.quarantine?.reason).toBe("");
@@ -741,7 +741,7 @@ describe("downloadPackage", () => {
     globalThis.fetch = mockFetch(async () => new Response("", { status: 451 }));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.quarantine?.reasonCode).toBe("QUARANTINED_OTHER");
     } finally {
@@ -761,7 +761,7 @@ describe("downloadPackage", () => {
     });
 
     try {
-      await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(attempts).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
@@ -961,7 +961,7 @@ describe("adversarial: SHA-256 tamper detection", () => {
     // than what the artifact actually contains. arc must reject because
     // it recomputes the hash from the downloaded bytes independently.
     const realContent = "legitimate package content";
-    const filePath = join(env.paths.reposDir, "tampered-hash.tar.gz");
+    const filePath = join(env.arc.reposDir, "tampered-hash.tar.gz");
     await writeFile(filePath, realContent);
 
     // Registry claims a hash that doesn't match the actual file
@@ -985,7 +985,7 @@ describe("adversarial: SHA-256 tamper detection", () => {
     const originalHash = hasher.digest("hex");
 
     // Write the malicious content but verify against original hash
-    const filePath = join(env.paths.reposDir, "swapped-same-size.bin");
+    const filePath = join(env.arc.reposDir, "swapped-same-size.bin");
     await writeFile(filePath, maliciousContent);
 
     const result = await verifyChecksum(filePath, originalHash);
@@ -1005,7 +1005,7 @@ describe("adversarial: SHA-256 tamper detection", () => {
     const fullHash = hasher.digest("hex");
 
     // Write truncated version and verify against full hash
-    const filePath = join(env.paths.reposDir, "truncated.tar.gz");
+    const filePath = join(env.arc.reposDir, "truncated.tar.gz");
     await writeFile(filePath, truncatedContent);
 
     const result = await verifyChecksum(filePath, fullHash);
@@ -1022,7 +1022,7 @@ describe("adversarial: SHA-256 tamper detection", () => {
     hasher.update(originalContent);
     const originalHash = hasher.digest("hex");
 
-    const filePath = join(env.paths.reposDir, "appended.tar.gz");
+    const filePath = join(env.arc.reposDir, "appended.tar.gz");
     await writeFile(filePath, tamperedContent);
 
     const result = await verifyChecksum(filePath, originalHash);
@@ -1040,7 +1040,7 @@ describe("adversarial: download path error handling", () => {
     });
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       expect(result.error).toContain("500");
       expect(attempts).toBe(2); // original + 1 retry
@@ -1054,13 +1054,13 @@ describe("adversarial: download path error handling", () => {
     globalThis.fetch = mockFetch(async () => new Response("Forbidden", { status: 403 }));
 
     try {
-      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.paths.reposDir);
+      const result = await downloadPackage("https://example.com/pkg.tar.gz", env.arc.reposDir);
       expect(result.success).toBe(false);
       // No tempPath should be returned on failure
       expect(result.tempPath).toBeUndefined();
       // Also verify no arc-download-* files leaked to disk
       const { readdirSync } = await import("fs");
-      const leaked = readdirSync(env.paths.reposDir).filter((f: string) => f.startsWith("arc-download-"));
+      const leaked = readdirSync(env.arc.reposDir).filter((f: string) => f.startsWith("arc-download-"));
       expect(leaked).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
@@ -1070,31 +1070,31 @@ describe("adversarial: download path error handling", () => {
 
 describe("adversarial: extract path integrity", () => {
   test("extraction cleans up on invalid tarball — no partial files left", async () => {
-    const badTarball = join(env.paths.reposDir, "adversarial-bad.tar.gz");
+    const badTarball = join(env.arc.reposDir, "adversarial-bad.tar.gz");
     await writeFile(badTarball, "this is not a valid tarball at all");
 
     const extractDir = "adversarial-test-pkg";
-    const result = await extractPackage(badTarball, env.paths.reposDir, extractDir);
+    const result = await extractPackage(badTarball, env.arc.reposDir, extractDir);
 
     expect(result.success).toBe(false);
     // The target directory should be cleaned up after failed extraction
     const { existsSync } = await import("fs");
-    expect(existsSync(join(env.paths.reposDir, extractDir))).toBe(false);
+    expect(existsSync(join(env.arc.reposDir, extractDir))).toBe(false);
   });
 
   test("extraction rejects archive without manifest", async () => {
     // Create a valid tarball but without arc-manifest.yaml
-    const tarDir = join(env.paths.reposDir, "no-manifest-src");
+    const tarDir = join(env.arc.reposDir, "no-manifest-src");
     const { mkdir: mkdirFs } = await import("fs/promises");
     await mkdirFs(tarDir, { recursive: true });
     await writeFile(join(tarDir, "README.md"), "# No manifest here");
 
-    const tarball = join(env.paths.reposDir, "no-manifest.tar.gz");
-    Bun.spawnSync(["tar", "czf", tarball, "-C", env.paths.reposDir, "no-manifest-src"], {
+    const tarball = join(env.arc.reposDir, "no-manifest.tar.gz");
+    Bun.spawnSync(["tar", "czf", tarball, "-C", env.arc.reposDir, "no-manifest-src"], {
       stdout: "pipe", stderr: "pipe",
     });
 
-    const result = await extractPackage(tarball, env.paths.reposDir, "no-manifest-pkg");
+    const result = await extractPackage(tarball, env.arc.reposDir, "no-manifest-pkg");
     expect(result.success).toBe(false);
     expect(result.error).toContain("arc-manifest.yaml");
   });

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -88,11 +88,11 @@ afterEach(async () => {
 describe("loadRegistry", () => {
   test("loads valid registry.yaml", async () => {
     await Bun.write(
-      env.paths.registryPath,
+      env.arc.registryPath,
       YAML.stringify(sampleRegistry())
     );
 
-    const config = await loadRegistry(env.paths.registryPath);
+    const config = await loadRegistry(env.arc.registryPath);
     expect(config).not.toBeNull();
     expect(config!.registry.skills).toHaveLength(3);
     expect(config!.registry.agents).toHaveLength(1);
@@ -100,13 +100,13 @@ describe("loadRegistry", () => {
   });
 
   test("returns null for missing file", async () => {
-    const config = await loadRegistry(env.paths.registryPath);
+    const config = await loadRegistry(env.arc.registryPath);
     expect(config).toBeNull();
   });
 
   test("throws for invalid registry (missing section)", async () => {
-    await Bun.write(env.paths.registryPath, "foo: bar\n");
-    await expect(loadRegistry(env.paths.registryPath)).rejects.toThrow(
+    await Bun.write(env.arc.registryPath, "foo: bar\n");
+    await expect(loadRegistry(env.arc.registryPath)).rejects.toThrow(
       "missing 'registry' section"
     );
   });

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -51,13 +51,13 @@ describe("fetchRemoteRegistry", () => {
     };
 
     // Pre-populate cache
-    await mkdir(env.paths.cachePath, { recursive: true });
+    await mkdir(env.arc.cachePath, { recursive: true });
     await writeFile(
-      join(env.paths.cachePath, "test-hub.yaml"),
+      join(env.arc.cachePath, "test-hub.yaml"),
       YAML.stringify(sampleRemoteRegistry())
     );
 
-    const result = await fetchRemoteRegistry(source, env.paths.cachePath);
+    const result = await fetchRemoteRegistry(source, env.arc.cachePath);
     expect(result).not.toBeNull();
     expect(result!.registry.skills[0].name).toBe("RemoteSkill");
   });
@@ -74,7 +74,7 @@ describe("fetchRemoteRegistry", () => {
     const originalWrite = process.stderr.write;
     process.stderr.write = (() => true) as any;
     try {
-      const result = await fetchRemoteRegistry(source, env.paths.cachePath);
+      const result = await fetchRemoteRegistry(source, env.arc.cachePath);
       expect(result).toBeNull();
     } finally {
       process.stderr.write = originalWrite;
@@ -94,7 +94,7 @@ describe("fetchRemoteRegistry", () => {
     process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
 
     try {
-      const result = await fetchRemoteRegistry(source, env.paths.cachePath);
+      const result = await fetchRemoteRegistry(source, env.arc.cachePath);
       expect(result).toBeNull();
       const output = stderrChunks.join("");
       expect(output).toContain("missing-local");
@@ -122,7 +122,7 @@ describe("fetchRemoteRegistry", () => {
     };
 
     try {
-      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      const result = await fetchRemoteRegistry(source, env.arc.cachePath, true);
       expect(result).toBeNull();
       const output = stderrChunks.join("");
       expect(output).toContain("broken-hub");
@@ -151,7 +151,7 @@ describe("fetchRemoteRegistry", () => {
     };
 
     try {
-      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      const result = await fetchRemoteRegistry(source, env.arc.cachePath, true);
       expect(result).toBeNull();
       const output = stderrChunks.join("");
       expect(output).toContain("private-hub");
@@ -172,9 +172,9 @@ describe("fetchRemoteRegistry", () => {
     };
 
     // Pre-populate stale cache
-    await mkdir(env.paths.cachePath, { recursive: true });
+    await mkdir(env.arc.cachePath, { recursive: true });
     await writeFile(
-      join(env.paths.cachePath, "flaky-hub.yaml"),
+      join(env.arc.cachePath, "flaky-hub.yaml"),
       YAML.stringify(sampleRemoteRegistry()),
     );
 
@@ -189,7 +189,7 @@ describe("fetchRemoteRegistry", () => {
     process.stderr.write = ((chunk: any) => { stderrChunks.push(String(chunk)); return true; }) as any;
 
     try {
-      const result = await fetchRemoteRegistry(source, env.paths.cachePath, true);
+      const result = await fetchRemoteRegistry(source, env.arc.cachePath, true);
       // Should fall back to stale cache
       expect(result).not.toBeNull();
       expect(result!.registry.skills[0].name).toBe("RemoteSkill");
@@ -224,7 +224,7 @@ describe("searchAllSources", () => {
       const results = await searchAllSources(
         sources,
         "anything",
-        env.paths.cachePath
+        env.arc.cachePath
       );
       expect(results).toHaveLength(0);
     } finally {
@@ -234,7 +234,7 @@ describe("searchAllSources", () => {
 
   test("aggregates from cached sources", async () => {
     // Pre-populate cache for two sources
-    await mkdir(env.paths.cachePath, { recursive: true });
+    await mkdir(env.arc.cachePath, { recursive: true });
 
     const reg1 = sampleRemoteRegistry();
     const reg2: RegistryConfig = {
@@ -255,8 +255,8 @@ describe("searchAllSources", () => {
       },
     };
 
-    await writeFile(join(env.paths.cachePath, "hub-a.yaml"), YAML.stringify(reg1));
-    await writeFile(join(env.paths.cachePath, "hub-b.yaml"), YAML.stringify(reg2));
+    await writeFile(join(env.arc.cachePath, "hub-a.yaml"), YAML.stringify(reg1));
+    await writeFile(join(env.arc.cachePath, "hub-b.yaml"), YAML.stringify(reg2));
 
     const sources: SourcesConfig = {
       sources: [
@@ -268,7 +268,7 @@ describe("searchAllSources", () => {
     const results = await searchAllSources(
       sources,
       "skill",
-      env.paths.cachePath
+      env.arc.cachePath
     );
 
     expect(results.length).toBe(2);
@@ -287,9 +287,9 @@ describe("searchAllSources", () => {
   });
 
   test("skips disabled sources", async () => {
-    await mkdir(env.paths.cachePath, { recursive: true });
+    await mkdir(env.arc.cachePath, { recursive: true });
     await writeFile(
-      join(env.paths.cachePath, "disabled-hub.yaml"),
+      join(env.arc.cachePath, "disabled-hub.yaml"),
       YAML.stringify(sampleRemoteRegistry())
     );
 
@@ -302,7 +302,7 @@ describe("searchAllSources", () => {
     const results = await searchAllSources(
       sources,
       "remote",
-      env.paths.cachePath
+      env.arc.cachePath
     );
 
     // Should not find anything (disabled source skipped, no local fallback since no registry)

--- a/test/unit/sources.test.ts
+++ b/test/unit/sources.test.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 
 describe("loadSources", () => {
   test("creates default sources.yaml if missing", async () => {
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(2);
     // Primary: metafactory API source
     expect(config.sources[0].name).toBe("metafactory");
@@ -45,26 +45,26 @@ describe("loadSources", () => {
         { name: "hub-b", url: "https://example.com/b.yaml", tier: "community", enabled: false },
       ],
     };
-    await Bun.write(env.paths.sourcesPath, YAML.stringify(custom));
+    await Bun.write(env.arc.sourcesPath, YAML.stringify(custom));
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(2);
     expect(config.sources[0].name).toBe("hub-a");
     expect(config.sources[1].enabled).toBe(false);
   });
 
   test("returns defaults for invalid yaml (no sources array)", async () => {
-    await Bun.write(env.paths.sourcesPath, "foo: bar\n");
+    await Bun.write(env.arc.sourcesPath, "foo: bar\n");
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(2);
     expect(config.sources[0].name).toBe("metafactory");
   });
 
   test("returns defaults for empty file", async () => {
-    await Bun.write(env.paths.sourcesPath, "");
+    await Bun.write(env.arc.sourcesPath, "");
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(2);
   });
 });
@@ -76,9 +76,9 @@ describe("saveSources", () => {
         { name: "test", url: "https://example.com/reg.yaml", tier: "custom", enabled: true },
       ],
     };
-    await saveSources(env.paths.sourcesPath, config);
+    await saveSources(env.arc.sourcesPath, config);
 
-    const reloaded = await loadSources(env.paths.sourcesPath);
+    const reloaded = await loadSources(env.arc.sourcesPath);
     expect(reloaded.sources).toHaveLength(1);
     expect(reloaded.sources[0].name).toBe("test");
   });
@@ -287,9 +287,9 @@ describe("backward compatibility", () => {
     tier: community
     enabled: true
 `;
-    await Bun.write(env.paths.sourcesPath, legacy);
+    await Bun.write(env.arc.sourcesPath, legacy);
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(1);
     expect(config.sources[0].type).toBeUndefined();
     expect(getSourceType(config.sources[0])).toBe("registry");
@@ -307,9 +307,9 @@ describe("forward compatibility", () => {
     future_field: some_value
     another_unknown: 123
 `;
-    await Bun.write(env.paths.sourcesPath, futureConfig);
+    await Bun.write(env.arc.sourcesPath, futureConfig);
 
-    const config = await loadSources(env.paths.sourcesPath);
+    const config = await loadSources(env.arc.sourcesPath);
     expect(config.sources).toHaveLength(1);
     expect(config.sources[0].name).toBe("future-source");
   });
@@ -324,9 +324,9 @@ describe("token handling", () => {
         token: "secret-token-123",
       }],
     };
-    await Bun.write(env.paths.sourcesPath, YAML.stringify(config));
+    await Bun.write(env.arc.sourcesPath, YAML.stringify(config));
 
-    const loaded = await loadSources(env.paths.sourcesPath);
+    const loaded = await loadSources(env.arc.sourcesPath);
     expect(loaded.sources[0].token).toBe("secret-token-123");
   });
 
@@ -338,9 +338,9 @@ describe("token handling", () => {
         token: "",
       }],
     };
-    await Bun.write(env.paths.sourcesPath, YAML.stringify(config));
+    await Bun.write(env.arc.sourcesPath, YAML.stringify(config));
 
-    const loaded = await loadSources(env.paths.sourcesPath);
+    const loaded = await loadSources(env.arc.sourcesPath);
     expect(loaded.sources[0].token || undefined).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

**Closes #117.** The 7-PR per-command sweep (#122–#128) completed the function-by-function migration; this PR removes the deprecated `PaiPaths` type, the `createPaths()` factory, and the `TestEnv.paths` back-compat field, plus migrates the 5 remaining non-command callers that still took `PaiPaths`.

## What this PR does

### Type and factory removal
- **`src/types.ts`**: delete `PaiPaths` type (was deprecated intersection alias `ArcPaths & { claudeRoot, skillsDir, agentsDir, promptsDir, binDir, settingsPath }`).
- **`src/lib/paths.ts`**: delete `createPaths()`. Migrate `ensureDirectories` from `(paths: PaiPaths)` to `(arc: ArcPaths, host: HostAdapter)`.
- **`test/helpers/test-env.ts`**: delete `paths: PaiPaths` field and the ~20 lines that composed it from `arc + host`. `TestEnv` is now `{ root, arc, host, db, cleanup }` only.

### Non-command callers (all arc-state only — one-line type rename per file)
- `src/commands/info.ts`: 3 functions, `paths?: PaiPaths` → `paths?: ArcPaths`
- `src/commands/login.ts`: options-bag `paths: PaiPaths` → `paths: ArcPaths`
- `src/commands/logout.ts`: same
- `src/commands/publish.ts`: same
- `src/commands/review.ts`: 5 functions / option types
- `src/commands/bundle.ts`: 1 options-bag type
- `src/commands/upgrade-core.ts`: removed stale unused `PaiPaths` import

### CLI
- `src/cli.ts`: `createPaths()` → `createArcPaths()` (26 sites).
- `getDefaultHost({ root: paths.claudeRoot })` → `getDefaultHost()` (10 sites). After Phase 3, `paths` carries no host fields, so the override would be a no-op.
- `ensureDirectories(paths, host)` (3 sites) — passes both required args.

### Tests
- Sweeping `env.paths.X` → `env.arc.X` or `env.host.paths.X` across all test files. Split per access:
  - arc-state: `reposDir`, `cachePath`, `dbPath`, `actionsDir`, `shimDir`, `catalogPath`, `registryPath`, `sourcesPath`, `secretsDir`, `runtimeDir`, `pipelinesDir`, `configRoot` → `env.arc.X`
  - host-paths: `skillsDir`, `agentsDir`, `promptsDir`, `binDir`, `settingsPath`, `claudeRoot` → `env.host.paths.X` (`claudeRoot` → `host.paths.root`)
- `test/commands/{login,logout,publish,review,bundle}.test.ts`: `paths: env.paths` → `paths: env.arc` for the options-bag callers.
- `test/unit/paths.test.ts`: dropped 5 `createPaths`-specific tests; promoted the two `ARC_CONFIG_ROOT` env-var tests to exercise `createArcPaths` (still meaningful — env-var precedence is host-independent state).
- `test/unit/hosts-dispatch.test.ts`: switched `createPaths` to `createArcPaths` in the two synthetic-host tests.

## Verification

- `bun test`: **715/715 passing** (was 718 — dropped 3 `createPaths`-specific unit tests that have no replacement, since the function they tested no longer exists).
- `bunx tsc --noEmit`: clean.
- `grep -rn 'PaiPaths\|createPaths\b' src/ test/`: **zero matches**.

## Sequence recap (#117 closes here)

| PR | Phase | Scope |
|----|-------|-------|
| #118 | 1 | ArcPaths + HostAdapter types, Claude-Code adapter |
| #119 | 2 | hostPathFor() dispatch + HostAdapter in install |
| #120 | 3a | requireHostDir() helper + arc/host on TestEnv |
| #121 | 2 | CortexHostAdapter |
| #122 | 3b/1 | verify.ts migrated |
| #123 | 3b/2 | upgrade.ts migrated |
| #124 | 3b/3 | install.ts migrated (kills upgrade.ts bridge) |
| #125 | 3b/4 | remove.ts migrated |
| #126 | 3b/5 | enable.ts migrated |
| #127 | 3b/6 | disable.ts migrated |
| #128 | 3b/7 | catalog.ts migrated (final command slice) |
| **this** | **3d** | **delete PaiPaths, createPaths, TestEnv.paths** |

**Closes #117.**

## Test plan

- [x] `bun test` — 715/715 green
- [x] `bunx tsc --noEmit` — clean
- [x] `grep PaiPaths|createPaths\b src/ test/` — zero matches
- [x] All callers (commands, lib, CLI, tests) accept `ArcPaths` + `HostAdapter` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)