### PR TITLE
fix(nats): server-side revoke + JWT push before delete (closes #130)

### DIFF
--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -21,10 +21,42 @@ const NSC_CONFIG_CANDIDATES = [
   join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "nsc", "nsc.json"),
 ];
 
-function nsc(args: string[]): string {
+/**
+ * Result of an nsc invocation. Shape matches the subset of Bun.spawnSync
+ * we care about; broken out as an interface so tests can stub the runner
+ * without depending on Bun internals.
+ */
+export interface NscResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type NscRunner = (args: string[]) => NscResult;
+
+const defaultRunner: NscRunner = (args) => {
   const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
-  const stdout = result.stdout.toString().trim();
-  const stderr = result.stderr.toString().trim();
+  return {
+    exitCode: result.exitCode ?? -1,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+};
+
+let runner: NscRunner = defaultRunner;
+
+/**
+ * Test-only hook to swap the nsc runner. Pass `null` to restore the default.
+ * Do NOT call from production code paths.
+ */
+export function __setNscRunnerForTests(next: NscRunner | null): void {
+  runner = next ?? defaultRunner;
+}
+
+function nsc(args: string[]): string {
+  const result = runner(args);
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
   if (result.exitCode !== 0) {
     throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
   }
@@ -32,18 +64,28 @@ function nsc(args: string[]): string {
 }
 
 function nscWithStderr(args: string[]): string {
-  const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
+  const result = runner(args);
   if (result.exitCode !== 0) {
-    const stderr = result.stderr.toString().trim();
-    const stdout = result.stdout.toString().trim();
+    const stderr = result.stderr.trim();
+    const stdout = result.stdout.trim();
     throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
   }
-  return (result.stdout.toString() + result.stderr.toString()).trim();
+  return (result.stdout + result.stderr).trim();
+}
+
+let nscInstallCheck: () => boolean = () => {
+  return Bun.spawnSync(["which", "nsc"], { stdout: "pipe" }).exitCode === 0;
+};
+
+/**
+ * Test-only hook to swap the install check. Pass `null` to restore the default.
+ */
+export function __setNscInstallCheckForTests(next: (() => boolean) | null): void {
+  nscInstallCheck = next ?? (() => Bun.spawnSync(["which", "nsc"], { stdout: "pipe" }).exitCode === 0);
 }
 
 export function ensureNscInstalled(): void {
-  const result = Bun.spawnSync(["which", "nsc"], { stdout: "pipe" });
-  if (result.exitCode !== 0) {
+  if (!nscInstallCheck()) {
     console.error("Error: nsc not found on PATH.");
     console.error("Install: brew install nats-io/nats-tools/nsc");
     process.exit(1);
@@ -92,6 +134,61 @@ function userExists(account: string, name: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Returns the user's NKey public key (the `sub` claim in the user JWT).
+ * Must be called BEFORE deleting the user — once the user record is gone,
+ * nsc can no longer resolve the pubkey.
+ */
+function getUserPubKey(account: string, name: string): string {
+  const json = nsc(["describe", "user", "-a", account, "-n", name, "-J"]);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Failed to parse nsc describe user JSON for "${name}": ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const sub = (parsed as { sub?: unknown }).sub;
+  if (typeof sub !== "string" || !sub.startsWith("U")) {
+    throw new Error(`Could not extract user public key for "${name}" (expected U-prefixed NKey in 'sub' claim).`);
+  }
+  return sub;
+}
+
+/**
+ * Server-side revoke: add the user's pubkey to the account's revocation map
+ * and push the updated account JWT to NATS so the server rejects any
+ * outstanding `.creds` for that user.
+ *
+ * Aborts (throws) on push failure — the caller MUST NOT proceed to delete
+ * the user locally if this throws, because a half-done revoke leaves the
+ * JWT valid on the bus and the operator unaware.
+ */
+function revokeAndPushUser(account: string, name: string): void {
+  const pubKey = getUserPubKey(account, name);
+
+  // Add to revocation map (keyed by pubkey so it survives local user delete).
+  try {
+    nsc(["revocations", "add-user", "-a", account, "-u", pubKey]);
+  } catch (err) {
+    throw new Error(
+      `Failed to add revocation for user "${name}" (${pubKey}): ${err instanceof Error ? err.message : String(err)}. ` +
+      `The user JWT is STILL VALID on the bus.`
+    );
+  }
+
+  // Push the updated account JWT so the NATS server picks up the revocation.
+  // If this fails, the JWT remains valid server-side — abort loudly.
+  try {
+    nsc(["push", "-a", account]);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Server-side revoke failed: ${reason}. The user JWT is STILL VALID on the bus. ` +
+      `Resolve connectivity and retry.`
+    );
   }
 }
 
@@ -201,6 +298,15 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     console.log(`  backup: ${backup}`);
   }
 
+  // Revoke the OLD user pubkey server-side BEFORE delete+add. If this fails
+  // we abort — leaking the old creds is the whole reason for the reissue.
+  try {
+    revokeAndPushUser(account, name);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
   nsc(["delete", "user", "-a", account, "-n", name]);
 
   try {
@@ -211,7 +317,11 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     console.error(`CRITICAL: failed to re-create user "${name}" after delete.`);
     if (existsSync(`${outPath}.bak`)) {
       console.error(`Old credentials backed up at: ${outPath}.bak`);
-      console.error(`Note: old creds are invalidated — backup is for reference only.`);
+      console.error(
+        `Note: old creds invalidated via revocations push above; the backup ` +
+        `captures the old JWT for forensics only (it's revoked server-side ` +
+        `and will be rejected by NATS).`
+      );
     }
     console.error(`Manual recovery: nsc add user -a ${account} -n ${name}`);
     console.error(`Cause: ${err instanceof Error ? err.message : String(err)}`);
@@ -223,7 +333,7 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
 
   console.log(`Re-issued credentials for ${name}`);
   console.log(`  credentials: ${outPath} (mode 600)`);
-  console.log(`  Note: old credentials are now invalid.`);
+  console.log(`  Note: old credentials revoked server-side and pushed to NATS.`);
 }
 
 export function listBots(account?: string): void {
@@ -285,8 +395,19 @@ export function removeBot(name: string, opts: RemoveBotOptions): void {
     process.exit(1);
   }
 
+  // Server-side revoke FIRST: add user pubkey to the account's revocation
+  // map and push the updated account JWT. If this fails we abort BEFORE
+  // deleting locally — a half-done revoke leaves a still-valid JWT on the
+  // bus and the operator unaware.
+  try {
+    revokeAndPushUser(account, name);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
   nsc(["delete", "user", "-a", account, "-n", name]);
-  console.log(`Removed user: ${name} (account: ${account})`);
+  console.log(`Revoked and removed user: ${name} (account: ${account})`);
 
   if (opts.deleteCreds) {
     const path = opts.output ?? defaultCredsPath(name);

--- a/test/commands/nats-revoke.test.ts
+++ b/test/commands/nats-revoke.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for the server-side revocation path added in arc#130.
+ *
+ * These tests stub the nsc runner so they run without a configured nsc
+ * environment. They assert call ORDER (revoke + push BEFORE delete), and
+ * that push failure aborts the operation without deleting locally.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import {
+  removeBot,
+  reissueBot,
+  __setNscRunnerForTests,
+  __setNscInstallCheckForTests,
+  type NscResult,
+  type NscRunner,
+} from "../../src/commands/nats.js";
+import { existsSync, unlinkSync, mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+const TEST_ACCOUNT = "OP_TEST";
+const TEST_BOT = "arc-revoke-test-bot";
+// Redirect creds writes to an isolated tmp dir so unit tests never touch the
+// operator's real ~/.config/nats. Each suite gets its own dir.
+const TMP_ROOT = mkdtempSync(join(tmpdir(), "arc-a130-"));
+const CUSTOM_OUT = join(TMP_ROOT, `${TEST_BOT}.creds`);
+
+// JWT body sample — only `sub` matters for getUserPubKey.
+const FAKE_USER_PUBKEY = "UAFAKEPUBKEYFORARCUNITTESTUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU";
+const FAKE_USER_JWT_JSON = JSON.stringify({
+  jti: "fake",
+  iat: 0,
+  iss: "AACCOUNT",
+  sub: FAKE_USER_PUBKEY,
+  name: TEST_BOT,
+  nats: { type: "user" },
+});
+
+interface Call {
+  args: string[];
+}
+
+function ok(stdout = ""): NscResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function fail(stderr = "boom"): NscResult {
+  return { exitCode: 1, stdout: "", stderr };
+}
+
+/**
+ * Build a runner that dispatches on the first arg + sub-arg to a handler map.
+ * Records every call in `calls` (in invocation order) for ordering assertions.
+ */
+function keyFor(args: string[]): string {
+  // Handlers are keyed by "<cmd>" or "<cmd> <subcmd>". A subcommand is the
+  // second token only when it is not a flag (does not start with `-`).
+  // Example: `push -a OP` → "push"; `revocations add-user -a OP -u UX` →
+  // "revocations add-user"; `delete user -a OP -n n` → "delete user".
+  const first = args[0] ?? "";
+  const second = args[1];
+  if (second && !second.startsWith("-")) return `${first} ${second}`;
+  return first;
+}
+
+function buildRunner(handlers: Record<string, (args: string[]) => NscResult>): { runner: NscRunner; calls: Call[] } {
+  const calls: Call[] = [];
+  const runner: NscRunner = (args) => {
+    calls.push({ args: [...args] });
+    const key = keyFor(args);
+    const handler = handlers[key];
+    if (!handler) {
+      throw new Error(`Test runner has no handler for: nsc ${args.join(" ")}`);
+    }
+    return handler(args);
+  };
+  return { runner, calls };
+}
+
+function cleanupOutPath(): void {
+  try { unlinkSync(CUSTOM_OUT); } catch { /* ignore — path may not exist */ }
+  try { unlinkSync(`${CUSTOM_OUT}.bak`); } catch { /* ignore — path may not exist */ }
+}
+
+beforeEach(() => {
+  __setNscInstallCheckForTests(() => true);
+});
+
+afterEach(() => {
+  __setNscRunnerForTests(null);
+  __setNscInstallCheckForTests(null);
+  cleanupOutPath();
+});
+
+describe("removeBot — server-side revocation", () => {
+  test("invokes revocations add-user + push BEFORE delete user", () => {
+    const { runner, calls } = buildRunner({
+      "describe user": (args) => {
+        // First call (userExists check) — no -J, return non-JSON success.
+        // Second call (getUserPubKey) — with -J, return JSON.
+        if (args.includes("-J")) return ok(FAKE_USER_JWT_JSON);
+        return ok("user exists (text describe)");
+      },
+      "revocations add-user": () => ok("revoked"),
+      "push": () => ok("pushed"),
+      "delete user": () => ok("deleted"),
+    });
+    __setNscRunnerForTests(runner);
+
+    removeBot(TEST_BOT, { account: TEST_ACCOUNT });
+
+    // Assert ORDER: revocations add-user → push → delete user.
+    const cmdSequence = calls.map((c) => keyFor(c.args));
+    const revokeIdx = cmdSequence.indexOf("revocations add-user");
+    const pushIdx = cmdSequence.indexOf("push");
+    const deleteIdx = cmdSequence.indexOf("delete user");
+
+    expect(revokeIdx).toBeGreaterThanOrEqual(0);
+    expect(pushIdx).toBeGreaterThanOrEqual(0);
+    expect(deleteIdx).toBeGreaterThanOrEqual(0);
+    expect(revokeIdx).toBeLessThan(pushIdx);
+    expect(pushIdx).toBeLessThan(deleteIdx);
+
+    // Revocation must reference the pubkey we surfaced via describe -J.
+    const revokeCall = calls.find((c) => c.args[0] === "revocations" && c.args[1] === "add-user")!;
+    expect(revokeCall.args).toContain("-u");
+    expect(revokeCall.args).toContain(FAKE_USER_PUBKEY);
+    expect(revokeCall.args).toContain(TEST_ACCOUNT);
+
+    // Push must be scoped to the account.
+    const pushCall = calls.find((c) => c.args[0] === "push")!;
+    expect(pushCall.args).toEqual(["push", "-a", TEST_ACCOUNT]);
+  });
+
+  test("aborts and does NOT call delete user when push fails", () => {
+    const { runner, calls } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : ok("exists"),
+      "revocations add-user": () => ok("revoked locally"),
+      "push": () => fail("connection refused: nats://localhost:4222"),
+      "delete user": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const errSpy = mock(() => undefined);
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = errSpy;
+
+    try {
+      expect(() => removeBot(TEST_BOT, { account: TEST_ACCOUNT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    // Critical: delete user MUST NOT have been called.
+    const deleteCalled = calls.some((c) => c.args[0] === "delete" && c.args[1] === "user");
+    expect(deleteCalled).toBe(false);
+
+    // Exit code must be non-zero.
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    // Operator must see the loud warning about the still-valid JWT.
+    const errMessages = errSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(errMessages).toContain("Server-side revoke failed");
+    expect(errMessages).toContain("STILL VALID");
+  });
+
+  test("aborts when revocations add-user fails (before push, before delete)", () => {
+    const { runner, calls } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : ok("exists"),
+      "revocations add-user": () => fail("permission denied: account signing key required"),
+      "push": () => ok("should-not-be-called"),
+      "delete user": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = mock(() => undefined);
+
+    try {
+      expect(() => removeBot(TEST_BOT, { account: TEST_ACCOUNT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    expect(calls.some((c) => c.args[0] === "push")).toBe(false);
+    expect(calls.some((c) => c.args[0] === "delete" && c.args[1] === "user")).toBe(false);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("reissueBot — server-side revocation of OLD pubkey", () => {
+  test("revokes old pubkey + push BEFORE delete + add", () => {
+    // reissueBot calls writeCredsFile to a path; we redirect via --output so
+    // the unit test does not touch the operator's real creds dir.
+    const outDir = dirname(CUSTOM_OUT);
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true, mode: 0o700 });
+    // Seed an existing creds file so the backup branch fires (exercises the
+    // full path, not just the no-backup variant).
+    writeFileSync(CUSTOM_OUT, "OLD CREDS CONTENT", { mode: 0o600 });
+
+    const { runner, calls } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : ok("exists"),
+      "revocations add-user": () => ok("revoked"),
+      "push": () => ok("pushed"),
+      "delete user": () => ok("deleted"),
+      "add user": () => ok("added"),
+      "generate creds": () => ok("-----BEGIN NATS USER JWT-----\nfake\n-----END NATS USER JWT-----\n-----BEGIN USER NKEY SEED-----\nSUFAKE\n-----END USER NKEY SEED-----"),
+    });
+    __setNscRunnerForTests(runner);
+
+    reissueBot(TEST_BOT, { account: TEST_ACCOUNT, output: CUSTOM_OUT });
+
+    const cmdSequence = calls.map((c) => keyFor(c.args));
+    const revokeIdx = cmdSequence.indexOf("revocations add-user");
+    const pushIdx = cmdSequence.indexOf("push");
+    const deleteIdx = cmdSequence.indexOf("delete user");
+    const addIdx = cmdSequence.indexOf("add user");
+
+    expect(revokeIdx).toBeGreaterThanOrEqual(0);
+    expect(pushIdx).toBeGreaterThanOrEqual(0);
+    expect(deleteIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(revokeIdx).toBeLessThan(pushIdx);
+    expect(pushIdx).toBeLessThan(deleteIdx);
+    expect(deleteIdx).toBeLessThan(addIdx);
+
+    // Revocation targets the OLD user's pubkey (captured via describe -J
+    // BEFORE delete).
+    const revokeCall = calls.find((c) => c.args[0] === "revocations" && c.args[1] === "add-user")!;
+    expect(revokeCall.args).toContain(FAKE_USER_PUBKEY);
+  });
+
+  test("aborts and does NOT delete+add when push fails", () => {
+    const outDir = dirname(CUSTOM_OUT);
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true, mode: 0o700 });
+    writeFileSync(CUSTOM_OUT, "OLD CREDS CONTENT", { mode: 0o600 });
+
+    const { runner, calls } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : ok("exists"),
+      "revocations add-user": () => ok("revoked locally"),
+      "push": () => fail("nats: timeout waiting for ACK"),
+      "delete user": () => ok("should-not-be-called"),
+      "add user": () => ok("should-not-be-called"),
+      "generate creds": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = mock(() => undefined);
+
+    try {
+      expect(() => reissueBot(TEST_BOT, { account: TEST_ACCOUNT, output: CUSTOM_OUT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    expect(calls.some((c) => c.args[0] === "delete" && c.args[1] === "user")).toBe(false);
+    expect(calls.some((c) => c.args[0] === "add" && c.args[1] === "user")).toBe(false);
+    expect(calls.some((c) => c.args[0] === "generate")).toBe(false);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("getUserPubKey — error surface", () => {
+  test("removeBot fails cleanly when describe -J returns malformed JSON", () => {
+    const { runner } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok("not-json{{{") : ok("exists"),
+      "revocations add-user": () => ok("should-not-be-called"),
+      "push": () => ok("should-not-be-called"),
+      "delete user": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = mock(() => undefined);
+
+    try {
+      expect(() => removeBot(TEST_BOT, { account: TEST_ACCOUNT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("removeBot fails cleanly when 'sub' is missing or not a U-prefixed nkey", () => {
+    const { runner } = buildRunner({
+      "describe user": (args) =>
+        args.includes("-J")
+          ? ok(JSON.stringify({ jti: "x", sub: "A_NOT_A_USER_NKEY" }))
+          : ok("exists"),
+      "revocations add-user": () => ok("should-not-be-called"),
+      "push": () => ok("should-not-be-called"),
+      "delete user": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = mock(() => undefined);
+
+    try {
+      expect(() => removeBot(TEST_BOT, { account: TEST_ACCOUNT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## What

Closes **arc#130** — real security gap. `arc nats remove-bot` and `arc nats reissue-bot` previously ran only `nsc delete user`, removing the user from the local NSC tree without pushing the revocation to the NATS server's $SYS account. The user JWT stayed valid on the bus until natural expiry. Any leaked copy of the `.creds` file (including the `.bak` file `reissueBot` itself writes) continued to authenticate.

This PR pushes the actual revocation before the local delete.

## Fix shape

New helpers in `src/commands/nats.ts`:
- **`getUserPubKey(account, name)`** — runs `nsc describe user -J`, parses JSON, validates `sub` is a U-prefixed NKey. Keyed by durable identity (pubkey), not the local name.
- **`revokeAndPushUser(account, name)`** — calls `nsc revocations add-user -u <pubkey>` then `nsc push -a <account>`. Throws with a "STILL VALID on the bus" message on either failure.

Updated commands:
- **`removeBot`**: calls `revokeAndPushUser` BEFORE `nsc delete user`. On failure, prints the error and `process.exit(1)` — never reaches the delete (half-done revoke is worse than failed revoke).
- **`reissueBot`**: revokes the OLD pubkey + pushes BEFORE `delete user` / `add user` / `generate creds`. CRITICAL-error message rewritten to reflect new server-side guarantee (old creds are revoked, backup is forensics-only).

## Pre-flight decisions

| Question | Issue body suggestion | What shipped | Rationale |
|---|---|---|---|
| Pubkey extraction | `nsc describe user -F sub` | `-J` + `JSON.parse(...).sub` + U-prefix validation | `-F sub` semantics not verifiable; `-J` returns documented full JWT claim |
| Revocation verb | `nsc revocations add-user` | Same, with `-u <pubkey>` form | Revocation map keyed by durable identity, not local name |
| Push surface | `nsc push -a <account>` | Same | Account-scoped push to operator's configured JWT server |

## Surprises in the existing code

- `nsc revocations add-user` accepts `-n <name>` pre-delete too — but the pubkey-keyed form (`-u`) is correct per the issue's intent: revocation entries must survive local user-record deletion.
- The existing `nsc` helper inlined `Bun.spawnSync` — refactored to an `NscRunner` interface (production behaviour unchanged; allows test-time injection). Same pattern for `ensureNscInstalled()` via parallel `__setNscInstallCheckForTests` hook.

## Tests (+7 new, all mock-based)

`test/commands/nats-revoke.test.ts`:
1. `removeBot` invokes `revocations add-user` + `push` BEFORE `delete user` (order asserted)
2. `removeBot` aborts when `push` fails — `delete user` is NEVER called, exit code 1, "STILL VALID" message surfaced
3. `removeBot` aborts when `revocations add-user` fails — neither `push` nor `delete user` is called
4. `reissueBot` revokes OLD pubkey + pushes BEFORE `delete user` / `add user` / `generate creds`
5. `reissueBot` aborts on push failure — none of delete/add/generate fire
6. `getUserPubKey` surfaces clean error on malformed JSON
7. `getUserPubKey` rejects a `sub` that is not a U-prefixed NKey

Writes are isolated to `mkdtempSync(tmpdir(), "arc-a130-")`; unit tests never touch `~/.config/nats`.

## Gates

- `bunx tsc --noEmit` → exit 0
- `bun test` → **720 pass / 2 pre-existing env-dependent fails** (identical set as baseline `main` — both die at `Error: set an operator -- 'nsc env -o operatorName'`; require a configured nsc operator on the local machine). +5 net pass.

## Why this matters

This is the load-bearing piece for any credential lifecycle story across the metafactory ecosystem (cortex sub-bots, future arc-installable bots, any per-component NATS user). cortex#77 was filed because cortex couldn't trust that `arc nats remove-bot` did a real revoke — and now we know why: it didn't. After this PR, the cortex#77 close ("revoke is arc's domain — use `arc nats remove-bot`") is correct end-to-end.

Refs cortex#77 (the consumer that surfaced this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)