### PR TITLE
fix(nats): move .bak write AFTER revoke+push; gate test seams on env (follow-up to #130/#132)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.24.0
+version: 0.24.1
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -47,9 +47,13 @@ let runner: NscRunner = defaultRunner;
 
 /**
  * Test-only hook to swap the nsc runner. Pass `null` to restore the default.
- * Do NOT call from production code paths.
+ *
+ * Gated on test-mode env so production callers that import this module can't
+ * silently swap the runner process-wide. Set `ARC_TEST_MODE=1` (or
+ * `NODE_ENV=test`, which `bun:test` sets implicitly) to enable the swap.
  */
 export function __setNscRunnerForTests(next: NscRunner | null): void {
+  assertTestModeForSeam("__setNscRunnerForTests");
   runner = next ?? defaultRunner;
 }
 
@@ -79,9 +83,19 @@ let nscInstallCheck: () => boolean = () => {
 
 /**
  * Test-only hook to swap the install check. Pass `null` to restore the default.
+ * Gated on test-mode env; see {@link __setNscRunnerForTests}.
  */
 export function __setNscInstallCheckForTests(next: (() => boolean) | null): void {
+  assertTestModeForSeam("__setNscInstallCheckForTests");
   nscInstallCheck = next ?? (() => Bun.spawnSync(["which", "nsc"], { stdout: "pipe" }).exitCode === 0);
+}
+
+function assertTestModeForSeam(seamName: string): void {
+  if (process.env.ARC_TEST_MODE !== "1" && process.env.NODE_ENV !== "test") {
+    throw new Error(
+      `${seamName} is a test-only seam. Set ARC_TEST_MODE=1 or NODE_ENV=test to enable.`,
+    );
+  }
 }
 
 export function ensureNscInstalled(): void {
@@ -289,22 +303,25 @@ export function reissueBot(name: string, opts: ReissueBotOptions): void {
     process.exit(1);
   }
 
-  // nsc requires delete+add for new keys (no in-place rekey).
-  // Back up old creds file before the destructive delete.
-  if (existsSync(outPath)) {
-    const backup = `${outPath}.bak`;
-    writeFileSync(backup, readFileSync(outPath));
-    chmodSync(backup, 0o600);
-    console.log(`  backup: ${backup}`);
-  }
-
-  // Revoke the OLD user pubkey server-side BEFORE delete+add. If this fails
-  // we abort — leaking the old creds is the whole reason for the reissue.
+  // Revoke the OLD user pubkey server-side BEFORE we touch local state. If
+  // this fails we abort cleanly: no local delete, and — critically — no .bak
+  // on disk holding the still-valid old creds (writing the backup before the
+  // revoke would re-create the exact leaked-backup threat #130 was filed for).
   try {
     revokeAndPushUser(account, name);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
+  }
+
+  // nsc requires delete+add for new keys (no in-place rekey). Now that the
+  // old JWT is revoked server-side, the .bak is safe to write — its
+  // embedded creds are already dead on the bus.
+  if (existsSync(outPath)) {
+    const backup = `${outPath}.bak`;
+    writeFileSync(backup, readFileSync(outPath));
+    chmodSync(backup, 0o600);
+    console.log(`  backup: ${backup}`);
   }
 
   nsc(["delete", "user", "-a", account, "-n", name]);

--- a/test/commands/identity.test.ts
+++ b/test/commands/identity.test.ts
@@ -147,7 +147,10 @@ describe("importPrincipals — security", () => {
     const origExitCode = process.exitCode;
     importPrincipals(importFile);
     expect(process.exitCode).toBe(1);
-    process.exitCode = origExitCode;
+    // `process.exitCode = undefined` does NOT clear it under Bun — the
+    // process retains the last assigned value and the whole `bun test`
+    // run exits non-zero even with 0 fails. Coerce to 0 for the smoke gate.
+    process.exitCode = origExitCode ?? 0;
   });
 
   test("rejects invalid file format", async () => {
@@ -159,7 +162,10 @@ describe("importPrincipals — security", () => {
     const origExitCode = process.exitCode;
     importPrincipals(importFile);
     expect(process.exitCode).toBe(1);
-    process.exitCode = origExitCode;
+    // `process.exitCode = undefined` does NOT clear it under Bun — the
+    // process retains the last assigned value and the whole `bun test`
+    // run exits non-zero even with 0 fails. Coerce to 0 for the smoke gate.
+    process.exitCode = origExitCode ?? 0;
   });
 });
 

--- a/test/commands/nats-revoke.test.ts
+++ b/test/commands/nats-revoke.test.ts
@@ -272,6 +272,87 @@ describe("reissueBot — server-side revocation of OLD pubkey", () => {
     expect(calls.some((c) => c.args[0] === "generate")).toBe(false);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  test("does NOT write .bak when push fails — fail-closed against leaked-backup", () => {
+    // The original threat #130 was filed for: a .bak holding the still-valid
+    // old creds survives a failed revoke and continues to authenticate against
+    // NATS. After this fix the .bak is written AFTER revokeAndPushUser
+    // succeeds, so the abort path leaves no backup on disk.
+    const outDir = dirname(CUSTOM_OUT);
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true, mode: 0o700 });
+    writeFileSync(CUSTOM_OUT, "OLD CREDS CONTENT", { mode: 0o600 });
+    // Pre-clean any stale .bak from prior runs.
+    try { unlinkSync(`${CUSTOM_OUT}.bak`); } catch { /* ok */ }
+
+    const { runner } = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : ok("exists"),
+      "revocations add-user": () => ok("revoked locally"),
+      "push": () => fail("nats: server unreachable"),
+      "delete user": () => ok("should-not-be-called"),
+      "add user": () => ok("should-not-be-called"),
+      "generate creds": () => ok("should-not-be-called"),
+    });
+    __setNscRunnerForTests(runner);
+
+    const exitSpy = mock(() => { throw new Error("process.exit called"); });
+    const origExit = process.exit;
+    const origErr = console.error;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    console.error = mock(() => undefined);
+
+    try {
+      expect(() => reissueBot(TEST_BOT, { account: TEST_ACCOUNT, output: CUSTOM_OUT })).toThrow("process.exit called");
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+
+    // The invariant: a .bak holding live creds must not exist after a
+    // failed revoke. Original creds file is untouched.
+    expect(existsSync(`${CUSTOM_OUT}.bak`)).toBe(false);
+    expect(existsSync(CUSTOM_OUT)).toBe(true);
+  });
+});
+
+describe("test-mode seam env-gate", () => {
+  test("__setNscRunnerForTests throws when ARC_TEST_MODE / NODE_ENV not set", () => {
+    const origTestMode = process.env.ARC_TEST_MODE;
+    const origNodeEnv = process.env.NODE_ENV;
+    delete process.env.ARC_TEST_MODE;
+    delete process.env.NODE_ENV;
+
+    try {
+      expect(() => __setNscRunnerForTests(null)).toThrow(/test-only seam/);
+    } finally {
+      if (origTestMode !== undefined) process.env.ARC_TEST_MODE = origTestMode;
+      if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    }
+  });
+
+  test("__setNscInstallCheckForTests throws when env not set", () => {
+    const origTestMode = process.env.ARC_TEST_MODE;
+    const origNodeEnv = process.env.NODE_ENV;
+    delete process.env.ARC_TEST_MODE;
+    delete process.env.NODE_ENV;
+
+    try {
+      expect(() => __setNscInstallCheckForTests(null)).toThrow(/test-only seam/);
+    } finally {
+      if (origTestMode !== undefined) process.env.ARC_TEST_MODE = origTestMode;
+      if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    }
+  });
+
+  test("__setNscRunnerForTests succeeds when ARC_TEST_MODE=1", () => {
+    const origTestMode = process.env.ARC_TEST_MODE;
+    process.env.ARC_TEST_MODE = "1";
+    try {
+      expect(() => __setNscRunnerForTests(null)).not.toThrow();
+    } finally {
+      if (origTestMode === undefined) delete process.env.ARC_TEST_MODE;
+      else process.env.ARC_TEST_MODE = origTestMode;
+    }
+  });
 });
 
 describe("getUserPubKey — error surface", () => {

--- a/test/commands/nats-revoke.test.ts
+++ b/test/commands/nats-revoke.test.ts
@@ -311,6 +311,9 @@ describe("reissueBot — server-side revocation of OLD pubkey", () => {
     // failed revoke. Original creds file is untouched.
     expect(existsSync(`${CUSTOM_OUT}.bak`)).toBe(false);
     expect(existsSync(CUSTOM_OUT)).toBe(true);
+    // Per Holly review: also pin the exit code so this test fails loudly
+    // if a future regression replaces `process.exit(1)` with `(0)`.
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
 

--- a/test/commands/nats.test.ts
+++ b/test/commands/nats.test.ts
@@ -9,6 +9,21 @@ const TEST_ACCOUNT = "OP_JC";
 const TEST_BOT = "arc-test-bot";
 const CREDS_PATH = join(homedir(), ".config", "nats", `${TEST_BOT}.creds`);
 
+// `removeBot` now requires server-side revocation push (#130). The local nsc
+// lifecycle test only runs against an operator whose JWT carries a reachable
+// account-jwt-server URL. `nsc push --diff` is non-destructive and reports
+// the same connectivity error as a real push, so we use it as a probe.
+// Coverage of revocation call-order + abort semantics without a server lives
+// in test/commands/nats-revoke.test.ts.
+const NATS_REACHABLE = (() => {
+  if (!NSC_AVAILABLE) return false;
+  const probe = Bun.spawnSync(
+    ["nsc", "push", "-a", TEST_ACCOUNT, "--diff"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  return probe.exitCode === 0;
+})();
+
 function cleanupTestBot(): void {
   Bun.spawnSync(["nsc", "delete", "user", "-a", TEST_ACCOUNT, "-n", TEST_BOT]);
   try { unlinkSync(CREDS_PATH); } catch { /* ok */ }
@@ -30,7 +45,7 @@ describe("nats commands", () => {
   });
 
   describe("addBot + removeBot lifecycle", () => {
-    test.skipIf(!NSC_AVAILABLE)("creates user, writes creds with correct perms, removes cleanly", () => {
+    test.skipIf(!NATS_REACHABLE)("creates user, writes creds with correct perms, removes cleanly", () => {
       cleanupTestBot();
 
       addBot(TEST_BOT, { account: TEST_ACCOUNT });


### PR DESCRIPTION
## Why this exists

PR #132 (merged earlier today) implemented the core fix for #130 — revoke + push before delete. While reviewing my parallel attempt at the same issue (#133), Echo surfaced two residual gaps that apply to merged main:

1. **`reissueBot` writes `<creds>.bak` BEFORE `revokeAndPushUser`.** If the push aborts, the `.bak` holds the still-valid old creds — the exact leaked-backup threat #130 was filed for. The revoke abort path in #132 correctly skips `nsc delete user`, but the backup file already exists by then.

2. **`__setNscRunnerForTests` and `__setNscInstallCheckForTests` are exported with no env gate.** The `__` prefix is convention only — a production caller that imports `arc/dist/commands/nats.js` can swap the runner process-wide. Not a vulnerability today (arc isn't consumed as a library), but the test seam is mutable global state on the public surface.

## Changes

### `src/commands/nats.ts`

1. **`reissueBot`**: move the `<creds>.bak` write block to AFTER `revokeAndPushUser` succeeds. Comment updated to reflect the new threat-model rationale.
2. **`__setNscRunnerForTests` / `__setNscInstallCheckForTests`**: gate via new private helper `assertTestModeForSeam(name)` — throws unless `ARC_TEST_MODE=1` or `NODE_ENV=test` (which `bun:test` sets implicitly).

### `test/commands/nats-revoke.test.ts` (+4 tests)

- `reissueBot — server-side revocation of OLD pubkey > does NOT write .bak when push fails — fail-closed against leaked-backup`
- `test-mode seam env-gate > __setNscRunnerForTests throws when ARC_TEST_MODE / NODE_ENV not set`
- `test-mode seam env-gate > __setNscInstallCheckForTests throws when env not set`
- `test-mode seam env-gate > __setNscRunnerForTests succeeds when ARC_TEST_MODE=1`

### `test/commands/nats.test.ts` (drive-by)

The local-nsc lifecycle test is now gated on a non-destructive `nsc push --diff` probe (`NATS_REACHABLE`) — skips on operators whose JWT has no resolver-server URL. Prior to this drive-by, the test hard-failed on JC's machine after #132 because `removeBot` now requires server reachability.

### `test/commands/identity.test.ts` (drive-by)

Two tests left `process.exitCode = 1` after their assertions because the "restore" line wrote `undefined` back, which under Bun does not reset the exit code. The whole `bun test` run exited 1 despite "0 fail", failing the pre-push smoke gate. Coerced to `0` via `origExitCode ?? 0`. Identical to the same drive-by on #133.

## Acknowledgements

Echo's review on #133 surfaced both substantive issues here. The `.bak` ordering invariant — _"backup only exists when the key is dead"_ — was Echo's phrasing.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → 725 pass / 1 skip / 0 fail
- [x] `bun test test/commands/nats-revoke.test.ts` → 11 pass
- [x] Pre-push smoke gate green (locally)
- [ ] Manual: against a resolver-less operator, `arc nats reissue-bot` aborts before writing `<creds>.bak` (verify via `ls <path>.bak` after the abort — file must not exist)

## Version

`0.24.0` → `0.24.1` (patch — bug fix + test-seam hardening, no API changes).

Refs #130, #132, #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
