### PR TITLE
feat(remove): multi-target uninstall + lifecycle.preuninstall (arc#140 P5)

### DIFF
--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -2,19 +2,26 @@ import { join } from "path";
 import { rm, lstat, readlink, unlink } from "fs/promises";
 import { homedir } from "os";
 import type { Database } from "bun:sqlite";
-import type { ArcPaths, HostAdapter } from "../types.js";
+import type {
+  ArcManifest,
+  ArcPaths,
+  DarwinLaunchdHostPaths,
+  HostAdapter,
+  HostId,
+} from "../types.js";
 import { getSkill, removeSkill, listByLibrary } from "../lib/db.js";
 import { removeSymlink, removeCliShim, extractAllCliInfo } from "../lib/symlinks.js";
 import { readManifest } from "../lib/manifest.js";
 import { removeHooks, hasHooks } from "../lib/hooks.js";
 import { findGitRoot } from "../lib/paths.js";
 import { unwireExtensions } from "../lib/extensions.js";
-import { runScript } from "../lib/scripts.js";
-
-export interface RemoveOptions {
-  /** Suppress interactive prompts / informational output (for non-interactive / test use). */
-  yes?: boolean;
-}
+import { runLifecycleScripts, runScript } from "../lib/scripts.js";
+import {
+  type HostOverrides,
+  orderTargetsForInstall,
+  resolveHost,
+} from "../lib/hosts/registry.js";
+import { removeLaunchdArtifacts } from "../lib/hosts/launchd-install.js";
 
 export interface RemoveResult {
   success: boolean;
@@ -23,57 +30,264 @@ export interface RemoveResult {
   removedCount?: number;
 }
 
+export interface RemoveOptions {
+  /** Suppress interactive prompts / informational output (arc#138). */
+  yes?: boolean;
+  /**
+   * Suppress console output (for non-interactive / test use). Passed
+   * through to lifecycle script runs.
+   */
+  quiet?: boolean;
+  /**
+   * Per-host adapter overrides for multi-target removes (arc#140 P5).
+   * Mirrors `InstallOptions.hostOverrides`.
+   */
+  hostOverrides?: HostOverrides;
+}
+
+/**
+ * Run the preuninstall phase (arc#140 P5): `scripts.preuninstall` (single
+ * script) first, then `lifecycle.preuninstall` (ordered array). The arc#140
+ * design (cortex `docs/design-arc-agent-bots.md` §8.3) requires
+ * preuninstall scripts to fire BEFORE any symlinks are removed — typical
+ * sequence is launchctl unload → drain → signal cortex reload, all of
+ * which need the agent fragment + binary still on disk.
+ *
+ * Symmetric to runPreinstallPhase / runPostinstallPhase in install.ts.
+ * On any script failure the function returns the error string; caller
+ * decides whether to abort the uninstall. Per the design doc's
+ * D7 ("abort-on-revoke-failure"), arc remove aborts to avoid leaving
+ * phantom state — the operator can investigate and retry.
+ */
+function runPreuninstallPhase(
+  installPath: string,
+  manifest: ArcManifest | null,
+  quiet?: boolean,
+): { success: true } | { success: false; error: string } {
+  if (!manifest) return { success: true };
+
+  const lifecycle = manifest.lifecycle?.preuninstall;
+  if (lifecycle && lifecycle.length > 0) {
+    const result = runLifecycleScripts({
+      installPath,
+      scriptPaths: lifecycle,
+      phase: "preuninstall",
+      quiet,
+    });
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Preuninstall lifecycle script failed: ${result.failedAt} (exit ${result.steps.at(-1)?.exitCode ?? "?"})`,
+      };
+    }
+  }
+
+  return { success: true };
+}
+
+/**
+ * Run the postuninstall phase (arc#140 P5): `lifecycle.postuninstall`
+ * (ordered array). Fires AFTER symlinks + plist + binary are removed,
+ * so it's safe for scripts that signal cortex to re-read agents.d/
+ * (which is now empty of this bot).
+ *
+ * Failures in postuninstall do NOT roll the uninstall back (the
+ * artifacts are already gone) — they're surfaced to the operator
+ * as warnings.
+ */
+function runPostuninstallPhase(
+  installPath: string,
+  manifest: ArcManifest | null,
+  quiet?: boolean,
+): { success: true } | { success: false; error: string } {
+  if (!manifest) return { success: true };
+
+  const lifecycle = manifest.lifecycle?.postuninstall;
+  if (lifecycle && lifecycle.length > 0) {
+    const result = runLifecycleScripts({
+      installPath,
+      scriptPaths: lifecycle,
+      phase: "postuninstall",
+      quiet,
+    });
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Postuninstall lifecycle script failed: ${result.failedAt} (exit ${result.steps.at(-1)?.exitCode ?? "?"})`,
+      };
+    }
+  }
+
+  return { success: true };
+}
+
+/**
+ * Multi-target uninstall walk (arc#140 P5).
+ *
+ * Reverses the install ordering: supervision hosts (darwin-launchd,
+ * linux-systemd) FIRST so the daemon stops and releases its NATS
+ * connection BEFORE the registry-side fragment is removed (per cortex
+ * `docs/design-arc-agent-bots.md` §8.3 "revoke creds BEFORE removing
+ * files").
+ *
+ * For each target:
+ *   - darwin-launchd → removeLaunchdArtifacts (plist + binary symlink)
+ *   - cortex / claude-code → remove the type-appropriate artifact
+ *     symlink from that host's directory
+ *
+ * Errors are best-effort: a missing artifact on one target does not
+ * abort the others. Non-ENOENT errors surface via console.warn.
+ */
+async function removePerTarget(opts: {
+  targets: HostId[];
+  manifest: ArcManifest;
+  packageName: string;
+  hostOverrides?: HostOverrides;
+  quiet?: boolean;
+}): Promise<void> {
+  const reverseOrder = [...orderTargetsForInstall(opts.targets)].reverse();
+
+  for (const targetId of reverseOrder) {
+    const targetHost = resolveHost(targetId, opts.hostOverrides);
+
+    if (targetId === "darwin-launchd") {
+      await removeLaunchdArtifacts({
+        host: targetHost as HostAdapter & { paths: DarwinLaunchdHostPaths },
+        manifest: opts.manifest,
+        quiet: opts.quiet,
+      });
+      continue;
+    }
+
+    // registry hosts (cortex, claude-code): unlink the type-conventional
+    // artifact symlink from this host's directory. Same per-type dispatch
+    // as the single-host path below — factored so the inline reuses it.
+    await removeArtifactFromHost(
+      opts.manifest.type,
+      opts.packageName,
+      targetHost,
+    );
+
+    // provides.files (e.g. cortex's <name>.md fragment) — unlink each
+    // declared target path.
+    for (const f of opts.manifest.provides?.files ?? []) {
+      const home = process.env.HOME ?? "";
+      const target = f.target.replace(/^~/, home);
+      await removeSymlink(target);
+    }
+  }
+}
+
+/**
+ * Remove the type-conventional artifact symlink from one host adapter.
+ *
+ * Pulled out of the legacy single-host remove path so both that path
+ * and {@link removePerTarget} share the same per-type unlink logic.
+ */
+async function removeArtifactFromHost(
+  type: ArcManifest["type"],
+  name: string,
+  host: HostAdapter,
+): Promise<void> {
+  switch (type) {
+    case "agent": {
+      const mdLink = join(host.paths.agentsDir, `${name}.md`);
+      const dirLink = join(host.paths.agentsDir, name);
+      if (!(await removeSymlink(mdLink))) {
+        await removeSymlink(dirLink);
+      }
+      return;
+    }
+    case "prompt": {
+      const mdLink = join(host.paths.promptsDir, `${name}.md`);
+      const dirLink = join(host.paths.promptsDir, name);
+      if (!(await removeSymlink(mdLink))) {
+        await removeSymlink(dirLink);
+      }
+      return;
+    }
+    case "tool": {
+      const binLink = join(host.paths.binDir, name);
+      await removeSymlink(binLink);
+      return;
+    }
+    case "skill":
+    case "system":
+    case "component":
+    case "rules":
+    case "library":
+    case "pipeline":
+    default: {
+      const skillLink = join(host.paths.skillsDir, name);
+      await removeSymlink(skillLink);
+      return;
+    }
+  }
+}
+
 /**
  * Completely remove an installed skill.
  *
  * Mirrors `install` in reverse:
- *  1. Fire `scripts.preremove` (if declared) so the package can stop daemons
- *     and clean up host-side state (launchd plists, etc.) BEFORE its repo +
- *     symlinks are torn down. See arc#138.
- *  2. Tear down primary symlink (skill/agent/tool/...) and CLI shims.
- *  3. Remove hooks from settings.json and unwire extensions.
- *  4. Reverse-iterate `provides.files` and unlink each target IFF it is a
- *     symlink pointing at the source we installed (hand-edited files are
- *     left in place with a warning).
- *  5. Delete the DB row and the cloned repo directory.
+ *  1. Fire `scripts.preremove` (if declared, arc#138) so the package can
+ *     stop daemons and clean up host-side state BEFORE its repo + symlinks
+ *     are torn down. Failures here warn but do not abort.
+ *  2. arc#140 P5: run `lifecycle.preuninstall` array (in declared order).
+ *     The bot's daemon needs the binary + creds in place to drain/unload.
+ *     Per design doc §10.1 D7, a failure here ABORTS the remove (phantom
+ *     state is worse than refusing the operation).
+ *  3. For packages declaring `targets:` (standalone-bot agents): walk each
+ *     target's artifacts in REVERSE install order (supervision hosts FIRST,
+ *     registry hosts LAST).
+ *  4. Otherwise: tear down primary symlink (skill/agent/tool/…).
+ *  5. CLI shims, hooks, extensions cleanup.
+ *  6. Reverse-iterate `provides.files` and unlink each target IFF it is a
+ *     symlink pointing at the source we installed (arc#138 safety).
+ *  7. Delete the DB row.
+ *  8. arc#140 P5: run `lifecycle.postuninstall` array. Failures warn only.
+ *  9. Delete the cloned repo directory.
  */
 export async function remove(
   db: Database,
   arc: ArcPaths,
   host: HostAdapter,
   name: string,
-  opts: RemoveOptions = {}
+  opts: RemoveOptions = {},
 ): Promise<RemoveResult> {
   const skill = getSkill(db, name);
   if (!skill) {
     return { success: false, error: `Skill '${name}' is not installed` };
   }
 
-  // Read manifest up-front. Needed for preremove firing, provides.files
-  // cleanup, CLI shim names, and hooks teardown. Best-effort: if the manifest
-  // is unreadable (corrupted clone, manual rm -rf, etc.) we fall through with
-  // a null manifest and skip the manifest-driven cleanup steps — the DB row
-  // and primary symlink will still be removed.
+  // Read manifest up-front. Needed for preremove firing, lifecycle scripts,
+  // provides.files cleanup, CLI shim names, and hooks teardown. Best-effort:
+  // if the manifest is unreadable (corrupted clone, manual rm -rf), fall
+  // through with a null manifest — DB row and primary symlink still removed.
   const manifest = await readManifest(skill.install_path).catch(() => null);
 
-  // 1. Fire preremove script BEFORE anything is torn down. Same shape as
-  //    preinstall/preupgrade — gives the package a chance to stop daemons,
-  //    unload launchd plists, etc. while its files and symlinks still exist.
-  //    Missing script falls through silently via runScript's skipped path.
+  // 1. Fire scripts.preremove (arc#138) — non-aborting on failure.
   if (manifest?.scripts?.preremove) {
     const preResult = runScript({
       installPath: skill.install_path,
       scriptPath: manifest.scripts.preremove,
       hookName: "preremove",
-      quiet: opts.yes,
+      quiet: opts.yes || opts.quiet,
     });
     if (!preResult.success && !preResult.skipped) {
-      // Do NOT abort: a failing preremove (e.g. daemon already stopped) must
-      // not block the user from finishing the cleanup. Warn loudly instead.
       console.warn(
         `  ⚠ preremove script exited ${preResult.exitCode}; continuing remove anyway`,
       );
     }
+  }
+
+  // 2. arc#140 P5: lifecycle.preuninstall array — ABORTS on failure (D7).
+  const preuninstallResult = runPreuninstallPhase(
+    skill.install_path,
+    manifest,
+    opts.quiet ?? opts.yes,
+  );
+  if (!preuninstallResult.success) {
+    return { success: false, error: preuninstallResult.error };
   }
 
   const isTool = skill.artifact_type === "tool";
@@ -82,7 +296,17 @@ export async function remove(
   const isPipeline = skill.artifact_type === "pipeline";
   const isAction = skill.artifact_type === "action";
 
-  if (isAction) {
+  // Multi-target path (arc#140 P5): walk targets in reverse install order.
+  // No-op when manifest is missing (we still try to clean DB/repo below).
+  if (manifest && manifest.targets && manifest.targets.length > 0) {
+    await removePerTarget({
+      targets: manifest.targets,
+      manifest,
+      packageName: name,
+      hostOverrides: opts?.hostOverrides,
+      quiet: opts?.quiet,
+    });
+  } else if (isAction) {
     // Actions: remove action symlink
     const actionLink = join(arc.actionsDir, name);
     await removeSymlink(actionLink);
@@ -159,6 +383,21 @@ export async function remove(
 
   // Remove from database (CASCADE deletes capabilities) — before repo removal
   removeSkill(db, name);
+
+  // arc#140 P5: run postuninstall lifecycle scripts AFTER artifacts are gone
+  // — typical use is to signal cortex reload so the AgentRegistry rebuilds
+  // without this agent. Failures here are surfaced as warnings (the
+  // uninstall itself already succeeded; the artifacts are no longer on disk).
+  if (manifest) {
+    const postuninstallResult = runPostuninstallPhase(
+      skill.install_path,
+      manifest,
+      opts?.quiet,
+    );
+    if (!postuninstallResult.success && !opts?.quiet) {
+      console.warn(`  ⚠ ${postuninstallResult.error}`);
+    }
+  }
 
   // Remove repo directory — but NOT if other library artifacts still reference it
   if (skill.library_name) {

--- a/src/lib/hosts/launchd-install.ts
+++ b/src/lib/hosts/launchd-install.ts
@@ -156,6 +156,69 @@ export async function installLaunchdArtifacts(opts: {
 }
 
 /**
+ * Reverse the launchd-side install at uninstall time (arc#140 P5).
+ *
+ * Symmetric to {@link installLaunchdArtifacts}: removes the binary
+ * symlink from `host.binDir` and the rendered plist from `host.plistDir`.
+ * Does NOT invoke `launchctl bootout` — that side effect lives in the
+ * bot's own `lifecycle.preuninstall` array, which arc runs BEFORE this
+ * function fires.
+ *
+ * Best-effort across both artifacts: ENOENT on either path is swallowed
+ * (idempotent removal), non-ENOENT errors surface via console.warn so
+ * the user sees orphans they need to inspect manually.
+ *
+ * Returns the paths actually removed (for caller-side diagnostics /
+ * test assertions). Empty fields mean "already gone or never declared".
+ */
+export async function removeLaunchdArtifacts(opts: {
+  host: HostAdapter & { paths: DarwinLaunchdHostPaths };
+  manifest: ArcManifest;
+  quiet?: boolean;
+}): Promise<LaunchdInstallRecord> {
+  const removed: LaunchdInstallRecord = {};
+  const provides = opts.manifest.provides ?? {};
+
+  if (provides.binary) {
+    const binName = provides.binary.split("/").pop()!;
+    const binLinkPath = join(opts.host.paths.binDir, binName);
+    try {
+      await unlink(binLinkPath);
+      removed.binSymlink = binLinkPath;
+      if (!opts.quiet) {
+        console.log(`  ✓ Binary unlinked: ${binLinkPath}`);
+      }
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        console.warn(
+          `  ⚠ remove: failed to unlink launchd binary ${binLinkPath}: ${err?.message ?? err}`,
+        );
+      }
+    }
+  }
+
+  if (provides.plist) {
+    const plistName = provides.plist.split("/").pop()!;
+    const plistPath = join(opts.host.paths.plistDir, plistName);
+    try {
+      await unlink(plistPath);
+      removed.plistPath = plistPath;
+      if (!opts.quiet) {
+        console.log(`  ✓ Plist removed: ${plistPath}`);
+      }
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        console.warn(
+          `  ⚠ remove: failed to unlink launchd plist ${plistPath}: ${err?.message ?? err}`,
+        );
+      }
+    }
+  }
+
+  return removed;
+}
+
+/**
  * Reverse {@link installLaunchdArtifacts}.
  *
  * Best-effort across both artifacts: an ENOENT on one path doesn't

--- a/test/commands/remove-multitarget-i140.test.ts
+++ b/test/commands/remove-multitarget-i140.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for arc#140 P5: arc remove honors lifecycle.preuninstall +
+ * multi-target uninstall ordering (supervision hosts FIRST, registry LAST).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync } from "fs";
+import { mkdir, writeFile, chmod, readFile } from "fs/promises";
+import { join } from "path";
+import {
+  createTestEnv,
+  type TestEnv,
+} from "../helpers/test-env.js";
+import { install } from "../../src/commands/install.js";
+import { remove } from "../../src/commands/remove.js";
+import { getSkill } from "../../src/lib/db.js";
+
+let env: TestEnv;
+let cortexRoot: string;
+let launchdPlistDir: string;
+let launchdBinDir: string;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  cortexRoot = join(env.root, ".config", "cortex");
+  launchdPlistDir = join(env.root, "Library", "LaunchAgents");
+  launchdBinDir = join(env.root, "bin");
+  await mkdir(join(cortexRoot, "agents.d"), { recursive: true });
+  await mkdir(launchdPlistDir, { recursive: true });
+  await mkdir(launchdBinDir, { recursive: true });
+  await writeFile(join(cortexRoot, "cortex.yaml"), "# fake cortex.yaml\n");
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+const hostOverrides = () => ({
+  cortex: {
+    configRoot: cortexRoot,
+    credsRoot: join(env.root, ".config", "nats", "creds"),
+  },
+  "darwin-launchd": {
+    plistDir: launchdPlistDir,
+    binDir: launchdBinDir,
+    forcePlatform: "darwin" as const,
+  },
+});
+
+async function makeStandaloneBotRepo(opts: {
+  name: string;
+  lifecycle?: {
+    preuninstall?: Array<{ path: string; content: string }>;
+    postuninstall?: Array<{ path: string; content: string }>;
+  };
+}): Promise<{ url: string }> {
+  const repoDir = join(env.root, `mock-${opts.name}`);
+  await mkdir(repoDir, { recursive: true });
+  await writeFile(
+    join(repoDir, `${opts.name}.md`),
+    `---\nname: ${opts.name}\n---\n# ${opts.name}\n`,
+  );
+  await mkdir(join(repoDir, "bin"), { recursive: true });
+  await writeFile(join(repoDir, "bin", opts.name), `#!/bin/bash\n`);
+  await chmod(join(repoDir, "bin", opts.name), 0o755);
+  await mkdir(join(repoDir, "services"), { recursive: true });
+  await writeFile(
+    join(repoDir, "services", `ai.meta-factory.${opts.name}.plist`),
+    `<plist></plist>`,
+  );
+
+  if (opts.lifecycle) {
+    for (const phase of Object.values(opts.lifecycle)) {
+      if (!phase) continue;
+      for (const s of phase) {
+        const p = join(repoDir, s.path);
+        await mkdir(join(p, ".."), { recursive: true });
+        await writeFile(p, s.content);
+        await chmod(p, 0o755);
+      }
+    }
+  }
+
+  const lifecycleYaml = opts.lifecycle
+    ? `lifecycle:
+${Object.entries(opts.lifecycle)
+  .filter(([, arr]) => arr && arr.length > 0)
+  .map(([phase, arr]) => `  ${phase}:\n${arr!.map((s) => `    - ${s.path}`).join("\n")}`)
+  .join("\n")}
+`
+    : "";
+
+  await writeFile(
+    join(repoDir, "arc-manifest.yaml"),
+    `name: ${opts.name}
+version: 0.1.0
+type: agent
+tier: custom
+targets: [cortex, darwin-launchd]
+identity:
+  id: ${opts.name}
+  roles: [agent-restricted]
+runtime:
+  substrate: custom-binary
+  mode: standalone
+provides:
+  files:
+    - source: ${opts.name}.md
+      target: ~/.config/cortex/agents.d/${opts.name}.md
+  binary: bin/${opts.name}
+  plist: services/ai.meta-factory.${opts.name}.plist
+${lifecycleYaml}`,
+  );
+
+  Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
+    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+  );
+  return { url: repoDir };
+}
+
+async function installBot(name: string, lifecycle?: any) {
+  const repo = await makeStandaloneBotRepo({ name, lifecycle });
+  // Override env HOME so provides.files (~/.config/...) lands inside env.root
+  // — without this, sage-shape installs leak into the developer's real ~/.
+  const originalHome = process.env.HOME;
+  process.env.HOME = env.root;
+  try {
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+      hostOverrides: hostOverrides(),
+    });
+    return result;
+  } finally {
+    process.env.HOME = originalHome;
+  }
+}
+
+async function removeBot(name: string) {
+  const originalHome = process.env.HOME;
+  process.env.HOME = env.root;
+  try {
+    return await remove(env.db, env.arc, env.host, name, {
+      quiet: true,
+      hostOverrides: hostOverrides(),
+    });
+  } finally {
+    process.env.HOME = originalHome;
+  }
+}
+
+describe("remove: multi-target uninstall", () => {
+  test("multi-target remove unlinks cortex fragment + launchd binary + plist", async () => {
+    await installBot("alpha-bot");
+
+    // Verify installed
+    const cortexLink = join(cortexRoot, "agents.d", "alpha-bot.md");
+    const binLink = join(launchdBinDir, "alpha-bot");
+    const plistPath = join(launchdPlistDir, "ai.meta-factory.alpha-bot.plist");
+    expect(existsSync(cortexLink)).toBe(true);
+    expect(existsSync(binLink)).toBe(true);
+    expect(existsSync(plistPath)).toBe(true);
+
+    const result = await removeBot("alpha-bot");
+    expect(result.success).toBe(true);
+
+    expect(existsSync(cortexLink)).toBe(false);
+    expect(existsSync(binLink)).toBe(false);
+    expect(existsSync(plistPath)).toBe(false);
+    expect(getSkill(env.db, "alpha-bot")).toBeNull();
+  });
+
+  test("lifecycle.preuninstall runs in declared order BEFORE artifacts are removed", async () => {
+    const logPath = join(env.root, "preuninstall-log.txt");
+    const checkPath = join(env.root, "preuninstall-saw.txt");
+    await installBot("beta-bot", {
+      preuninstall: [
+        {
+          path: "scripts/01-stop.sh",
+          content: `#!/bin/bash
+echo "stop" >> "${logPath}"
+# Capture cortex fragment + launchd plist presence at preuninstall time —
+# the design contract says both must still be on disk.
+[ -e "${join(cortexRoot, "agents.d", "beta-bot.md")}" ] && echo "cortex=present" >> "${checkPath}"
+[ -e "${join(launchdPlistDir, "ai.meta-factory.beta-bot.plist")}" ] && echo "plist=present" >> "${checkPath}"
+`,
+        },
+        {
+          path: "scripts/02-drain.sh",
+          content: `#!/bin/bash\necho "drain" >> "${logPath}"\n`,
+        },
+        {
+          path: "scripts/03-signal.sh",
+          content: `#!/bin/bash\necho "signal" >> "${logPath}"\n`,
+        },
+      ],
+    });
+
+    const result = await removeBot("beta-bot");
+    expect(result.success).toBe(true);
+
+    const log = await readFile(logPath, "utf-8");
+    expect(log).toBe("stop\ndrain\nsignal\n");
+    const check = await readFile(checkPath, "utf-8");
+    expect(check).toContain("cortex=present");
+    expect(check).toContain("plist=present");
+  });
+
+  test("lifecycle.preuninstall failure aborts remove; artifacts stay on disk", async () => {
+    await installBot("gamma-bot", {
+      preuninstall: [
+        { path: "scripts/ok.sh", content: `#!/bin/bash\nexit 0\n` },
+        { path: "scripts/fail.sh", content: `#!/bin/bash\nexit 5\n` },
+      ],
+    });
+
+    const result = await removeBot("gamma-bot");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Preuninstall lifecycle script failed.*scripts\/fail\.sh/);
+
+    // Artifacts remain
+    expect(existsSync(join(cortexRoot, "agents.d", "gamma-bot.md"))).toBe(true);
+    expect(existsSync(join(launchdBinDir, "gamma-bot"))).toBe(true);
+    expect(existsSync(join(launchdPlistDir, "ai.meta-factory.gamma-bot.plist"))).toBe(true);
+
+    // DB row remains
+    expect(getSkill(env.db, "gamma-bot")).not.toBeNull();
+  });
+
+  test("supervision target unlinks BEFORE registry target (reverse install order)", async () => {
+    const orderPath = join(env.root, "remove-order.txt");
+    await installBot("delta-bot", {
+      preuninstall: [
+        {
+          path: "scripts/probe.sh",
+          content: `#!/bin/bash
+# At preuninstall time everything is still in place — record initial state.
+echo "preuninstall: cortex=$([ -e "${join(cortexRoot, "agents.d", "delta-bot.md")}" ] && echo yes || echo no) plist=$([ -e "${join(launchdPlistDir, "ai.meta-factory.delta-bot.plist")}" ] && echo yes || echo no)" >> "${orderPath}"
+`,
+        },
+      ],
+      postuninstall: [
+        {
+          path: "scripts/probe-after.sh",
+          content: `#!/bin/bash
+echo "postuninstall: cortex=$([ -e "${join(cortexRoot, "agents.d", "delta-bot.md")}" ] && echo yes || echo no) plist=$([ -e "${join(launchdPlistDir, "ai.meta-factory.delta-bot.plist")}" ] && echo yes || echo no)" >> "${orderPath}"
+`,
+        },
+      ],
+    });
+
+    await removeBot("delta-bot");
+    const log = await readFile(orderPath, "utf-8");
+    expect(log).toContain("preuninstall: cortex=yes plist=yes");
+    expect(log).toContain("postuninstall: cortex=no plist=no");
+  });
+
+  test("lifecycle.postuninstall runs AFTER artifacts are removed", async () => {
+    const seenPath = join(env.root, "post-saw.txt");
+    await installBot("epsilon-bot", {
+      postuninstall: [
+        {
+          path: "scripts/check-gone.sh",
+          content: `#!/bin/bash
+# Cortex fragment must already be gone by the time this runs.
+if [ ! -e "${join(cortexRoot, "agents.d", "epsilon-bot.md")}" ]; then
+  echo "gone" > "${seenPath}"
+fi
+`,
+        },
+      ],
+    });
+
+    const result = await removeBot("epsilon-bot");
+    expect(result.success).toBe(true);
+    expect(existsSync(seenPath)).toBe(true);
+    const seen = await readFile(seenPath, "utf-8");
+    expect(seen.trim()).toBe("gone");
+  });
+
+  test("legacy single-target remove path unaffected (regression check)", async () => {
+    // type:skill, no targets → existing path
+    const repoDir = join(env.root, "mock-legacy");
+    await mkdir(join(repoDir, "skill"), { recursive: true });
+    await writeFile(join(repoDir, "skill", "SKILL.md"), `---\nname: LegacySkill\n---\n`);
+    await writeFile(
+      join(repoDir, "arc-manifest.yaml"),
+      `name: LegacySkill
+version: 1.0.0
+type: skill
+tier: custom
+provides:
+  skill: [{ trigger: legacyskill }]
+capabilities:
+  filesystem: { read: [], write: [] }
+  network: []
+  bash: { allowed: false }
+  secrets: []
+`,
+    );
+    Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repoDir, yes: true });
+    expect(existsSync(join(env.host.paths.skillsDir, "LegacySkill"))).toBe(true);
+
+    const result = await remove(env.db, env.arc, env.host, "LegacySkill", { quiet: true });
+    expect(result.success).toBe(true);
+    expect(existsSync(join(env.host.paths.skillsDir, "LegacySkill"))).toBe(false);
+    expect(getSkill(env.db, "LegacySkill")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fifth slice of arc#140 — \`arc remove\` now executes \`lifecycle.preuninstall\` scripts in declared order BEFORE any artifact is removed, walks multi-target packages in REVERSE install order, and removes the launchd-side plist + binary symlink alongside the cortex-side agent fragment.

Closes the end-to-end install/remove loop for standalone \`type: agent\` bot packages per cortex \`docs/design-arc-agent-bots.md\` §8.3.

**Stacked:** Base = \`feat/i-140-p3-multitarget\` (PR #143).

## Uninstall ordering invariant

1. \`lifecycle.preuninstall\` scripts (in declared order) — bot's stop-daemon.sh, drain-tasks.sh, signal-cortex-reload.sh run while everything is still on disk
2. supervision hosts (darwin-launchd) artifacts — plist + binary symlink unlinked
3. registry hosts (cortex, claude-code) artifacts — agent fragment + persona symlinks unlinked
4. hook + extension cleanup (existing)
5. DB row removed
6. \`lifecycle.postuninstall\` scripts (in declared order) — runs AFTER fragment is gone
7. repo directory removed

## D7 abort-on-failure

Per design doc §10.1 D7 — phantom state is worse than refusing the operation. \`lifecycle.preuninstall\` failure aborts the remove with the offending script in the error message; the operator can investigate and retry. \`lifecycle.postuninstall\` failures are warnings (artifacts are already gone — uninstall succeeded).

## New / changed code

- \`src/commands/remove.ts\`:
  - \`RemoveOptions { quiet, hostOverrides }\`
  - \`runPreuninstallPhase\` / \`runPostuninstallPhase\`
  - \`removePerTarget\` walks reverse install order
  - \`removeArtifactFromHost\` extracted from legacy path so both paths share per-type unlink dispatch
- \`src/lib/hosts/launchd-install.ts\`:
  - \`removeLaunchdArtifacts\` (symmetric to \`installLaunchdArtifacts\`). Does NOT invoke \`launchctl bootout\` — that belongs in the bot's \`lifecycle.preuninstall\` per the design

## Tests

6 new tests verifying:
- cortex fragment + launchd binary + plist all unlinked
- \`lifecycle.preuninstall\` runs in declared order BEFORE any artifact removed (probe scripts capture initial state)
- preuninstall failure aborts; artifacts + DB row stay
- ordering: at preuninstall both still present; at postuninstall both gone
- \`lifecycle.postuninstall\` runs AFTER artifacts removed
- legacy single-target remove unaffected (regression)

Full suite: 818 pass / 0 fail (was 812).

## Test plan

- [x] \`bun test test/commands/remove-multitarget-i140.test.ts\` — 6 / 0
- [x] Full suite — 818 / 0
- [x] \`bun x tsc --noEmit\` — clean
- [x] arc#140 acceptance: \`arc remove\` executes \`lifecycle.preuninstall\` scripts in declared order before any symlinks are removed ✓
- [x] arc#140 acceptance: darwin-launchd plist + binary unlinked ✓
- [x] arc#140 acceptance: reverse-order ✓
- [x] arc#140 acceptance: legacy paths preserved ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)