### PR TITLE
feat(manifest): targets + lifecycle arrays + agent runtime/identity (arc#140 P1)

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -4,7 +4,7 @@ import type { ArcPaths, ArcManifest, ArtifactType, HostAdapter, PackageTier } fr
 import type { Database } from "bun:sqlite";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
-import { runScript } from "../lib/scripts.js";
+import { runScript, runLifecycleScripts } from "../lib/scripts.js";
 import {
   registerHooks,
   removeHooks,
@@ -247,20 +247,10 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     }
   }
 
-  // 3b. Run preinstall script if declared
-  if (manifest.scripts?.preinstall) {
-    const preResult = runScript({
-      installPath,
-      scriptPath: manifest.scripts.preinstall,
-      hookName: "preinstall",
-      quiet: opts.yes,
-    });
-    if (!preResult.success && !preResult.skipped) {
-      return {
-        success: false,
-        error: `Preinstall script failed (exit ${preResult.exitCode})`,
-      };
-    }
+  // 3b. Run preinstall script(s) if declared
+  const preinstallResult = runPreinstallPhase(installPath, manifest, opts.yes);
+  if (!preinstallResult.success) {
+    return preinstallResult;
   }
 
   // 4. Create symlinks based on artifact type
@@ -347,28 +337,18 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // 6. Run bun install if package.json exists
   installNodeDependencies(installPath);
 
-  // 6b. Run postinstall script if declared
-  if (manifest.scripts?.postinstall) {
-    const postResult = runScript({
-      installPath,
-      scriptPath: manifest.scripts.postinstall,
-      hookName: "postinstall",
-      quiet: opts.yes,
-    });
-    if (!postResult.success && !postResult.skipped) {
-      // #97: postinstall failure leaves the same partial-state shape as the
-      // hook-validation gate (#89) plus registered hooks pointing at a package
-      // the DB has no record of (recordInstall happens AFTER postinstall).
-      // Tear down hook registrations and symlinks before returning so the
-      // user gets a clean failure rather than orphans they have to clean up
-      // by hand.
-      await removeHooks(manifest.name, host.paths.settingsPath);
-      await rollbackArtifactSymlinks(symlinkResult.record);
-      return {
-        success: false,
-        error: `Postinstall script failed (exit ${postResult.exitCode})`,
-      };
-    }
+  // 6b. Run postinstall script(s) if declared
+  const postinstallResult = runPostinstallPhase(installPath, manifest, opts.yes);
+  if (!postinstallResult.success) {
+    // #97: postinstall failure leaves the same partial-state shape as the
+    // hook-validation gate (#89) plus registered hooks pointing at a package
+    // the DB has no record of (recordInstall happens AFTER postinstall).
+    // Tear down hook registrations and symlinks before returning so the
+    // user gets a clean failure rather than orphans they have to clean up
+    // by hand.
+    await removeHooks(manifest.name, host.paths.settingsPath);
+    await rollbackArtifactSymlinks(symlinkResult.record);
+    return postinstallResult;
   }
 
   // 7. Record in database
@@ -528,20 +508,10 @@ export async function installSingleArtifact(
     }
   }
 
-  // Run preinstall script
-  if (manifest.scripts?.preinstall) {
-    const preResult = runScript({
-      installPath: artifactDir,
-      scriptPath: manifest.scripts.preinstall,
-      hookName: "preinstall",
-      quiet: opts.yes,
-    });
-    if (!preResult.success && !preResult.skipped) {
-      return {
-        success: false,
-        error: `Preinstall script failed (exit ${preResult.exitCode})`,
-      };
-    }
+  // Run preinstall script(s)
+  const preinstallResult = runPreinstallPhase(artifactDir, manifest, opts.yes);
+  if (!preinstallResult.success) {
+    return preinstallResult;
   }
 
   // Create symlinks based on artifact type
@@ -618,28 +588,18 @@ export async function installSingleArtifact(
   // Run bun install if package.json exists in artifact dir
   installNodeDependencies(artifactDir);
 
-  // Run postinstall script
-  if (manifest.scripts?.postinstall) {
-    const postResult = runScript({
-      installPath: artifactDir,
-      scriptPath: manifest.scripts.postinstall,
-      hookName: "postinstall",
-      quiet: opts.yes,
-    });
-    if (!postResult.success && !postResult.skipped) {
-      // #97: postinstall failure leaves the same partial-state shape as the
-      // hook-validation gate (#89) plus registered hooks pointing at a package
-      // the DB has no record of (recordInstall happens AFTER postinstall).
-      // Tear down hook registrations and symlinks before returning so the
-      // user gets a clean failure rather than orphans they have to clean up
-      // by hand.
-      await removeHooks(manifest.name, host.paths.settingsPath);
-      await rollbackArtifactSymlinks(symlinkResult.record);
-      return {
-        success: false,
-        error: `Postinstall script failed (exit ${postResult.exitCode})`,
-      };
-    }
+  // Run postinstall script(s)
+  const postinstallResult = runPostinstallPhase(artifactDir, manifest, opts.yes);
+  if (!postinstallResult.success) {
+    // #97: postinstall failure leaves the same partial-state shape as the
+    // hook-validation gate (#89) plus registered hooks pointing at a package
+    // the DB has no record of (recordInstall happens AFTER postinstall).
+    // Tear down hook registrations and symlinks before returning so the
+    // user gets a clean failure rather than orphans they have to clean up
+    // by hand.
+    await removeHooks(manifest.name, host.paths.settingsPath);
+    await rollbackArtifactSymlinks(symlinkResult.record);
+    return postinstallResult;
   }
 
   // Resolve the skill_dir for DB recording
@@ -672,6 +632,101 @@ export async function installSingleArtifact(
     version: manifest.version,
     manifest,
   };
+}
+
+/**
+ * Run the preinstall phase: single-script `scripts.preinstall` first, then
+ * the ordered `lifecycle.preinstall` array (arc#140). Both shapes may be
+ * present on the same manifest; arc runs them in that order.
+ *
+ * Called BEFORE any symlinks are created — a failure here leaves no
+ * partial filesystem state to roll back, so the caller just returns the
+ * error directly.
+ */
+function runPreinstallPhase(
+  installPath: string,
+  manifest: ArcManifest,
+  quiet?: boolean,
+): InstallResult {
+  if (manifest.scripts?.preinstall) {
+    const result = runScript({
+      installPath,
+      scriptPath: manifest.scripts.preinstall,
+      hookName: "preinstall",
+      quiet,
+    });
+    if (!result.success && !result.skipped) {
+      return {
+        success: false,
+        error: `Preinstall script failed (exit ${result.exitCode})`,
+      };
+    }
+  }
+
+  const lifecycle = manifest.lifecycle?.preinstall;
+  if (lifecycle && lifecycle.length > 0) {
+    const result = runLifecycleScripts({
+      installPath,
+      scriptPaths: lifecycle,
+      phase: "preinstall",
+      quiet,
+    });
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Preinstall lifecycle script failed: ${result.failedAt} (exit ${result.steps.at(-1)?.exitCode ?? "?"})`,
+      };
+    }
+  }
+
+  return { success: true };
+}
+
+/**
+ * Run the postinstall phase: single-script `scripts.postinstall` first,
+ * then the ordered `lifecycle.postinstall` array (arc#140). Same ordering
+ * rationale as runPreinstallPhase.
+ *
+ * Called AFTER symlinks + hooks are placed; caller is responsible for
+ * rollback on failure (see install.ts §6b).
+ */
+function runPostinstallPhase(
+  installPath: string,
+  manifest: ArcManifest,
+  quiet?: boolean,
+): InstallResult {
+  if (manifest.scripts?.postinstall) {
+    const result = runScript({
+      installPath,
+      scriptPath: manifest.scripts.postinstall,
+      hookName: "postinstall",
+      quiet,
+    });
+    if (!result.success && !result.skipped) {
+      return {
+        success: false,
+        error: `Postinstall script failed (exit ${result.exitCode})`,
+      };
+    }
+  }
+
+  const lifecycle = manifest.lifecycle?.postinstall;
+  if (lifecycle && lifecycle.length > 0) {
+    const result = runLifecycleScripts({
+      installPath,
+      scriptPaths: lifecycle,
+      phase: "postinstall",
+      quiet,
+    });
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Postinstall lifecycle script failed: ${result.failedAt} (exit ${result.steps.at(-1)?.exitCode ?? "?"})`,
+      };
+    }
+  }
+
+  return { success: true };
 }
 
 /**

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -1,7 +1,8 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 import YAML from "yaml";
-import type { ArcManifest, RiskLevel } from "../types.js";
+import type { ArcManifest, HostId, RiskLevel } from "../types.js";
+import { KNOWN_HOST_IDS } from "../types.js";
 
 /** Preferred manifest filename (new name). */
 export const MANIFEST_FILENAME = "arc-manifest.yaml";
@@ -109,6 +110,8 @@ async function readManifestFromDir(
       }
 
       normalizeCapabilities(parsed, filename);
+      validateTargets(parsed, filename);
+      validateLifecycle(parsed, filename);
 
       return parsed;
     } catch (err: any) {
@@ -179,6 +182,117 @@ export function normalizeCapabilities(manifest: ArcManifest, filename: string): 
 }
 
 /**
+ * Validate `targets:` on the manifest.
+ *
+ * - Each entry must be a member of `KNOWN_HOST_IDS` (claude-code | cortex |
+ *   darwin-launchd | linux-systemd today).
+ * - Duplicates are rejected — ambiguous semantics for multi-target install
+ *   ordering.
+ * - Empty array is rejected — declaring `targets: []` is more confusing than
+ *   omitting the field. Omission means "default host".
+ *
+ * The membership check is purely schema-level. arc#140 P3 adds a
+ * detection-time check ("target X listed but adapter not implemented") at
+ * dispatch time.
+ */
+export function validateTargets(manifest: ArcManifest, filename: string): void {
+  const targets = manifest.targets;
+  if (targets === undefined) return;
+
+  if (!Array.isArray(targets)) {
+    throw new Error(
+      `Invalid ${filename}: 'targets' must be an array of host IDs (got ${typeof targets})`,
+    );
+  }
+  if (targets.length === 0) {
+    throw new Error(
+      `Invalid ${filename}: 'targets' is empty — omit the field to use the default host`,
+    );
+  }
+
+  const seen = new Set<HostId>();
+  for (const entry of targets) {
+    if (typeof entry !== "string") {
+      throw new Error(
+        `Invalid ${filename}: targets entries must be strings, got ${JSON.stringify(entry)}`,
+      );
+    }
+    if (!(KNOWN_HOST_IDS as readonly string[]).includes(entry)) {
+      throw new Error(
+        `Invalid ${filename}: unknown target host '${entry}'. Known: ${KNOWN_HOST_IDS.join(", ")}`,
+      );
+    }
+    if (seen.has(entry as HostId)) {
+      throw new Error(
+        `Invalid ${filename}: duplicate target '${entry}' in 'targets'`,
+      );
+    }
+    seen.add(entry as HostId);
+  }
+}
+
+/**
+ * Validate `lifecycle:` arrays.
+ *
+ * - Each known phase (preinstall/postinstall/preuninstall/postuninstall) is
+ *   an array of strings.
+ * - Each script path is relative (no leading `/`) and contains no `..`
+ *   segment — defense in depth against a package whose install root differs
+ *   from the bundled-script root.
+ * - Unknown phase keys are rejected so typos surface at parse time rather
+ *   than silently no-op'ing at install.
+ */
+export function validateLifecycle(manifest: ArcManifest, filename: string): void {
+  const lifecycle = manifest.lifecycle;
+  if (lifecycle === undefined) return;
+
+  if (typeof lifecycle !== "object" || Array.isArray(lifecycle)) {
+    throw new Error(
+      `Invalid ${filename}: 'lifecycle' must be an object with phase arrays`,
+    );
+  }
+
+  const knownPhases = new Set([
+    "preinstall",
+    "postinstall",
+    "preuninstall",
+    "postuninstall",
+  ]);
+
+  for (const key of Object.keys(lifecycle)) {
+    if (!knownPhases.has(key)) {
+      throw new Error(
+        `Invalid ${filename}: unknown lifecycle phase '${key}'. Known: ${[...knownPhases].join(", ")}`,
+      );
+    }
+    const arr = (lifecycle as Record<string, unknown>)[key];
+    if (!Array.isArray(arr)) {
+      throw new Error(
+        `Invalid ${filename}: lifecycle.${key} must be an array of script paths`,
+      );
+    }
+    for (const entry of arr) {
+      if (typeof entry !== "string") {
+        throw new Error(
+          `Invalid ${filename}: lifecycle.${key} entries must be strings, got ${JSON.stringify(entry)}`,
+        );
+      }
+      if (entry.startsWith("/")) {
+        throw new Error(
+          `Invalid ${filename}: lifecycle.${key} entry '${entry}' must be a relative path (no leading /)`,
+        );
+      }
+      const segments = entry.split("/");
+      if (segments.includes("..")) {
+        throw new Error(
+          `Invalid ${filename}: lifecycle.${key} entry '${entry}' must not contain '..'`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Validate a library root manifest.
  * Libraries must have an artifacts array and must NOT have provides/capabilities/scripts.
  */
@@ -203,6 +317,11 @@ function validateLibraryManifest(parsed: ArcManifest, filename: string): void {
   if (parsed.scripts) {
     throw new Error(
       `Invalid ${filename}: library root manifest must not contain 'scripts' (belongs on per-artifact manifests)`
+    );
+  }
+  if (parsed.lifecycle) {
+    throw new Error(
+      `Invalid ${filename}: library root manifest must not contain 'lifecycle' (belongs on per-artifact manifests)`
     );
   }
 

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -63,3 +63,80 @@ export function runScript(opts: RunScriptOpts): RunScriptResult {
     exitCode: result.exitCode,
   };
 }
+
+export interface RunLifecycleOpts {
+  /** Absolute path to the installed repo */
+  installPath: string;
+  /** Ordered array of script paths from manifest.lifecycle.<phase> */
+  scriptPaths: string[];
+  /** Phase name for logging ("preinstall", "postinstall", "preuninstall", "postuninstall") */
+  phase: string;
+  /** Suppress console output (for non-interactive / test use) */
+  quiet?: boolean;
+  /** Extra env vars to pass to each script */
+  env?: Record<string, string>;
+}
+
+export interface RunLifecycleResult {
+  /** True iff every script ran (or was missing) without a non-zero exit. */
+  success: boolean;
+  /** Phase name, echoed for caller convenience. */
+  phase: string;
+  /** Per-script results in declared order. Empty when scriptPaths is empty. */
+  steps: Array<{
+    scriptPath: string;
+    exitCode: number | null;
+    skipped: boolean;
+  }>;
+  /** The script that failed, if any — last entry of `steps` when !success. */
+  failedAt?: string;
+}
+
+/**
+ * Run a `manifest.lifecycle.<phase>` array of scripts in declared order.
+ *
+ * Lifecycle arrays exist for sequences where order matters — e.g. the
+ * type:agent standalone-bot install sequence (cortex `docs/design-arc-agent-bots.md`
+ * §8.1 / §8.2): signal-cortex-reload → issue-nats-creds → launchctl-load.
+ * Each script is invoked via {@link runScript}, so per-script env injection
+ * and missing-file handling stay consistent with the single-script
+ * `manifest.scripts.<phase>` path.
+ *
+ * On first non-zero exit, the runner stops and returns `success: false`
+ * with the failed script in `failedAt`. Earlier scripts are NOT re-run on
+ * retry; callers wiring rollback should treat the partial side-effects of
+ * earlier scripts as already-applied state to be reversed by the rollback
+ * path.
+ *
+ * Empty array → `success: true, steps: []` (no-op).
+ */
+export function runLifecycleScripts(
+  opts: RunLifecycleOpts,
+): RunLifecycleResult {
+  const steps: RunLifecycleResult["steps"] = [];
+
+  for (const scriptPath of opts.scriptPaths) {
+    const result = runScript({
+      installPath: opts.installPath,
+      scriptPath,
+      hookName: opts.phase,
+      quiet: opts.quiet,
+      env: opts.env,
+    });
+    steps.push({
+      scriptPath,
+      exitCode: result.exitCode,
+      skipped: result.skipped ?? false,
+    });
+    if (!result.success && !result.skipped) {
+      return {
+        success: false,
+        phase: opts.phase,
+        steps,
+        failedAt: scriptPath,
+      };
+    }
+  }
+
+  return { success: true, phase: opts.phase, steps };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,61 @@ export interface RulesConfig {
   [key: string]: unknown;
 }
 
+/**
+ * Runtime declaration for type:agent packages.
+ *
+ * Per cortex `docs/design-arc-agent-bots.md` §4. Names the substrate
+ * (claude-code / codex / pi-dev / custom) and the supervision mode
+ * (in-process under cortex's runner, or standalone as its own daemon).
+ * Capabilities are register-on-start values published to NATS KV by
+ * the bot's daemon — listed here so cortex can scope credentials and
+ * the dashboard can render an accurate provenance badge.
+ */
+export interface AgentRuntime {
+  substrate: "claude-code" | "codex" | "pi-dev" | "custom-binary" | string;
+  mode: "in-process" | "standalone";
+  capabilities?: string[];
+}
+
+/**
+ * Identity declaration for type:agent packages.
+ *
+ * Rendered into the cortex fragment (`~/.config/cortex/agents.d/<id>.yaml`)
+ * by the CortexHostAdapter. The `trust` list is propagated to the
+ * runtime's `TrustResolver` — every id MUST resolve in the merged
+ * `AgentRegistry` at construction time (cortex `docs/design-arc-agent-bots.md`
+ * §9, registry.ts §9.3 rule 1).
+ */
+export interface AgentIdentity {
+  id: string;
+  did?: string;
+  displayName?: string;
+  roles?: string[];
+  trust?: string[];
+}
+
+/**
+ * Ordered lifecycle script arrays for `type: agent` packages.
+ *
+ * Sister field to the existing `scripts.{preinstall,postinstall,…}` single-
+ * script shape. The array form is required for standalone-bot install
+ * sequences where order matters (cortex `docs/design-arc-agent-bots.md`
+ * §8.1 / §8.2): drop fragment → signal cortex reload → issue NATS creds →
+ * (standalone only) launchctl load. Uninstall reverses.
+ *
+ * Each entry is a path relative to the package install root, exactly like
+ * the single-script `scripts` fields. Both shapes may be present on the
+ * same manifest; arc runs `scripts.<phase>` first, then `lifecycle.<phase>`
+ * in declared order. A failure in any entry aborts the install and
+ * triggers the same rollback path as the single-script form.
+ */
+export interface LifecycleScripts {
+  preinstall?: string[];
+  postinstall?: string[];
+  preuninstall?: string[];
+  postuninstall?: string[];
+}
+
 /** Inline hook array format (e.g. Grove) */
 export type InlineHook = {
   event: string;
@@ -190,6 +245,28 @@ export interface ArcManifest {
   type: "skill" | "system" | "tool" | "agent" | "prompt" | "component" | "pipeline" | "rules" | "library";
   /** Only present when type is "library" — lists contained artifacts */
   artifacts?: LibraryArtifactEntry[];
+  /**
+   * Multi-target install destinations (arc#117 multi-backend HostAdapter).
+   *
+   * When absent, arc routes to the single host adapter passed in
+   * InstallOptions (today: claude-code). When present, arc dispatches
+   * once per declared target in the order required by the artifact's
+   * design contract — for `type: agent` standalone bots, that means
+   * `cortex` FIRST, then the OS-supervision host (`darwin-launchd` or
+   * `linux-systemd`) per cortex `docs/design-arc-agent-bots.md` §3.2.
+   */
+  targets?: HostId[];
+  /**
+   * Runtime declaration — type:agent only. Names substrate + supervision
+   * mode + capabilities. Required for type:agent packages that declare
+   * `targets: [cortex, …]`. See AgentRuntime.
+   */
+  runtime?: AgentRuntime;
+  /**
+   * Identity declaration — type:agent only. Rendered into the cortex
+   * agent fragment. See AgentIdentity.
+   */
+  identity?: AgentIdentity;
   tier?: PackageTier;
   author?: {
     name: string;
@@ -207,6 +284,25 @@ export interface ArcManifest {
     files?: Array<{ source: string; target: string }>;
     templates?: RulesTemplate[];
     hooks?: HooksDeclaration;
+    /**
+     * Standalone-bot daemon binary, relative to the package install root.
+     * Rendered into the OS-supervision host's binDir (`~/bin/<binary>` on
+     * darwin-launchd) at install time. type:agent + runtime.mode=standalone only.
+     */
+    binary?: string;
+    /**
+     * macOS launchd plist template, relative to the package install root.
+     * Rendered into `~/Library/LaunchAgents/<label>.plist` by the
+     * darwin-launchd HostAdapter, with token substitution (e.g.,
+     * `{{NATS_URL}}`, `{{BIN}}`, `{{LOG_DIR}}`).
+     */
+    plist?: string;
+    /**
+     * Linux systemd user unit template, relative to the package install root.
+     * Rendered into `~/.config/systemd/user/<unit>.service` by the
+     * linux-systemd HostAdapter (post-P6).
+     */
+    systemdUnit?: string;
   };
   extensions?: {
     statusline?: ExtensionEntry[];
@@ -226,6 +322,13 @@ export interface ArcManifest {
      *  stop daemons, unload launchd plists, etc. */
     preremove?: string;
   };
+  /**
+   * Ordered lifecycle script arrays — for sequences where order matters
+   * (e.g. type:agent standalone bots: signal-reload → issue-creds →
+   * launchctl-load). Runs after the single-script `scripts` field of the
+   * same phase. See LifecycleScripts.
+   */
+  lifecycle?: LifecycleScripts;
   /** Optional namespace for publishing (alternative to account default) */
   namespace?: string;
   /** Bundle configuration for arc publish */
@@ -429,8 +532,28 @@ export interface AuditWarning {
  * the type stays truthful: a value of `HostId` should always correspond to
  * an actually implemented `HostAdapter`. Phase 2 of #117 adds `"codex"`,
  * `"cursor"`, etc. as those adapters arrive.
+ *
+ * `darwin-launchd` and `linux-systemd` are OS-supervision hosts for
+ * standalone-bot type:agent packages — they receive the daemon binary and
+ * a launchd plist (macOS) or systemd user unit (Linux). See cortex
+ * `docs/design-arc-agent-bots.md` §3.2 and arc#140. The adapter for
+ * `darwin-launchd` lands in P2 of arc#140; `linux-systemd` later (Phase C
+ * of the design doc). Schema declares the union so a `targets:` value can
+ * be parsed and validated even before its adapter is registered.
  */
-export type HostId = "claude-code" | "cortex";
+export type HostId =
+  | "claude-code"
+  | "cortex"
+  | "darwin-launchd"
+  | "linux-systemd";
+
+/** Set of all known HostId values — for runtime validation of `targets:`. */
+export const KNOWN_HOST_IDS: readonly HostId[] = [
+  "claude-code",
+  "cortex",
+  "darwin-launchd",
+  "linux-systemd",
+] as const;
 
 /** arc's own state — host-independent. Lives under ~/.config/metafactory/. */
 export interface ArcPaths {

--- a/test/commands/install-lifecycle-i140.test.ts
+++ b/test/commands/install-lifecycle-i140.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for arc#140 P1: ordered `lifecycle.{preinstall,postinstall}` arrays
+ * are executed at install time and back-compat with `scripts.*` is preserved.
+ *
+ * Companion to test/commands/lifecycle-hooks.test.ts which covers the
+ * pre-arc#140 single-script shape.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  createTestEnv,
+  createMockSkillRepo,
+  type TestEnv,
+} from "../helpers/test-env.js";
+import { install } from "../../src/commands/install.js";
+import { getSkill } from "../../src/lib/db.js";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+describe("install: lifecycle array execution", () => {
+  test("runs lifecycle.postinstall scripts in declared order", async () => {
+    const logPath = join(env.root, "lifecycle.log");
+    const repo = await createMockSkillRepo(env.root, {
+      name: "LifecycleOrdered",
+      lifecycle: {
+        postinstall: [
+          { path: "scripts/01-first.sh", content: `#!/bin/bash\necho "1" >> "${logPath}"\n` },
+          { path: "scripts/02-second.sh", content: `#!/bin/bash\necho "2" >> "${logPath}"\n` },
+          { path: "scripts/03-third.sh", content: `#!/bin/bash\necho "3" >> "${logPath}"\n` },
+        ],
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(logPath)).toBe(true);
+    const log = await Bun.file(logPath).text();
+    expect(log).toBe("1\n2\n3\n");
+  });
+
+  test("runs lifecycle.preinstall before symlinks land", async () => {
+    const markerPath = join(env.root, "preinstall-marker");
+    const repo = await createMockSkillRepo(env.root, {
+      name: "LifecyclePreinstall",
+      lifecycle: {
+        preinstall: [
+          { path: "scripts/check.sh", content: `#!/bin/bash\ntouch "${markerPath}"\n` },
+        ],
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  test("scripts.postinstall runs BEFORE lifecycle.postinstall (both declared)", async () => {
+    const logPath = join(env.root, "order.log");
+    const repo = await createMockSkillRepo(env.root, {
+      name: "BothShapes",
+      scripts: {
+        postinstall: {
+          path: "scripts/legacy-postinstall.sh",
+          content: `#!/bin/bash\necho "legacy" >> "${logPath}"\n`,
+        },
+      },
+      lifecycle: {
+        postinstall: [
+          { path: "scripts/lifecycle-1.sh", content: `#!/bin/bash\necho "lifecycle-1" >> "${logPath}"\n` },
+          { path: "scripts/lifecycle-2.sh", content: `#!/bin/bash\necho "lifecycle-2" >> "${logPath}"\n` },
+        ],
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    const log = await Bun.file(logPath).text();
+    expect(log).toBe("legacy\nlifecycle-1\nlifecycle-2\n");
+  });
+
+  test("lifecycle.postinstall failure aborts install and removes symlinks", async () => {
+    const repo = await createMockSkillRepo(env.root, {
+      name: "LifecycleFailing",
+      lifecycle: {
+        postinstall: [
+          { path: "scripts/ok.sh", content: `#!/bin/bash\nexit 0\n` },
+          { path: "scripts/fail.sh", content: `#!/bin/bash\nexit 9\n` },
+          { path: "scripts/never.sh", content: `#!/bin/bash\ntouch "${join(env.root, "should-not-exist")}"\n` },
+        ],
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Postinstall lifecycle script failed.*scripts\/fail\.sh/);
+    expect(result.error).toMatch(/exit 9/);
+
+    // Later script in array did NOT run
+    expect(existsSync(join(env.root, "should-not-exist"))).toBe(false);
+
+    // DB should have no record of the package
+    const record = getSkill(env.db, "LifecycleFailing");
+    expect(record).toBeNull();
+
+    // Symlink should be torn down (rollback path)
+    const skillLink = join(env.host.paths.skillsDir, "LifecycleFailing");
+    expect(existsSync(skillLink)).toBe(false);
+  });
+
+  test("lifecycle.preinstall failure aborts before any symlinks are placed", async () => {
+    const repo = await createMockSkillRepo(env.root, {
+      name: "PreinstallFailing",
+      lifecycle: {
+        preinstall: [
+          { path: "scripts/fail.sh", content: `#!/bin/bash\nexit 3\n` },
+        ],
+        postinstall: [
+          { path: "scripts/never.sh", content: `#!/bin/bash\ntouch "${join(env.root, "never-marker")}"\n` },
+        ],
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Preinstall lifecycle script failed.*scripts\/fail\.sh/);
+
+    // postinstall never ran
+    expect(existsSync(join(env.root, "never-marker"))).toBe(false);
+
+    // No symlink, no DB row
+    expect(getSkill(env.db, "PreinstallFailing")).toBeNull();
+    expect(existsSync(join(env.host.paths.skillsDir, "PreinstallFailing"))).toBe(false);
+  });
+
+  test("PAI_HOOK env exposes the phase name to lifecycle scripts", async () => {
+    const outPath = join(env.root, "hook-name.txt");
+    const repo = await createMockSkillRepo(env.root, {
+      name: "PaiHookEnv",
+      lifecycle: {
+        postinstall: [
+          { path: "scripts/show.sh", content: `#!/bin/bash\necho "$PAI_HOOK" > "${outPath}"\n` },
+        ],
+      },
+    });
+
+    await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+    });
+
+    expect(existsSync(outPath)).toBe(true);
+    const out = await Bun.file(outPath).text();
+    expect(out.trim()).toBe("postinstall");
+  });
+});

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -113,6 +113,18 @@ export async function createMockSkillRepo(
     /** provides.files entries to declare in the manifest. Source files
      *  are created on disk so install can symlink them. */
     files?: Array<{ source: string; target: string; content?: string }>;
+    /**
+     * Ordered lifecycle script arrays (arc#140). Each phase is an ordered
+     * list of `{ path, content }`. The helper writes each script to disk
+     * (executable) and the manifest's `lifecycle.<phase>` is rendered as
+     * the array of paths in declared order.
+     */
+    lifecycle?: {
+      preinstall?: Array<{ path: string; content: string }>;
+      postinstall?: Array<{ path: string; content: string }>;
+      preuninstall?: Array<{ path: string; content: string }>;
+      postuninstall?: Array<{ path: string; content: string }>;
+    };
   }
 ): Promise<MockSkillRepo> {
   const repoDir = join(root, `mock-${opts.name}`);
@@ -183,6 +195,17 @@ export async function createMockSkillRepo(
     }
   }
 
+  if (opts.lifecycle) {
+    for (const phase of Object.values(opts.lifecycle)) {
+      if (!phase) continue;
+      for (const script of phase) {
+        const scriptAbsPath = join(repoDir, script.path);
+        await Bun.write(scriptAbsPath, script.content);
+        Bun.spawnSync(["chmod", "+x", scriptAbsPath], { stdout: "pipe", stderr: "pipe" });
+      }
+    }
+  }
+
   // Create arc-manifest.yaml (unless testing without it)
   if (!opts.withoutManifest) {
     const caps = opts.capabilities ?? {};
@@ -219,6 +242,13 @@ export async function createMockSkillRepo(
       ...(opts.scripts ? {
         scripts: Object.fromEntries(
           Object.entries(opts.scripts).map(([hook, s]) => [hook, s.path])
+        ),
+      } : {}),
+      ...(opts.lifecycle ? {
+        lifecycle: Object.fromEntries(
+          Object.entries(opts.lifecycle)
+            .filter(([, arr]) => arr && arr.length > 0)
+            .map(([phase, arr]) => [phase, arr!.map((s) => s.path)]),
         ),
       } : {}),
     };

--- a/test/unit/manifest-i140.test.ts
+++ b/test/unit/manifest-i140.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for arc#140 P1 manifest schema additions:
+ *
+ *   - targets:                    HostId[] validation
+ *   - lifecycle.{pre,post}install array validation
+ *   - lifecycle.{pre,post}uninstall array validation
+ *   - runtime / identity / provides.{binary,plist,systemdUnit} pass-through
+ *
+ * Behavioural tests for the actual install-time execution of lifecycle
+ * arrays live in test/commands/lifecycle-hooks.test.ts and the P3 multi-
+ * target dispatch tests.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { readManifest, MANIFEST_FILENAME } from "../../src/lib/manifest.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-i140-manifest-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writeManifest(content: string): Promise<void> {
+  await Bun.write(join(tempDir, MANIFEST_FILENAME), content);
+}
+
+const baseAgentManifest = `
+name: example-agent
+version: 0.1.0
+type: agent
+`;
+
+describe("targets validation", () => {
+  test("accepts a single known target", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: [cortex]\n`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.targets).toEqual(["cortex"]);
+  });
+
+  test("accepts multi-target standalone-bot shape", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: [cortex, darwin-launchd]\n`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.targets).toEqual(["cortex", "darwin-launchd"]);
+  });
+
+  test("rejects unknown target host", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: [bogus-host]\n`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/unknown target host 'bogus-host'/);
+  });
+
+  test("rejects empty targets array", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: []\n`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/'targets' is empty/);
+  });
+
+  test("rejects duplicate targets", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: [cortex, cortex]\n`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/duplicate target 'cortex'/);
+  });
+
+  test("rejects non-array targets", async () => {
+    await writeManifest(
+      `${baseAgentManifest}targets: cortex\n`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/'targets' must be an array/);
+  });
+
+  test("targets absent is OK (existing single-host shape)", async () => {
+    await writeManifest(baseAgentManifest);
+    const m = await readManifest(tempDir);
+    expect(m!.targets).toBeUndefined();
+  });
+});
+
+describe("lifecycle validation", () => {
+  test("accepts ordered postinstall array", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  postinstall:
+    - scripts/signal-cortex-reload.sh
+    - scripts/issue-nats-creds.sh
+    - scripts/start-daemon.sh
+`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.lifecycle?.postinstall).toEqual([
+      "scripts/signal-cortex-reload.sh",
+      "scripts/issue-nats-creds.sh",
+      "scripts/start-daemon.sh",
+    ]);
+  });
+
+  test("accepts all four phases", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstall:    [scripts/check.sh]
+  postinstall:   [scripts/post.sh]
+  preuninstall:  [scripts/pre-un.sh]
+  postuninstall: [scripts/post-un.sh]
+`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.lifecycle?.preinstall).toEqual(["scripts/check.sh"]);
+    expect(m!.lifecycle?.postinstall).toEqual(["scripts/post.sh"]);
+    expect(m!.lifecycle?.preuninstall).toEqual(["scripts/pre-un.sh"]);
+    expect(m!.lifecycle?.postuninstall).toEqual(["scripts/post-un.sh"]);
+  });
+
+  test("rejects unknown lifecycle phase", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstallx: [scripts/x.sh]
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/unknown lifecycle phase 'preinstallx'/);
+  });
+
+  test("rejects absolute paths", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstall:
+    - /etc/passwd
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/must be a relative path/);
+  });
+
+  test("rejects '..' segments", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstall:
+    - ../escape.sh
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/must not contain '\.\.'/);
+  });
+
+  test("rejects non-array phase value", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstall: scripts/x.sh
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/must be an array of script paths/);
+  });
+
+  test("rejects non-string entries", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  preinstall:
+    - 42
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/entries must be strings/);
+  });
+
+  test("lifecycle absent is OK", async () => {
+    await writeManifest(baseAgentManifest);
+    const m = await readManifest(tempDir);
+    expect(m!.lifecycle).toBeUndefined();
+  });
+
+  test("empty phase array is OK (no-op at runtime)", async () => {
+    await writeManifest(
+      `${baseAgentManifest}lifecycle:
+  postinstall: []
+`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.lifecycle?.postinstall).toEqual([]);
+  });
+});
+
+describe("library root manifest rejects lifecycle", () => {
+  test("type:library with lifecycle fails", async () => {
+    await writeManifest(
+      `name: lib
+version: 1.0.0
+type: library
+artifacts:
+  - path: ./a
+lifecycle:
+  postinstall: [scripts/x.sh]
+`,
+    );
+    await expect(readManifest(tempDir)).rejects.toThrow(/library root manifest must not contain 'lifecycle'/);
+  });
+});
+
+describe("runtime / identity / provides.binary,plist,systemdUnit pass-through", () => {
+  test("runtime + identity parse for standalone bot", async () => {
+    await writeManifest(
+      `${baseAgentManifest}runtime:
+  substrate: pi-dev
+  mode: standalone
+  capabilities: [code-review, typescript]
+identity:
+  id: sage
+  did: did:mf:sage
+  displayName: Sage
+  roles: [agent-restricted]
+  trust: [luna, holly]
+`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.runtime?.substrate).toBe("pi-dev");
+    expect(m!.runtime?.mode).toBe("standalone");
+    expect(m!.runtime?.capabilities).toEqual(["code-review", "typescript"]);
+    expect(m!.identity?.id).toBe("sage");
+    expect(m!.identity?.did).toBe("did:mf:sage");
+    expect(m!.identity?.roles).toEqual(["agent-restricted"]);
+    expect(m!.identity?.trust).toEqual(["luna", "holly"]);
+  });
+
+  test("provides.binary, plist, systemdUnit pass through", async () => {
+    await writeManifest(
+      `${baseAgentManifest}provides:
+  binary: bin/sage-bot
+  plist: services/ai.meta-factory.sage.plist
+  systemdUnit: services/sage.service
+`,
+    );
+    const m = await readManifest(tempDir);
+    expect(m!.provides?.binary).toBe("bin/sage-bot");
+    expect(m!.provides?.plist).toBe("services/ai.meta-factory.sage.plist");
+    expect(m!.provides?.systemdUnit).toBe("services/sage.service");
+  });
+});

--- a/test/unit/scripts-lifecycle.test.ts
+++ b/test/unit/scripts-lifecycle.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for arc#140 P1: runLifecycleScripts — ordered array runner.
+ *
+ * Sister to the existing runScript single-script tests. Verifies:
+ *   - empty array → no-op success
+ *   - declared order is preserved
+ *   - first failure halts subsequent scripts
+ *   - missing files are treated as skip (consistent with runScript)
+ *   - env vars are passed through to each script
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, chmod } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runLifecycleScripts } from "../../src/lib/scripts.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-i140-lifecycle-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writeScript(name: string, body: string): Promise<string> {
+  const path = join(tempDir, name);
+  await writeFile(path, `#!/usr/bin/env bash\n${body}\n`);
+  await chmod(path, 0o755);
+  return name;
+}
+
+describe("runLifecycleScripts", () => {
+  test("empty array → success no-op", () => {
+    const result = runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: [],
+      phase: "postinstall",
+      quiet: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.steps).toEqual([]);
+    expect(result.failedAt).toBeUndefined();
+  });
+
+  test("runs scripts in declared order", async () => {
+    const logFile = join(tempDir, "log.txt");
+    await writeScript("a.sh", `echo "A" >> "${logFile}"`);
+    await writeScript("b.sh", `echo "B" >> "${logFile}"`);
+    await writeScript("c.sh", `echo "C" >> "${logFile}"`);
+
+    const result = runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: ["a.sh", "b.sh", "c.sh"],
+      phase: "postinstall",
+      quiet: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps.map((s) => s.scriptPath)).toEqual([
+      "a.sh",
+      "b.sh",
+      "c.sh",
+    ]);
+
+    const log = await Bun.file(logFile).text();
+    expect(log).toBe("A\nB\nC\n");
+  });
+
+  test("halts after first failure; later scripts not run", async () => {
+    const logFile = join(tempDir, "log.txt");
+    await writeScript("ok.sh", `echo "OK" >> "${logFile}"`);
+    await writeScript("fail.sh", `echo "FAIL" >> "${logFile}"\nexit 7`);
+    await writeScript("never.sh", `echo "NEVER" >> "${logFile}"`);
+
+    const result = runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: ["ok.sh", "fail.sh", "never.sh"],
+      phase: "postinstall",
+      quiet: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.failedAt).toBe("fail.sh");
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[1].exitCode).toBe(7);
+
+    const log = await Bun.file(logFile).text();
+    expect(log).toBe("OK\nFAIL\n");
+  });
+
+  test("missing script file is a skip, not a failure", async () => {
+    await writeScript("present.sh", `true`);
+
+    const result = runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: ["missing.sh", "present.sh"],
+      phase: "postinstall",
+      quiet: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].skipped).toBe(true);
+    expect(result.steps[1].skipped).toBe(false);
+  });
+
+  test("passes env vars to each script", async () => {
+    const outFile = join(tempDir, "out.txt");
+    await writeScript("env.sh", `echo "VAR=$ARC_I140_TEST_VAR" > "${outFile}"`);
+
+    const result = runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: ["env.sh"],
+      phase: "postinstall",
+      quiet: true,
+      env: { ARC_I140_TEST_VAR: "hello" },
+    });
+    expect(result.success).toBe(true);
+
+    const out = await Bun.file(outFile).text();
+    expect(out.trim()).toBe("VAR=hello");
+  });
+
+  test("PAI_HOOK env var matches phase name", async () => {
+    const outFile = join(tempDir, "out.txt");
+    await writeScript("phase.sh", `echo "$PAI_HOOK" > "${outFile}"`);
+
+    runLifecycleScripts({
+      installPath: tempDir,
+      scriptPaths: ["phase.sh"],
+      phase: "preuninstall",
+      quiet: true,
+    });
+
+    const out = await Bun.file(outFile).text();
+    expect(out.trim()).toBe("preuninstall");
+  });
+});


### PR DESCRIPTION
## Summary

First slice of arc#140 — the schema and execution surface that the rest of the standalone-bot install path will plug into.

- Extends `arc-manifest.yaml` with `targets`, `runtime`, `identity`, `provides.{binary,plist,systemdUnit}`, and `lifecycle.{preinstall,postinstall,preuninstall,postuninstall}` ordered arrays (per cortex `docs/design-arc-agent-bots.md` §3.2 / §4).
- Adds `runLifecycleScripts()` — the ordered runner the multi-target install dispatch (P3) and `arc remove` preuninstall path (P5) will share.
- Wires lifecycle array execution into `install()` and `installSingleArtifact()` next to the existing single-script `scripts.*` runner. Both shapes coexist; legacy runs first, lifecycle array second.
- Failure of any lifecycle script invokes the existing rollback path (arc#97).

## Schema details

| Field | Type | Purpose |
|-------|------|---------|
| \`targets\` | \`HostId[]\` | Multi-target install destinations. Validated; dispatch lands in P3. |
| \`runtime\` | \`AgentRuntime\` | type:agent only — substrate / mode / capabilities. |
| \`identity\` | \`AgentIdentity\` | type:agent only — id / did / roles / trust. Rendered into the cortex agent fragment by the future CortexHostAdapter. |
| \`provides.binary\` | \`string\` | Standalone-bot daemon binary. |
| \`provides.plist\` | \`string\` | macOS launchd plist template (rendered by darwin-launchd adapter in P2). |
| \`provides.systemdUnit\` | \`string\` | Linux systemd user unit template (P6). |
| \`lifecycle.<phase>\` | \`string[]\` | Ordered script paths. Phase ∈ {preinstall, postinstall, preuninstall, postuninstall}. |

\`HostId\` union expands with \`darwin-launchd\` and \`linux-systemd\` so \`targets:\` values are schema-validatable before the corresponding adapter ships. \`KNOWN_HOST_IDS\` is exported for runtime validation.

## Validation rules

- \`targets\` rejects: empty array, non-array, duplicates, unknown host IDs.
- \`lifecycle\` rejects: unknown phase keys (typos surface at parse, not install), non-array phase values, non-string entries, absolute paths, \`..\` segments.
- Library root manifests reject \`lifecycle:\` for the same reason they reject \`scripts:\`.

## Runner contract

\`runLifecycleScripts({ installPath, scriptPaths, phase, ... })\`:

- Walks the array in declared order via the existing \`runScript()\`.
- Halts on first non-zero exit; returns structured \`{ success, steps, failedAt }\`.
- Missing files = skip (consistent with single-script behavior).
- Empty array → success no-op.

## Install integration

\`runPreinstallPhase()\` / \`runPostinstallPhase()\` execute \`scripts.<phase>\` first, then \`lifecycle.<phase>\`. On lifecycle failure, the existing rollback (arc#97) tears down symlinks + hooks — no DB row is written.

## Tests

31 new tests, all passing:

- \`test/unit/manifest-i140.test.ts\` (19) — schema validation.
- \`test/unit/scripts-lifecycle.test.ts\` (6) — runner ordering, halt-on-failure, missing-file skip, env propagation.
- \`test/commands/install-lifecycle-i140.test.ts\` (6) — install-time wiring, legacy-then-lifecycle ordering, rollback on failure.

Full suite: 773 pass / 0 fail (was 742 / 0).

## What's NOT in this PR (subsequent slices of arc#140)

- P2: darwin-launchd HostAdapter
- P3: multi-target install dispatch driven by \`targets:\`
- P4: transactional rollback across multiple HostAdapter targets
- P5: \`arc remove\` honoring \`lifecycle.preuninstall\`
- P6: linux-systemd adapter (deferred per design doc Phase C)

## Test plan

- [x] \`bun test\` — 773 / 0
- [x] \`bun x tsc --noEmit\` — clean
- [x] Manifest validation rejects malformed lifecycle / targets shapes
- [x] Ordered execution + halt-on-failure verified
- [x] Back-compat: existing single-script \`scripts.{preinstall,postinstall}\` paths untouched

Closes arc#140 (P1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)