### PR TITLE
feat(hosts): linux-systemd adapter + sage P3 review fixes (arc#140 P6)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.25.0
+version: 0.26.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -4,7 +4,6 @@ import type {
   ArcPaths,
   ArcManifest,
   ArtifactType,
-  DarwinLaunchdHostPaths,
   HostAdapter,
   HostId,
   PackageTier,
@@ -38,6 +37,7 @@ import {
   installLaunchdArtifacts,
   rollbackLaunchdArtifacts,
 } from "../lib/hosts/launchd-install.js";
+import { isDarwinLaunchdHost } from "../lib/hosts/darwin-launchd.js";
 
 export interface InstallOptions {
   /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
@@ -760,9 +760,19 @@ async function installPerTarget(opts: {
     }
 
     if (targetId === "darwin-launchd") {
+      // Sage P3 review (arc#143): type guard replaces a blanket `as` cast
+      // so a future refactor that drops the plistDir extension surfaces
+      // here instead of at runtime when host.paths.plistDir is undefined.
+      if (!isDarwinLaunchdHost(targetHost)) {
+        await rollbackAll();
+        return {
+          error:
+            `Internal error: 'darwin-launchd' resolved to a host adapter without launchd paths`,
+        };
+      }
       try {
         const rec = await installLaunchdArtifacts({
-          host: targetHost as HostAdapter & { paths: DarwinLaunchdHostPaths },
+          host: targetHost,
           manifest: opts.manifest,
           installDir: opts.installPath,
           quiet: opts.quiet,
@@ -775,6 +785,22 @@ async function installPerTarget(opts: {
         };
       }
       continue;
+    }
+
+    if (targetId === "linux-systemd") {
+      // arc#140 P6: the adapter surface exists so `targets: [..., linux-systemd]`
+      // manifests parse cleanly, but rendering the systemd unit + binary
+      // install lands "once the first Linux host enters the deployment
+      // topology" per cortex `docs/design-arc-agent-bots.md` §3.2 / §11
+      // Phase C.3. Fail clearly so an operator on macOS doesn't see a
+      // silent half-install when a manifest happens to declare both
+      // darwin-launchd AND linux-systemd targets.
+      await rollbackAll();
+      return {
+        error:
+          `Target 'linux-systemd' is recognized but its install dispatch is not yet implemented (arc#140 Phase C). ` +
+          `Install on macOS, or wait for the linux-systemd install path to land.`,
+      };
     }
 
     // registry hosts (cortex, claude-code) take the existing symlink path

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -5,7 +5,6 @@ import type { Database } from "bun:sqlite";
 import type {
   ArcManifest,
   ArcPaths,
-  DarwinLaunchdHostPaths,
   HostAdapter,
   HostId,
 } from "../types.js";
@@ -22,6 +21,7 @@ import {
   resolveHost,
 } from "../lib/hosts/registry.js";
 import { removeLaunchdArtifacts } from "../lib/hosts/launchd-install.js";
+import { isDarwinLaunchdHost } from "../lib/hosts/darwin-launchd.js";
 
 export interface RemoveResult {
   success: boolean;
@@ -151,11 +151,32 @@ async function removePerTarget(opts: {
     const targetHost = resolveHost(targetId, opts.hostOverrides);
 
     if (targetId === "darwin-launchd") {
+      // Sage P3 review (arc#143): type guard instead of blanket cast.
+      if (!isDarwinLaunchdHost(targetHost)) {
+        if (!opts.quiet) {
+          console.warn(
+            `  ⚠ Skipping darwin-launchd remove: adapter did not expose plistDir`,
+          );
+        }
+        continue;
+      }
       await removeLaunchdArtifacts({
-        host: targetHost as HostAdapter & { paths: DarwinLaunchdHostPaths },
+        host: targetHost,
         manifest: opts.manifest,
         quiet: opts.quiet,
       });
+      continue;
+    }
+
+    if (targetId === "linux-systemd") {
+      // arc#140 P6: matched install-side behavior — the adapter exists
+      // but remove dispatch isn't yet wired. Skip with a warning rather
+      // than aborting; the operator can clean up manually.
+      if (!opts.quiet) {
+        console.warn(
+          `  ⚠ Skipping linux-systemd remove: dispatch not yet implemented (arc#140 Phase C)`,
+        );
+      }
       continue;
     }
 

--- a/src/lib/hosts/darwin-launchd.ts
+++ b/src/lib/hosts/darwin-launchd.ts
@@ -94,3 +94,21 @@ export function createDarwinLaunchdHost(
     supports: (type: ArtifactType) => type === "agent" || type === "tool",
   };
 }
+
+/**
+ * Type guard for the darwin-launchd host's narrowed paths shape.
+ *
+ * Use this in multi-target dispatch instead of a blanket `as` cast —
+ * if `createDarwinLaunchdHost()` is ever refactored to drop the
+ * `plistDir` extension, this guard fails fast at runtime with a clear
+ * message instead of letting a downstream `.paths.plistDir` access
+ * surface as `undefined`. Sage P3 review (arc#143).
+ */
+export function isDarwinLaunchdHost(
+  host: HostAdapter,
+): host is HostAdapter & { paths: DarwinLaunchdHostPaths } {
+  return (
+    host.id === "darwin-launchd" &&
+    typeof (host.paths as Partial<DarwinLaunchdHostPaths>).plistDir === "string"
+  );
+}

--- a/src/lib/hosts/launchd-install.ts
+++ b/src/lib/hosts/launchd-install.ts
@@ -58,9 +58,14 @@ export function buildLaunchdTokens(opts: {
  * is preserved verbatim in the output. This lets a bot package use
  * custom markers that its own lifecycle script resolves before
  * `launchctl bootstrap`.
+ *
+ * The marker grammar accepts `[A-Za-z0-9_-]+` so hyphenated token names
+ * (e.g. `{{LOG-DIR}}`, `{{ai-meta-factory}}`) substitute too. Sage P3
+ * review (arc#143): the original `\w` class silently passed hyphenated
+ * markers through unsubstituted even when present in the tokens map.
  */
 export function renderPlist(template: string, tokens: LaunchdTokens): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+  return template.replace(/\{\{([A-Za-z0-9_-]+)\}\}/g, (match, key: string) => {
     return key in tokens ? tokens[key]! : match;
   });
 }

--- a/src/lib/hosts/linux-systemd.ts
+++ b/src/lib/hosts/linux-systemd.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "fs";
+import { homedir, platform } from "os";
+import { join } from "path";
+import type {
+  ArtifactType,
+  HostAdapter,
+  LinuxSystemdHostPaths,
+} from "../../types.js";
+
+/**
+ * linux-systemd host adapter (arc#140 P6).
+ *
+ * Sister to the darwin-launchd HostAdapter; the OS-supervision host for
+ * standalone `type: agent` bot packages on Linux. Per cortex
+ * `docs/design-arc-agent-bots.md` §3.2 platform note: "On Linux the
+ * equivalent is systemd user units (`systemctl --user` +
+ * `~/.config/systemd/user/`). The bot's `arc-manifest.yaml` declares
+ * OS-specific `provides` entries (`provides.plist` for darwin,
+ * `provides.systemdUnit` for linux), and arc renders + loads the
+ * appropriate one."
+ *
+ * Detection rule:
+ *   1. `platform() === "linux"`.
+ *   2. `~/.config/systemd/user` either exists already or its parent
+ *      (`~/.config/systemd`) is writable. `systemctl --user`
+ *      auto-creates the user dir on first unit registration, so absence
+ *      is not a hard "this host doesn't exist" — but we still gate on
+ *      the parent so a stripped container without systemd registers as
+ *      undetected.
+ *
+ * Install/remove dispatch (rendering `provides.systemdUnit`, copying
+ * `provides.binary`, `systemctl --user enable --now`) is NOT in this
+ * PR — landing the adapter surface unblocks `targets: [..., linux-systemd]`
+ * manifests from rejecting at parse, and the install dispatch for systemd
+ * will follow once the first Linux host enters the deployment topology
+ * (per design doc §11 Phase C.3, also noted in P6).
+ *
+ * `supports()` matches darwin-launchd (`agent` + `tool`).
+ */
+
+export interface LinuxSystemdHostOptions {
+  /** Override `~/.config/systemd/user` (test isolation). */
+  unitDir?: string;
+  /** Override `~/bin` (test isolation; shared shim dir). */
+  binDir?: string;
+  /**
+   * Override the platform check. Lets non-linux CI exercise the
+   * adapter's path-building and `supports()` logic without skipping
+   * the file.
+   */
+  forcePlatform?: NodeJS.Platform;
+}
+
+/** Build linux-systemd host paths rooted at the given directories. */
+export function linuxSystemdPaths(
+  opts?: LinuxSystemdHostOptions,
+): LinuxSystemdHostPaths {
+  const home = homedir();
+  const unitDir = opts?.unitDir ?? join(home, ".config", "systemd", "user");
+  const binDir = opts?.binDir ?? join(home, "bin");
+  return {
+    root: unitDir,
+    skillsDir: "",
+    agentsDir: "",
+    promptsDir: "",
+    binDir,
+    settingsPath: unitDir,
+    unitDir,
+  };
+}
+
+export function createLinuxSystemdHost(
+  opts?: LinuxSystemdHostOptions,
+): HostAdapter & { paths: LinuxSystemdHostPaths } {
+  const paths = linuxSystemdPaths(opts);
+  const onLinux = (opts?.forcePlatform ?? platform()) === "linux";
+  return {
+    id: "linux-systemd",
+    paths,
+    detect: () => onLinux && existsSync(paths.unitDir),
+    supports: (type: ArtifactType) => type === "agent" || type === "tool",
+  };
+}

--- a/src/lib/hosts/linux-systemd.ts
+++ b/src/lib/hosts/linux-systemd.ts
@@ -19,14 +19,17 @@ import type {
  * `provides.systemdUnit` for linux), and arc renders + loads the
  * appropriate one."
  *
- * Detection rule:
+ * Detection rule (matches darwin-launchd's file-presence approach):
  *   1. `platform() === "linux"`.
- *   2. `~/.config/systemd/user` either exists already or its parent
- *      (`~/.config/systemd`) is writable. `systemctl --user`
- *      auto-creates the user dir on first unit registration, so absence
- *      is not a hard "this host doesn't exist" — but we still gate on
- *      the parent so a stripped container without systemd registers as
- *      undetected.
+ *   2. `~/.config/systemd/user` exists.
+ *
+ * A user who has run `systemctl --user` at least once will have this
+ * directory present. A stripped container without systemd auto-fails
+ * the second check and registers as undetected. We do not stat
+ * `systemctl` on PATH for the same reason darwin-launchd skips
+ * `launchctl` — the binary is part of the base systemd install, and a
+ * sysadmin-stripped layout is exotic enough to defer to install-time
+ * error surfacing.
  *
  * Install/remove dispatch (rendering `provides.systemdUnit`, copying
  * `provides.binary`, `systemctl --user enable --now`) is NOT in this

--- a/src/lib/hosts/registry.ts
+++ b/src/lib/hosts/registry.ts
@@ -2,6 +2,7 @@ import type { HostAdapter, HostId } from "../../types.js";
 import { createClaudeCodeHost } from "./claude-code.js";
 import { createCortexHost } from "./cortex.js";
 import { createDarwinLaunchdHost } from "./darwin-launchd.js";
+import { createLinuxSystemdHost } from "./linux-systemd.js";
 
 /**
  * Per-host adapter constructor overrides (test isolation).
@@ -17,6 +18,11 @@ export interface HostOverrides {
   cortex?: { configRoot?: string; credsRoot?: string };
   "darwin-launchd"?: {
     plistDir?: string;
+    binDir?: string;
+    forcePlatform?: NodeJS.Platform;
+  };
+  "linux-systemd"?: {
+    unitDir?: string;
     binDir?: string;
     forcePlatform?: NodeJS.Platform;
   };
@@ -45,10 +51,7 @@ export function resolveHost(
     case "darwin-launchd":
       return createDarwinLaunchdHost(overrides?.["darwin-launchd"]);
     case "linux-systemd":
-      throw new Error(
-        `Host adapter 'linux-systemd' is not yet implemented (arc#140 Phase C). ` +
-          `Manifests declaring this target cannot be installed today; install on macOS or wait for the adapter to land.`,
-      );
+      return createLinuxSystemdHost(overrides?.["linux-systemd"]);
     default: {
       const exhaustive: never = id;
       throw new Error(`Unknown host id: ${exhaustive as string}`);
@@ -80,6 +83,15 @@ export function categorizeHost(id: HostId): HostCategory {
     case "darwin-launchd":
     case "linux-systemd":
       return "supervision";
+    default: {
+      // arc#143 review (sage): exhaustiveness guard matching resolveHost().
+      // Adding a new HostId without updating this switch surfaces a
+      // compile error; without this case it would silently default to
+      // the "supervision" bucket (the else leg of orderTargetsForInstall),
+      // violating the install-order invariant with no diagnostic.
+      const exhaustive: never = id;
+      throw new Error(`Unhandled HostId in categorizeHost: ${exhaustive as string}`);
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -647,6 +647,25 @@ export interface LaunchdPaths {
 export type DarwinLaunchdHostPaths = HostPaths & LaunchdPaths;
 
 /**
+ * linux-systemd-host-only path extensions. Sister to LaunchdPaths for the
+ * macOS / Linux OS-supervision split. Standalone-bot daemons land their
+ * unit file into the user-scope systemd directory (`~/.config/systemd/user/`).
+ *
+ * See cortex `docs/design-arc-agent-bots.md` §3.2 platform note and
+ * arc#140 P6.
+ */
+export interface SystemdPaths {
+  /** Linux user systemd directory (~/.config/systemd/user/). */
+  unitDir: string;
+}
+
+/**
+ * linux-systemd host's concrete `paths` shape. Use this when you've
+ * already narrowed `host.id === "linux-systemd"`.
+ */
+export type LinuxSystemdHostPaths = HostPaths & SystemdPaths;
+
+/**
  * Host adapter — describes one agentic backend (Claude Code, Codex CLI, Cursor, …).
  *
  * Phase 1 (this PR): interface + Claude-Code default implementation. No dispatch yet.

--- a/test/unit/host-registry.test.ts
+++ b/test/unit/host-registry.test.ts
@@ -27,8 +27,11 @@ describe("resolveHost", () => {
     expect(host.id).toBe("darwin-launchd");
   });
 
-  test("rejects linux-systemd (not yet implemented)", () => {
-    expect(() => resolveHost("linux-systemd")).toThrow(/not yet implemented/);
+  test("resolves linux-systemd (P6 — install dispatch follows in Phase C)", () => {
+    const host = resolveHost("linux-systemd", {
+      "linux-systemd": { forcePlatform: "linux" },
+    });
+    expect(host.id).toBe("linux-systemd");
   });
 
   test("threads overrides into the adapter", () => {

--- a/test/unit/linux-systemd-host.test.ts
+++ b/test/unit/linux-systemd-host.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the linux-systemd HostAdapter (arc#140 P6).
+ *
+ * Adapter surface only — install/remove dispatch lands "once the first
+ * Linux host enters the deployment topology" per cortex
+ * `docs/design-arc-agent-bots.md` §11 Phase C.3.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  createLinuxSystemdHost,
+  linuxSystemdPaths,
+} from "../../src/lib/hosts/linux-systemd.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-systemd-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("linux-systemd HostAdapter", () => {
+  test("id is 'linux-systemd'", () => {
+    const host = createLinuxSystemdHost({ forcePlatform: "linux" });
+    expect(host.id).toBe("linux-systemd");
+  });
+
+  test("default paths reference ~/.config/systemd/user and ~/bin", () => {
+    const paths = linuxSystemdPaths();
+    expect(paths.unitDir).toMatch(/\.config\/systemd\/user$/);
+    expect(paths.binDir).toMatch(/\/bin$/);
+    expect(paths.settingsPath).toBe(paths.unitDir);
+    expect(paths.root).toBe(paths.unitDir);
+  });
+
+  test("non-host directories (skills/agents/prompts) are empty strings", () => {
+    const paths = linuxSystemdPaths();
+    expect(paths.skillsDir).toBe("");
+    expect(paths.agentsDir).toBe("");
+    expect(paths.promptsDir).toBe("");
+  });
+
+  test("paths can be overridden for test isolation", () => {
+    const unitDir = join(tempDir, "systemd-user");
+    const binDir = join(tempDir, "bin");
+    const paths = linuxSystemdPaths({ unitDir, binDir });
+    expect(paths.unitDir).toBe(unitDir);
+    expect(paths.binDir).toBe(binDir);
+  });
+
+  test("detect() returns true on linux when unitDir exists", async () => {
+    const unitDir = join(tempDir, "systemd-user");
+    await mkdir(unitDir, { recursive: true });
+    const host = createLinuxSystemdHost({
+      unitDir, binDir: join(tempDir, "bin"), forcePlatform: "linux",
+    });
+    expect(host.detect()).toBe(true);
+  });
+
+  test("detect() returns false when unitDir does not exist", () => {
+    const host = createLinuxSystemdHost({
+      unitDir: join(tempDir, "missing"), binDir: join(tempDir, "bin"), forcePlatform: "linux",
+    });
+    expect(host.detect()).toBe(false);
+  });
+
+  test("detect() returns false on non-linux platforms even when unitDir exists", async () => {
+    const unitDir = join(tempDir, "systemd-user");
+    await mkdir(unitDir, { recursive: true });
+    const host = createLinuxSystemdHost({
+      unitDir, binDir: join(tempDir, "bin"), forcePlatform: "darwin",
+    });
+    expect(host.detect()).toBe(false);
+  });
+
+  test("supports() accepts agent and tool artifact types", () => {
+    const host = createLinuxSystemdHost({ forcePlatform: "linux" });
+    expect(host.supports("agent")).toBe(true);
+    expect(host.supports("tool")).toBe(true);
+  });
+
+  test("supports() declines artifact types systemd does not host", () => {
+    const host = createLinuxSystemdHost({ forcePlatform: "linux" });
+    expect(host.supports("skill")).toBe(false);
+    expect(host.supports("prompt")).toBe(false);
+    expect(host.supports("component")).toBe(false);
+  });
+});

--- a/test/unit/sage-review-fixes.test.ts
+++ b/test/unit/sage-review-fixes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression tests for sage P3 review findings (arc#143).
+ *
+ * Three findings:
+ *   1. (important) categorizeHost lacks exhaustiveness check
+ *   2. (important) installPerTarget uses unsafe `as` cast for darwin-launchd
+ *   3. (suggestion) renderPlist regex doesn't match hyphenated tokens
+ *
+ * Each finding gets a positive test (verify the new behavior) plus the
+ * regression scenario where applicable.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { renderPlist } from "../../src/lib/hosts/launchd-install.js";
+import { isDarwinLaunchdHost, createDarwinLaunchdHost } from "../../src/lib/hosts/darwin-launchd.js";
+import { createCortexHost } from "../../src/lib/hosts/cortex.js";
+
+describe("sage review #1 — categorizeHost exhaustiveness guard", () => {
+  // Compile-time: adding a HostId to the union without adding a case to
+  // categorizeHost surfaces as a `never` mismatch (verified by `bun x tsc --noEmit`).
+  // Runtime test: passing an unknown value at the type-erased boundary throws.
+  test("unknown HostId throws at runtime", async () => {
+    const { categorizeHost } = await import("../../src/lib/hosts/registry.js");
+    expect(() => categorizeHost("totally-unknown" as any)).toThrow(/Unhandled HostId/);
+  });
+});
+
+describe("sage review #2 — isDarwinLaunchdHost type guard", () => {
+  test("returns true for a real darwin-launchd host", () => {
+    const host = createDarwinLaunchdHost({ forcePlatform: "darwin" });
+    expect(isDarwinLaunchdHost(host)).toBe(true);
+  });
+
+  test("returns false for a cortex host (different id)", () => {
+    const host = createCortexHost();
+    expect(isDarwinLaunchdHost(host)).toBe(false);
+  });
+
+  test("returns false when id matches but plistDir is missing", () => {
+    const synthetic = {
+      id: "darwin-launchd" as const,
+      paths: {
+        root: "", skillsDir: "", agentsDir: "", promptsDir: "", binDir: "",
+        settingsPath: "",
+        // plistDir intentionally absent — simulates a future refactor mistake
+      } as any,
+      detect: () => false,
+      supports: () => false,
+    };
+    expect(isDarwinLaunchdHost(synthetic as any)).toBe(false);
+  });
+});
+
+describe("sage review #3 — renderPlist supports hyphenated tokens", () => {
+  test("hyphenated token in template + tokens map substitutes", () => {
+    const out = renderPlist("X={{MY-TOKEN}}", { "MY-TOKEN": "ok" });
+    expect(out).toBe("X=ok");
+  });
+
+  test("hyphenated token not in map passes through verbatim", () => {
+    const out = renderPlist("X={{MY-TOKEN}}", { OTHER: "x" });
+    expect(out).toBe("X={{MY-TOKEN}}");
+  });
+
+  test("mixed underscore and hyphen tokens both work", () => {
+    const out = renderPlist("{{NATS_URL}} and {{ai-meta-factory}}", {
+      NATS_URL: "nats://x",
+      "ai-meta-factory": "yes",
+    });
+    expect(out).toBe("nats://x and yes");
+  });
+});


### PR DESCRIPTION
## Summary

Final slice of arc#140 — ships the \`linux-systemd\` sibling HostAdapter (per cortex \`docs/design-arc-agent-bots.md\` §3.2 platform note) AND incorporates the three findings from sage's P3 code review (2 important + 1 suggestion).

**Stacked:** Base = \`feat/i-140-p5-remove\` (PR #144).

## linux-systemd HostAdapter

| Field | Value |
|-------|-------|
| \`unitDir\` | \`~/.config/systemd/user\` (extension field) |
| \`binDir\` | \`~/bin\` (shared shim dir) |
| \`detect()\` | \`platform() === "linux"\` + \`unitDir\` exists |
| \`supports()\` | \`agent\` + \`tool\` |

\`resolveHost("linux-systemd")\` now returns the adapter instead of throwing. Install/remove dispatch handles it explicitly:

- **install**: aborts with "dispatch not yet implemented (arc#140 Phase C)" so a mixed-target install on macOS doesn't half-land state
- **remove**: skips with a warning

Full render + \`systemctl --user enable\` lands once the first Linux host enters the deployment topology (design doc §11 Phase C.3).

## Sage P3 review fixes (arc#143)

| Severity | Finding | Fix |
|----------|---------|-----|
| important | \`categorizeHost\` lacked exhaustiveness check | Added \`default: { const exhaustive: never = id; throw ... }\` matching the \`resolveHost\` pattern |
| important | \`installPerTarget\` used blanket \`as\` cast on \`resolveHost("darwin-launchd")\` | New \`isDarwinLaunchdHost()\` type guard in \`darwin-launchd.ts\`; both install and remove call sites use it |
| suggestion | \`renderPlist\` regex used \`\w\` — hyphenated tokens never substituted | Broadened to \`[A-Za-z0-9_-]+\` |

## Tests

16 new:
- \`test/unit/linux-systemd-host.test.ts\` (9): id, paths, overrides, detect, supports
- \`test/unit/sage-review-fixes.test.ts\` (7): exhaustiveness throw, type guard positive/negative, hyphenated tokens
- Updated \`host-registry.test.ts\`: linux-systemd no longer rejected

Full suite: 834 pass / 0 fail (was 818).

## What this completes

| Acceptance criterion (arc#140) | Status |
|-------------------------------|--------|
| arc install of type:agent + standalone + targets:[cortex, darwin-launchd] runs lifecycle.postinstall in declared order | ✓ (P1 + P3) |
| darwin-launchd HostAdapter renders provides.plist + installs provides.binary | ✓ (P2 + P3) |
| arc remove runs lifecycle.preuninstall scripts in declared order before symlinks removed; unloads launchd unit | ✓ (P5) |
| Multi-target install transactional | ✓ (P3) |
| linux-systemd sibling | ✓ adapter surface (P6); full dispatch deferred to Phase C.3 |
| Sage installs end-to-end with single arc install | ✓ (P1-P5 chain) |

## Out of scope

- Linux-systemd install dispatch (render + \`systemctl --user enable\`) — Phase C.3
- Sage e2e smoke test — needs a running sage daemon registered with cortex, which IS what this PR-chain enables. Promote to a manual operator smoke in the issue closure note.

**Closes arc#140.**

## Test plan

- [x] \`bun test\` — 834 / 0
- [x] \`bun x tsc --noEmit\` — clean
- [x] Sage P3 review's 3 findings have regression tests
- [x] linux-systemd adapter detect/supports cover platform + unitDir presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)