### PR TITLE
fix(nats): push server-side revocation in remove-bot/reissue-bot (closes #130)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.24.0
+version: 0.24.1
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -21,10 +21,34 @@ const NSC_CONFIG_CANDIDATES = [
   join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "nsc", "nsc.json"),
 ];
 
-function nsc(args: string[]): string {
+export interface NscResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type NscRunner = (args: string[]) => NscResult;
+
+const realNscRunner: NscRunner = (args) => {
   const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
-  const stdout = result.stdout.toString().trim();
-  const stderr = result.stderr.toString().trim();
+  return {
+    exitCode: result.exitCode ?? 1,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+};
+
+let currentNscRunner: NscRunner = realNscRunner;
+
+// Test seam: replace the nsc invoker. Pass null to restore the real runner.
+export function __setNscRunner(fn: NscRunner | null): void {
+  currentNscRunner = fn ?? realNscRunner;
+}
+
+function nsc(args: string[]): string {
+  const result = currentNscRunner(args);
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
   if (result.exitCode !== 0) {
     throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
   }
@@ -32,13 +56,13 @@ function nsc(args: string[]): string {
 }
 
 function nscWithStderr(args: string[]): string {
-  const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
+  const result = currentNscRunner(args);
   if (result.exitCode !== 0) {
-    const stderr = result.stderr.toString().trim();
-    const stdout = result.stdout.toString().trim();
+    const stderr = result.stderr.trim();
+    const stdout = result.stdout.trim();
     throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
   }
-  return (result.stdout.toString() + result.stderr.toString()).trim();
+  return (result.stdout + result.stderr).trim();
 }
 
 export function ensureNscInstalled(): void {
@@ -92,6 +116,46 @@ function userExists(account: string, name: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Server-side revocation: add the user's public key to the account's revocations
+ * map, then push the updated account JWT to the NATS server's $SYS account so
+ * the server starts rejecting connections from any creds derived from that key.
+ *
+ * MUST be called before `nsc delete user` — the pubkey can't be looked up after
+ * the local user record is gone. Throws on push failure WITHOUT deleting the
+ * user, leaving a recoverable state.
+ */
+function revokeAndPush(account: string, name: string): void {
+  // 1. Resolve pubkey from the user JWT (`sub` field). Must happen before delete.
+  let userPubKey: string;
+  try {
+    userPubKey = nsc(["describe", "user", "-a", account, "-n", name, "--field", "sub"]);
+  } catch (err) {
+    throw new Error(
+      `Cannot look up pubkey for user "${name}" — server-side revoke skipped. ` +
+      `Cause: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  // nsc may wrap `--field` output in quotes; strip them.
+  userPubKey = userPubKey.replace(/^"|"$/g, "");
+  if (!userPubKey) {
+    throw new Error(`Empty pubkey returned for user "${name}" — refusing to proceed.`);
+  }
+
+  // 2. Add to account revocations map.
+  nsc(["revocations", "add-user", "-a", account, "-u", userPubKey]);
+
+  // 3. Push the updated account JWT to the NATS server's $SYS account.
+  try {
+    nsc(["push", "-a", account]);
+  } catch (err) {
+    throw new Error(
+      `Server-side revoke failed: ${err instanceof Error ? err.message : String(err)}. ` +
+      `The user JWT is STILL VALID on the bus. Resolve and retry.`,
+    );
   }
 }
 
@@ -201,6 +265,12 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     console.log(`  backup: ${backup}`);
   }
 
+  // Server-side revoke of the OLD user's pubkey BEFORE delete. The new user
+  // gets a fresh keypair and is unaffected. If push fails, abort without
+  // delete (recoverable). See issue #130.
+  revokeAndPush(account, name);
+  console.log(`Revoked old credentials on server`);
+
   nsc(["delete", "user", "-a", account, "-n", name]);
 
   try {
@@ -211,7 +281,7 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     console.error(`CRITICAL: failed to re-create user "${name}" after delete.`);
     if (existsSync(`${outPath}.bak`)) {
       console.error(`Old credentials backed up at: ${outPath}.bak`);
-      console.error(`Note: old creds are invalidated — backup is for reference only.`);
+      console.error(`Note: old creds are already revoked server-side — backup is for forensic reference only.`);
     }
     console.error(`Manual recovery: nsc add user -a ${account} -n ${name}`);
     console.error(`Cause: ${err instanceof Error ? err.message : String(err)}`);
@@ -223,7 +293,7 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
 
   console.log(`Re-issued credentials for ${name}`);
   console.log(`  credentials: ${outPath} (mode 600)`);
-  console.log(`  Note: old credentials are now invalid.`);
+  console.log(`  Note: old credentials are revoked on the NATS server.`);
 }
 
 export function listBots(account?: string): void {
@@ -284,6 +354,11 @@ export function removeBot(name: string, opts: RemoveBotOptions): void {
     console.error(`Error: user "${name}" not found under "${account}".`);
     process.exit(1);
   }
+
+  // Server-side revoke FIRST. If the push fails, abort without deleting the
+  // user locally — leaves a recoverable state. See issue #130.
+  revokeAndPush(account, name);
+  console.log(`Revoked on server: ${name} (account: ${account})`);
 
   nsc(["delete", "user", "-a", account, "-n", name]);
   console.log(`Removed user: ${name} (account: ${account})`);

--- a/test/commands/identity.test.ts
+++ b/test/commands/identity.test.ts
@@ -147,7 +147,11 @@ describe("importPrincipals — security", () => {
     const origExitCode = process.exitCode;
     importPrincipals(importFile);
     expect(process.exitCode).toBe(1);
-    process.exitCode = origExitCode;
+    // Setting `process.exitCode = undefined` does NOT clear it under Bun —
+    // the process retains the last assigned value, which makes the whole
+    // `bun test` run exit non-zero even with 0 fails. Coerce to 0 so the
+    // smoke-test gate sees a clean exit.
+    process.exitCode = origExitCode ?? 0;
   });
 
   test("rejects invalid file format", async () => {
@@ -159,7 +163,11 @@ describe("importPrincipals — security", () => {
     const origExitCode = process.exitCode;
     importPrincipals(importFile);
     expect(process.exitCode).toBe(1);
-    process.exitCode = origExitCode;
+    // Setting `process.exitCode = undefined` does NOT clear it under Bun —
+    // the process retains the last assigned value, which makes the whole
+    // `bun test` run exit non-zero even with 0 fails. Coerce to 0 so the
+    // smoke-test gate sees a clean exit.
+    process.exitCode = origExitCode ?? 0;
   });
 });
 

--- a/test/commands/nats.test.ts
+++ b/test/commands/nats.test.ts
@@ -9,6 +9,20 @@ const TEST_ACCOUNT = "OP_JC";
 const TEST_BOT = "arc-test-bot";
 const CREDS_PATH = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
 
+// `removeBot` now requires server-side revocation push (#130). The local
+// nsc lifecycle test only runs against an operator whose JWT carries a
+// reachable account-jwt-server URL. `nsc push --diff` is non-destructive
+// and reports the same connectivity error as a real push, so we use it
+// as a probe.
+const NATS_REACHABLE = (() => {
+  if (!NSC_AVAILABLE) return false;
+  const probe = Bun.spawnSync(
+    ["nsc", "push", "-a", TEST_ACCOUNT, "--diff"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  return probe.exitCode === 0;
+})();
+
 function cleanupTestBot(): void {
   Bun.spawnSync(["nsc", "delete", "user", "-a", TEST_ACCOUNT, "-n", TEST_BOT]);
   try { unlinkSync(CREDS_PATH); } catch { /* ok */ }
@@ -30,7 +44,10 @@ describe("nats commands", () => {
   });
 
   describe("addBot + removeBot lifecycle", () => {
-    test.skipIf(!NSC_AVAILABLE)("creates user, writes creds with correct perms, removes cleanly", () => {
+    // Requires both nsc AND a reachable NATS server, since `removeBot` now
+    // pushes revocations to the server (#130). Unit-level coverage of the
+    // revoke/push call ordering lives in test/unit/nats-revocation.test.ts.
+    test.skipIf(!NATS_REACHABLE)("creates user, writes creds with correct perms, removes cleanly", () => {
       cleanupTestBot();
 
       addBot(TEST_BOT, { account: TEST_ACCOUNT });

--- a/test/unit/nats-revocation.test.ts
+++ b/test/unit/nats-revocation.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { existsSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  removeBot,
+  reissueBot,
+  __setNscRunner,
+  type NscResult,
+} from "../../src/commands/nats.js";
+
+/**
+ * Unit tests for #130: server-side NATS revocation must happen BEFORE the
+ * local `nsc delete user`, and a push failure must abort the operation
+ * without deleting the user.
+ *
+ * These tests inject a mock `nsc` runner so they don't require nsc or a
+ * running NATS server.
+ */
+
+const ACCOUNT = "OP_TEST";
+const BOT = "test-bot";
+const FAKE_PUBKEY = "UAFAKEPUBKEY1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+type RecordedCall = { args: string[] };
+
+function recordingRunner(behavior: {
+  fail?: (args: string[]) => string | null;
+  describeOutput?: string;
+}) {
+  const calls: RecordedCall[] = [];
+  const run = (args: string[]): NscResult => {
+    calls.push({ args });
+    const failMsg = behavior.fail?.(args);
+    if (failMsg !== null && failMsg !== undefined) {
+      return { exitCode: 1, stdout: "", stderr: failMsg };
+    }
+    // canned responses
+    if (args[0] === "describe" && args[1] === "user") {
+      return { exitCode: 0, stdout: behavior.describeOutput ?? FAKE_PUBKEY, stderr: "" };
+    }
+    if (args[0] === "generate" && args[1] === "creds") {
+      return {
+        exitCode: 0,
+        stdout: "-----BEGIN NATS USER JWT-----\nx\n------END NATS USER JWT------\n-----BEGIN USER NKEY SEED-----\ny\n------END USER NKEY SEED------",
+        stderr: "",
+      };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+  return { calls, run };
+}
+
+function indexOfArgs(calls: RecordedCall[], match: (args: string[]) => boolean): number {
+  return calls.findIndex((c) => match(c.args));
+}
+
+afterEach(() => {
+  __setNscRunner(null);
+});
+
+describe("removeBot — server-side revocation (#130)", () => {
+  test("invokes describe → revocations add-user → push → delete user, in order", () => {
+    const { calls, run } = recordingRunner({});
+    __setNscRunner(run);
+
+    removeBot(BOT, { account: ACCOUNT });
+
+    const idxDescribe = indexOfArgs(calls, (a) => a[0] === "describe" && a[1] === "user");
+    const idxRevoke = indexOfArgs(calls, (a) => a[0] === "revocations" && a[1] === "add-user");
+    const idxPush = indexOfArgs(calls, (a) => a[0] === "push");
+    const idxDelete = indexOfArgs(calls, (a) => a[0] === "delete" && a[1] === "user");
+
+    expect(idxDescribe).toBeGreaterThanOrEqual(0);
+    expect(idxRevoke).toBeGreaterThanOrEqual(0);
+    expect(idxPush).toBeGreaterThanOrEqual(0);
+    expect(idxDelete).toBeGreaterThanOrEqual(0);
+
+    // Strict ordering: describe < revoke < push < delete
+    expect(idxDescribe).toBeLessThan(idxRevoke);
+    expect(idxRevoke).toBeLessThan(idxPush);
+    expect(idxPush).toBeLessThan(idxDelete);
+  });
+
+  test("passes the user's pubkey from describe to revocations add-user", () => {
+    const { calls, run } = recordingRunner({ describeOutput: FAKE_PUBKEY });
+    __setNscRunner(run);
+
+    removeBot(BOT, { account: ACCOUNT });
+
+    const revokeCall = calls.find((c) => c.args[0] === "revocations" && c.args[1] === "add-user");
+    expect(revokeCall).toBeDefined();
+    expect(revokeCall!.args).toContain("-u");
+    const uIdx = revokeCall!.args.indexOf("-u");
+    expect(revokeCall!.args[uIdx + 1]).toBe(FAKE_PUBKEY);
+  });
+
+  test("strips wrapping quotes from `nsc describe --field sub` output", () => {
+    const { calls, run } = recordingRunner({ describeOutput: `"${FAKE_PUBKEY}"` });
+    __setNscRunner(run);
+
+    removeBot(BOT, { account: ACCOUNT });
+
+    const revokeCall = calls.find((c) => c.args[0] === "revocations" && c.args[1] === "add-user");
+    const uIdx = revokeCall!.args.indexOf("-u");
+    expect(revokeCall!.args[uIdx + 1]).toBe(FAKE_PUBKEY);
+  });
+
+  test("aborts on `nsc push` failure WITHOUT calling delete user", () => {
+    const { calls, run } = recordingRunner({
+      fail: (args) => (args[0] === "push" ? "nats: server unreachable" : null),
+    });
+    __setNscRunner(run);
+
+    expect(() => removeBot(BOT, { account: ACCOUNT })).toThrow(/Server-side revoke failed/);
+    expect(() => removeBot(BOT, { account: ACCOUNT })).toThrow(/STILL VALID/);
+
+    const deleteCall = calls.find((c) => c.args[0] === "delete" && c.args[1] === "user");
+    expect(deleteCall).toBeUndefined();
+  });
+
+  test("aborts on pubkey-lookup failure with clear error", () => {
+    const { calls, run } = recordingRunner({
+      // Fail the *second* describe (the one with --field sub). The first describe
+      // call comes from userExists() and must succeed so we reach revoke logic.
+      fail: (() => {
+        let seen = 0;
+        return (args: string[]) => {
+          if (args[0] === "describe" && args[1] === "user") {
+            seen++;
+            if (seen >= 2 && args.includes("--field")) return "user JWT not found";
+          }
+          return null;
+        };
+      })(),
+    });
+    __setNscRunner(run);
+
+    expect(() => removeBot(BOT, { account: ACCOUNT })).toThrow(/server-side revoke skipped/);
+
+    const deleteCall = calls.find((c) => c.args[0] === "delete" && c.args[1] === "user");
+    expect(deleteCall).toBeUndefined();
+  });
+
+  test("revokes even when --delete-creds is false (local file unrelated to server revoke)", () => {
+    const { calls, run } = recordingRunner({});
+    __setNscRunner(run);
+
+    removeBot(BOT, { account: ACCOUNT, deleteCreds: false });
+
+    const revokeCall = calls.find((c) => c.args[0] === "revocations" && c.args[1] === "add-user");
+    const pushCall = calls.find((c) => c.args[0] === "push");
+    expect(revokeCall).toBeDefined();
+    expect(pushCall).toBeDefined();
+  });
+});
+
+describe("reissueBot — server-side revocation of old creds (#130)", () => {
+  let tmpDir: string;
+  let credsPath: string;
+
+  function setupTmpCreds() {
+    tmpDir = mkdtempSync(join(tmpdir(), "arc-nats-revoke-"));
+    credsPath = join(tmpDir, "test-bot.creds");
+    writeFileSync(credsPath, "OLD_CREDS_CONTENT");
+  }
+
+  function cleanupTmp() {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+
+  test("revokes + pushes BEFORE delete during rotation", () => {
+    setupTmpCreds();
+    try {
+      const { calls, run } = recordingRunner({});
+      __setNscRunner(run);
+
+      reissueBot(BOT, { account: ACCOUNT, output: credsPath });
+
+      const idxRevoke = indexOfArgs(calls, (a) => a[0] === "revocations" && a[1] === "add-user");
+      const idxPush = indexOfArgs(calls, (a) => a[0] === "push");
+      const idxDelete = indexOfArgs(calls, (a) => a[0] === "delete" && a[1] === "user");
+      const idxAdd = indexOfArgs(calls, (a) => a[0] === "add" && a[1] === "user");
+
+      expect(idxRevoke).toBeGreaterThanOrEqual(0);
+      expect(idxPush).toBeGreaterThanOrEqual(0);
+      expect(idxRevoke).toBeLessThan(idxPush);
+      expect(idxPush).toBeLessThan(idxDelete);
+      expect(idxDelete).toBeLessThan(idxAdd);
+    } finally {
+      cleanupTmp();
+    }
+  });
+
+  test("aborts on push failure without deleting the old user", () => {
+    setupTmpCreds();
+    try {
+      const { calls, run } = recordingRunner({
+        fail: (args) => (args[0] === "push" ? "nats: server unreachable" : null),
+      });
+      __setNscRunner(run);
+
+      expect(() => reissueBot(BOT, { account: ACCOUNT, output: credsPath })).toThrow(/Server-side revoke failed/);
+
+      const deleteCall = calls.find((c) => c.args[0] === "delete" && c.args[1] === "user");
+      expect(deleteCall).toBeUndefined();
+
+      // Old creds file still intact on disk since we aborted before delete
+      expect(existsSync(credsPath)).toBe(true);
+    } finally {
+      cleanupTmp();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #130 — security gap: `arc nats remove-bot` and `arc nats reissue-bot` ran only `nsc delete user`, leaving the user's JWT valid on the bus until natural expiry. Any leaked `.creds` (backup, container image, prior filesystem access, the `.bak` file `reissue` itself wrote) continued to authenticate.

## What changed

Both commands now run the full revoke flow **before** the local delete:

1. `nsc describe user --field sub` — resolve pubkey (must precede delete)
2. `nsc revocations add-user` — add pubkey to account revocations map
3. `nsc push -a <account>` — push updated account JWT to `$SYS`
4. `nsc delete user` — local cleanup

If the server push fails, the operation **aborts** and the user is NOT deleted locally — leaves a recoverable state and surfaces:

```
Server-side revoke failed: <reason>. The user JWT is STILL VALID on the bus. Resolve and retry.
```

## Test seam

Module-private `nsc()` runner is now backed by a swappable `NscRunner` so unit tests can verify call ordering and abort semantics without nsc or a running NATS server. Exposed as `__setNscRunner(fn | null)`.

## Tests

- `test/unit/nats-revocation.test.ts` (8 tests, unconditional):
  - ordering: `describe → revocations add-user → push → delete user` for both `removeBot` and `reissueBot`
  - pubkey from `describe --field sub` is passed to `revocations add-user`
  - quote-stripping on `--field sub` output
  - push failure → throws "Server-side revoke failed … STILL VALID" + does NOT call `delete user`
  - pubkey-lookup failure → aborts with clear error + does NOT call `delete user`
  - revoke happens even when `--delete-creds` is false (independent of local file cleanup)
  - reissue: old creds file remains on disk if push aborts
- `test/commands/nats.test.ts` lifecycle test now gated on a non-destructive `nsc push --diff` probe — skipped when operator JWT has no resolver-server URL.

## Drive-by

`test/commands/identity.test.ts` was leaving `process.exitCode = 1` after two assertion tests because the "restore" line wrote `undefined` back, and `bun:test` inherits the last assigned exit code. Coerced to `0` with `origExitCode ?? 0`. Pre-existing on main; was blocking the pre-push smoke gate.

## Out of scope (follow-ups)

- Real integration test against a running `nats-server` with resolver — the issue's "actually rejects subsequent connections" check needs a CI fixture (`nats-server` container with operator JWT pre-configured). File as separate issue.
- `--json` output mode for cortex delegation (issue #131).

## Deferred edge case

The issue raises the question of whether `nsc push` needs a specific operator/account context. Today's flow inherits the current operator from `nsc env`, same as `addBot`. If a deployment uses a non-default operator the operator should `nsc env -o <op>` first — same precondition as the rest of the `arc nats` surface.

## Version

`0.24.0` → `0.24.1` (patch — bug fix, no API surface change beyond adding `__setNscRunner` for test injection).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 722 pass, 1 skip (lifecycle test on hosts without resolver-enabled NATS), 0 fail
- [x] `bun test test/unit/nats-revocation.test.ts` — 8 pass
- [ ] Manual: `arc nats add-bot foo` → `arc nats remove-bot foo` against a resolver-enabled local nats-server, verify `nats --creds=./foo.creds.bak pub …` is rejected post-revoke

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
