### PR TITLE
feat(hosts): darwin-launchd HostAdapter (arc#140 P2)

### DIFF
--- a/src/lib/hosts/darwin-launchd.ts
+++ b/src/lib/hosts/darwin-launchd.ts
@@ -1,0 +1,96 @@
+import { existsSync } from "fs";
+import { homedir, platform } from "os";
+import { join } from "path";
+import type {
+  ArtifactType,
+  DarwinLaunchdHostPaths,
+  HostAdapter,
+} from "../../types.js";
+
+/**
+ * darwin-launchd host adapter (arc#140 P2).
+ *
+ * OS-supervision host for standalone `type: agent` bot packages on macOS,
+ * per cortex `docs/design-arc-agent-bots.md` §3.2. Receives:
+ *
+ *   - `provides.binary`  → `~/bin/<binary>` (symlink to the package install)
+ *   - `provides.plist`   → `~/Library/LaunchAgents/<label>.plist` (rendered
+ *                           with token substitution, then `launchctl bootstrap`)
+ *
+ * Tools (`type: tool`) are also supported here as a convenience for
+ * platform packages that need their CLI on PATH without requiring a
+ * claude-code host (e.g. operator runbook tools on a server without
+ * `~/.claude/`). Skills / agents / prompts are not hosted by launchd —
+ * those concepts only exist in the claude-code or cortex hosts.
+ *
+ * Install/remove dispatch (rendering the plist, copying the binary,
+ * `launchctl bootstrap` / `bootout`) lands in arc#140 P3. This file is
+ * the adapter surface only: `id`, `paths`, `detect()`, `supports()`.
+ *
+ * Detection rule (intentionally simple):
+ *
+ *   1. `platform() === "darwin"` — the unit format is macOS-specific.
+ *   2. `~/Library/LaunchAgents` exists and is a directory.
+ *
+ * We do not stat `launchctl` on PATH at `detect()` time — the binary
+ * is part of base macOS and a sysadmin-stripped install is exotic enough
+ * to defer to install-time error surfacing. (Cortex does the same: it
+ * recognizes itself by file presence, not by binary on PATH.)
+ *
+ * Path semantics:
+ *
+ *   - `binDir`     → `~/bin` (shared with claude-code's binDir by
+ *                    convention — both are ultimately a single PATH-
+ *                    accessible shim directory)
+ *   - `plistDir`   → `~/Library/LaunchAgents` (extension field)
+ *   - `settingsPath` → set to `plistDir` so `host.paths.settingsPath`
+ *                      points at the directory whose presence proves the
+ *                      adapter is usable; nothing else in arc reads it
+ *                      for launchd.
+ *   - `skillsDir`, `agentsDir`, `promptsDir` are intentionally empty —
+ *     launchd is not those things' host. `supports()` declines those
+ *     artifact types directly; the empty paths are belt-and-suspenders.
+ */
+
+export interface DarwinLaunchdHostOptions {
+  /** Override `~/Library/LaunchAgents` (test isolation). */
+  plistDir?: string;
+  /** Override `~/bin` (test isolation; shared shim dir with claude-code). */
+  binDir?: string;
+  /**
+   * Override the platform check (test isolation — lets non-darwin CI
+   * still exercise the adapter's path-building and `supports()` logic).
+   */
+  forcePlatform?: NodeJS.Platform;
+}
+
+/** Build darwin-launchd host paths rooted at the given directories. */
+export function darwinLaunchdPaths(
+  opts?: DarwinLaunchdHostOptions,
+): DarwinLaunchdHostPaths {
+  const home = homedir();
+  const plistDir = opts?.plistDir ?? join(home, "Library", "LaunchAgents");
+  const binDir = opts?.binDir ?? join(home, "bin");
+  return {
+    root: plistDir,
+    skillsDir: "",
+    agentsDir: "",
+    promptsDir: "",
+    binDir,
+    settingsPath: plistDir,
+    plistDir,
+  };
+}
+
+export function createDarwinLaunchdHost(
+  opts?: DarwinLaunchdHostOptions,
+): HostAdapter & { paths: DarwinLaunchdHostPaths } {
+  const paths = darwinLaunchdPaths(opts);
+  const onDarwin = (opts?.forcePlatform ?? platform()) === "darwin";
+  return {
+    id: "darwin-launchd",
+    paths,
+    detect: () => onDarwin && existsSync(paths.plistDir),
+    supports: (type: ArtifactType) => type === "agent" || type === "tool",
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,6 +623,30 @@ export interface CortexPaths {
 export type CortexHostPaths = HostPaths & CortexPaths;
 
 /**
+ * darwin-launchd-host-only path extensions. Standalone-bot daemons land
+ * their plist into the user's `~/Library/LaunchAgents/` directory; arc
+ * uses `plistDir` instead of overloading the base `settingsPath` because
+ * the plist directory is a *collection*, not a single config file. The
+ * binary lands in the base `binDir` field.
+ *
+ * Same pattern as `CortexPaths` — not promoted to `HostPaths` because no
+ * other adapter has a comparable concept (cortex's `personasDir`,
+ * `credsDir`; launchd's `plistDir`).
+ *
+ * See cortex `docs/design-arc-agent-bots.md` §3.2 and arc#140 P2.
+ */
+export interface LaunchdPaths {
+  /** macOS user LaunchAgents directory (~/Library/LaunchAgents/). */
+  plistDir: string;
+}
+
+/**
+ * darwin-launchd host's concrete `paths` shape. Use this when you've
+ * already narrowed `host.id === "darwin-launchd"`.
+ */
+export type DarwinLaunchdHostPaths = HostPaths & LaunchdPaths;
+
+/**
  * Host adapter — describes one agentic backend (Claude Code, Codex CLI, Cursor, …).
  *
  * Phase 1 (this PR): interface + Claude-Code default implementation. No dispatch yet.

--- a/test/unit/darwin-launchd-host.test.ts
+++ b/test/unit/darwin-launchd-host.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the darwin-launchd HostAdapter (arc#140 P2).
+ *
+ * Adapter surface only — install/remove dispatch lands in arc#140 P3.
+ * Verifies:
+ *   - id is "darwin-launchd"
+ *   - paths build correctly from defaults and from overrides
+ *   - detect() honors platform + plist directory presence
+ *   - supports() recognizes agent + tool, declines skill/prompt/etc.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  createDarwinLaunchdHost,
+  darwinLaunchdPaths,
+} from "../../src/lib/hosts/darwin-launchd.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-launchd-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("darwin-launchd HostAdapter", () => {
+  test("id is 'darwin-launchd'", () => {
+    const host = createDarwinLaunchdHost({ forcePlatform: "darwin" });
+    expect(host.id).toBe("darwin-launchd");
+  });
+
+  test("default paths reference ~/Library/LaunchAgents and ~/bin", () => {
+    const paths = darwinLaunchdPaths();
+    expect(paths.plistDir).toMatch(/Library\/LaunchAgents$/);
+    expect(paths.binDir).toMatch(/\/bin$/);
+    expect(paths.settingsPath).toBe(paths.plistDir);
+    expect(paths.root).toBe(paths.plistDir);
+  });
+
+  test("non-host directories (skills/agents/prompts) are empty strings", () => {
+    const paths = darwinLaunchdPaths();
+    expect(paths.skillsDir).toBe("");
+    expect(paths.agentsDir).toBe("");
+    expect(paths.promptsDir).toBe("");
+  });
+
+  test("paths can be overridden for test isolation", () => {
+    const plistDir = join(tempDir, "LaunchAgents");
+    const binDir = join(tempDir, "bin");
+    const paths = darwinLaunchdPaths({ plistDir, binDir });
+    expect(paths.plistDir).toBe(plistDir);
+    expect(paths.binDir).toBe(binDir);
+    expect(paths.settingsPath).toBe(plistDir);
+  });
+
+  test("detect() returns true on darwin when plistDir exists", async () => {
+    const plistDir = join(tempDir, "LaunchAgents");
+    await mkdir(plistDir, { recursive: true });
+    const host = createDarwinLaunchdHost({
+      plistDir,
+      binDir: join(tempDir, "bin"),
+      forcePlatform: "darwin",
+    });
+    expect(host.detect()).toBe(true);
+  });
+
+  test("detect() returns false when plistDir does not exist", () => {
+    const host = createDarwinLaunchdHost({
+      plistDir: join(tempDir, "missing-LaunchAgents"),
+      binDir: join(tempDir, "bin"),
+      forcePlatform: "darwin",
+    });
+    expect(host.detect()).toBe(false);
+  });
+
+  test("detect() returns false on non-darwin platforms even when plistDir exists", async () => {
+    const plistDir = join(tempDir, "LaunchAgents");
+    await mkdir(plistDir, { recursive: true });
+    const host = createDarwinLaunchdHost({
+      plistDir,
+      binDir: join(tempDir, "bin"),
+      forcePlatform: "linux",
+    });
+    expect(host.detect()).toBe(false);
+  });
+
+  test("supports() accepts agent and tool artifact types", () => {
+    const host = createDarwinLaunchdHost({ forcePlatform: "darwin" });
+    expect(host.supports("agent")).toBe(true);
+    expect(host.supports("tool")).toBe(true);
+  });
+
+  test("supports() declines artifact types launchd does not host", () => {
+    const host = createDarwinLaunchdHost({ forcePlatform: "darwin" });
+    expect(host.supports("skill")).toBe(false);
+    expect(host.supports("prompt")).toBe(false);
+    expect(host.supports("component")).toBe(false);
+    expect(host.supports("rules")).toBe(false);
+    expect(host.supports("library")).toBe(false);
+    expect(host.supports("pipeline")).toBe(false);
+    expect(host.supports("action")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of arc#140 — the OS-supervision host adapter for standalone `type: agent` bot packages on macOS (per cortex `docs/design-arc-agent-bots.md` §3.2).

**Stacked on top of PR #141 (P1)** — merges into `feat/i-140-launchd-lifecycle` for now; will rebase onto `main` once P1 lands.

## What's in this PR

- \`src/lib/hosts/darwin-launchd.ts\` — adapter surface (\`id\`, \`paths\`, \`detect()\`, \`supports()\`).
- \`LaunchdPaths { plistDir }\` + \`DarwinLaunchdHostPaths\` intersection type, mirroring the \`CortexPaths\` extension pattern.
- \`forcePlatform\` constructor option so non-darwin CI can exercise the adapter's logic.

## Path semantics

| Field | Value |
|-------|-------|
| \`binDir\` | \`~/bin\` (shared shim dir with claude-code — both PATH-accessible) |
| \`plistDir\` | \`~/Library/LaunchAgents\` (extension field) |
| \`settingsPath\` | mirrored to \`plistDir\` so detection's presence check works through the base interface |
| \`skillsDir\`, \`agentsDir\`, \`promptsDir\` | empty strings (launchd doesn't host those concepts) |

## supports()

Accepts \`agent\` and \`tool\`. Declines everything else (skill / prompt / component / rules / library / pipeline / action).

## Detection rule

\`platform() === "darwin"\` AND \`~/Library/LaunchAgents\` exists. \`launchctl\` on PATH is not checked — base-macOS binary, exotic to remove. Mirrors the CortexHostAdapter's file-presence detection approach.

## What's NOT in this PR

P2 ships the **adapter surface only**. Install/remove dispatch — rendering the plist with token substitution, copying \`provides.binary\` into \`~/bin\`, \`launchctl bootstrap\`/\`bootout\` — lands in arc#140 P3.

## Tests

9 new tests, all passing. Full suite: 783 pass / 0 fail.

## Test plan

- [x] \`bun test test/unit/darwin-launchd-host.test.ts\` — 9 / 0
- [x] Full suite — 783 / 0
- [x] \`bun x tsc --noEmit\` — clean
- [x] \`detect()\` correctly false on non-darwin via \`forcePlatform\`
- [x] Paths overridable for test isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)