### PR TITLE
chore(eslint): enable strict ESLint with typescript-eslint preset

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,17 @@ export default tseslint.config(
       // Mirrors myelin#123.
       "@typescript-eslint/no-confusing-void-expression": "off",
       "@typescript-eslint/await-thenable": "off",
+      // Tests routinely defensive-check values that the production
+      // types claim are non-nullable, because mocks structurally
+      // typed against an interface may not honor the type's promise.
+      // `expect(maybeX).toBeDefined()` and similar guards are
+      // intentional in test code. Mirrors myelin#124.
+      "@typescript-eslint/no-unnecessary-condition": "off",
+      // Empty mock methods that satisfy an interface contract without
+      // behavior (e.g., `close() {}` on a test transport) are routine
+      // in tests. Production stubs (6 sites today) get inline disables
+      // or per-file banners. Mirrors myelin#125.
+      "@typescript-eslint/no-empty-function": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,117 @@
+// @ts-check
+import tseslint from "typescript-eslint";
+import eslint from "@eslint/js";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // ── Strict (error): type-safety bugs we genuinely want to gate on ──
+      //
+      // These rules catch real bugs (un-awaited promises, missing branches,
+      // wrong + on non-numerics). Violations fail lint.
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/no-deprecated": "error",
+      "@typescript-eslint/no-redundant-type-constituents": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+
+      // ── Demoted to warn (existing-code sweep deferred) ────────────
+      //
+      // Real concerns but high cost to fix in this PR. Surface in IDE +
+      // lint output, don't gate. Tighten in subsequent focused PRs.
+      "@typescript-eslint/restrict-plus-operands": "warn",
+      "no-useless-escape": "warn",
+      "no-useless-assignment": "warn",
+      "no-control-regex": "warn",
+      "@typescript-eslint/no-require-imports": "warn",
+      "preserve-caught-error": "warn",
+
+      // ── Warn: stylistic / preference rules with high pre-existing
+      //         violation counts. Surface in IDE + lint output, don't
+      //         gate the build. Tightened in subsequent PRs after a
+      //         dedicated cleanup pass per rule.
+      //
+      //   require-await ........ 94 → many `async` fns without await
+      //                           (often for future-proofing the signature)
+      //   no-unnecessary-condition .. 63 → existsSync()-then-act idioms
+      //   await-thenable ....... 26 → Bun.write returns Promise but lint
+      //                           cannot prove it from generics
+      //   no-empty-function ..... 25 → catch blocks with `{}` (intentional swallow)
+      //   no-non-null-assertion . 23 → `result.files!` after success-narrow
+      //   prefer-nullish-coalescing  8 → idiomatic `||` for string defaults
+      //   no-explicit-any ...... infra layers that bridge untyped surfaces
+      //   no-unsafe-* .......... Bun.spawnSync / process / yaml-parsed
+      //                           dynamic data flows through these
+      "@typescript-eslint/require-await": "warn",
+      "@typescript-eslint/no-unnecessary-condition": "warn",
+      "@typescript-eslint/await-thenable": "warn",
+      "@typescript-eslint/no-empty-function": "warn",
+      "@typescript-eslint/no-non-null-assertion": "warn",
+      "@typescript-eslint/prefer-nullish-coalescing": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-unsafe-call": "warn",
+      "@typescript-eslint/no-unsafe-argument": "warn",
+      "@typescript-eslint/no-unsafe-return": "warn",
+      "@typescript-eslint/no-base-to-string": "warn",
+      "@typescript-eslint/restrict-template-expressions": "warn",
+      "@typescript-eslint/return-await": "warn",
+      "@typescript-eslint/no-unused-expressions": "warn",
+      // Commander-style fluent chains pass method references as args
+      // (`.option(handler)`); the rule mis-reads them as `this`-rebinding
+      // hazards. Real binding issues still surface via test failures.
+      "@typescript-eslint/unbound-method": "warn",
+      // catch (err: unknown) is the modern idiom but a lot of CLI error
+      // paths predate it. Warn so it surfaces; tighten in a sweep PR.
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
+      // Bun-flavored idioms.
+      "@typescript-eslint/no-confusing-void-expression": "off",
+    },
+  },
+  {
+    // Test files: looser rules — tests intentionally exercise edge cases
+    // (any-typed mocks, unsafe casts for failure injection).
+    files: ["test/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/no-misused-promises": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-deprecated": "off",
+    },
+  },
+  {
+    // Files outside the typed-project scope (scripts/, eslint.config.js,
+    // etc.). The strict project-service rules need a tsconfig "include"
+    // entry to type-check; ignoring is cleaner than expanding include
+    // for one-off scripts.
+    ignores: [
+      "dist/",
+      "node_modules/",
+      "vendor/",
+      "**/*.bak.ts",
+      "eslint.config.js",
+      "scripts/",
+    ],
+  },
+);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,7 +73,7 @@ export default tseslint.config(
       "@typescript-eslint/no-empty-function": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/prefer-nullish-coalescing": "error",
-      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",
       "@typescript-eslint/no-unsafe-call": "warn",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,10 @@ export default tseslint.config(
       "no-useless-assignment": "warn",
       "no-control-regex": "warn",
       "@typescript-eslint/no-require-imports": "warn",
-      "preserve-caught-error": "warn",
+      // Mirrors myelin#127. `throw new Error(msg)` from a catch block
+      // should pass `{ cause: err }` to preserve the underlying exception
+      // chain for debuggability.
+      "preserve-caught-error": "error",
 
       // ── Warn: stylistic / preference rules with high pre-existing
       //         violation counts. Surface in IDE + lint output, don't
@@ -92,9 +95,10 @@ export default tseslint.config(
       // (`.option(handler)`); the rule mis-reads them as `this`-rebinding
       // hazards. Real binding issues still surface via test failures.
       "@typescript-eslint/unbound-method": "warn",
-      // catch (err: unknown) is the modern idiom but a lot of CLI error
-      // paths predate it. Warn so it surfaces; tighten in a sweep PR.
-      "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
+      // Mirrors myelin#127. `.catch((err: unknown) => …)` is the safe
+      // idiom; bare `(err)` defaults to implicit `any`. All 2 arc sites
+      // were already _err stubs; just type-annotated.
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
       // Same bun-test idiom as await-thenable. Off in tests (override
       // below), error at src so a real `.forEach(() => doThing())`
       // where doThing returns void still gets caught when callers

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,7 +94,11 @@ export default tseslint.config(
       // Commander-style fluent chains pass method references as args
       // (`.option(handler)`); the rule mis-reads them as `this`-rebinding
       // hazards. Real binding issues still surface via test failures.
-      "@typescript-eslint/unbound-method": "warn",
+      // 100% test-file noise today (mock helpers like `mock(fs.readFile)`
+      // pass bound methods to `mock()`; rule reads them as `this`-leaks).
+      // Off in tests, error in src so future commander-handler patterns
+      // are flagged for explicit `.bind(this)` or arrow-function wrap.
+      "@typescript-eslint/unbound-method": "error",
       // Mirrors myelin#127. `.catch((err: unknown) => …)` is the safe
       // idiom; bare `(err)` defaults to implicit `any`. All 2 arc sites
       // were already _err stubs; just type-annotated.
@@ -148,6 +152,10 @@ export default tseslint.config(
       // in tests. Production stubs (6 sites today) get inline disables
       // or per-file banners. Mirrors myelin#125.
       "@typescript-eslint/no-empty-function": "off",
+      // Mock helpers pass bound class methods (`mock(fs.readFile)`,
+      // `spyOn(obj, "method")`); the rule mis-reads them as `this`
+      // hazards. Real `this`-binding bugs surface as test failures.
+      "@typescript-eslint/unbound-method": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,7 +71,7 @@ export default tseslint.config(
       // myelin#123.
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-empty-function": "error",
-      "@typescript-eslint/no-non-null-assertion": "warn",
+      "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,7 +60,13 @@ export default tseslint.config(
       // gate the build.
       "@typescript-eslint/require-await": "error",
       "@typescript-eslint/no-unnecessary-condition": "warn",
-      "@typescript-eslint/await-thenable": "warn",
+      // 100% test-file noise from bun-test's
+      // `await expect(promise).rejects.toThrow(...)` matcher idiom.
+      // The matcher chain returns void; the rule reads it as awaiting
+      // a non-thenable. Off in tests (override below), error at src
+      // so genuine "awaiting a sync value" bugs get caught. Mirrors
+      // myelin#123.
+      "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-empty-function": "warn",
       "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/prefer-nullish-coalescing": "warn",
@@ -89,8 +95,11 @@ export default tseslint.config(
       // catch (err: unknown) is the modern idiom but a lot of CLI error
       // paths predate it. Warn so it surfaces; tighten in a sweep PR.
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
-      // Bun-flavored idioms.
-      "@typescript-eslint/no-confusing-void-expression": "off",
+      // Same bun-test idiom as await-thenable. Off in tests (override
+      // below), error at src so a real `.forEach(() => doThing())`
+      // where doThing returns void still gets caught when callers
+      // expect a return value.
+      "@typescript-eslint/no-confusing-void-expression": "error",
     },
   },
   {
@@ -118,6 +127,12 @@ export default tseslint.config(
       // has zero require-await sites today; this override only affects
       // tests.
       "@typescript-eslint/require-await": "off",
+      // Bun-test's `await expect(promise).rejects.toThrow(...)` idiom
+      // returns void from the matcher chain. Both rules fire as false
+      // positives on every assert of that shape across the suite.
+      // Mirrors myelin#123.
+      "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/await-thenable": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,35 +34,23 @@ export default tseslint.config(
       "@typescript-eslint/restrict-plus-operands": "error",
       "no-useless-escape": "error",
       "no-useless-assignment": "error",
-      "no-control-regex": "warn",
+      "no-control-regex": "error",
       "@typescript-eslint/no-require-imports": "error",
       // Mirrors myelin#127. `throw new Error(msg)` from a catch block
       // should pass `{ cause: err }` to preserve the underlying exception
       // chain for debuggability.
       "preserve-caught-error": "error",
 
-      // ── Warn: stylistic / preference rules with high pre-existing
-      //         violation counts. Surface in IDE + lint output, don't
-      //         gate the build. Tightened in subsequent PRs after a
-      //         dedicated cleanup pass per rule.
+      // All previously-warn rules promoted to error after dedicated
+      // cleanup sweeps. Test files keep targeted overrides (see below)
+      // for idioms that are noise in tests but signal in production.
       //
-      //   require-await ........ 94 → many `async` fns without await
-      //                           (often for future-proofing the signature)
-      //   no-unnecessary-condition .. 63 → existsSync()-then-act idioms
-      //   await-thenable ....... 26 → Bun.write returns Promise but lint
-      //                           cannot prove it from generics
-      //   no-empty-function ..... 25 → catch blocks with `{}` (intentional swallow)
-      //   no-non-null-assertion . 23 → `result.files!` after success-narrow
-      //   prefer-nullish-coalescing  → 0 (promoted to error)
-      //   no-explicit-any ...... infra layers that bridge untyped surfaces
-      //   no-unsafe-* .......... Bun.spawnSync / process / yaml-parsed
-      //                           dynamic data flows through these
       // Production code has zero require-await sites — myelin#121's
       // pattern: turn off in tests (adapter mocks have async signatures
       // without I/O), promote to error elsewhere so new src violations
       // gate the build.
       "@typescript-eslint/require-await": "error",
-      "@typescript-eslint/no-unnecessary-condition": "warn",
+      "@typescript-eslint/no-unnecessary-condition": "error",
       // 100% test-file noise from bun-test's
       // `await expect(promise).rejects.toThrow(...)` matcher idiom.
       // The matcher chain returns void; the rule reads it as awaiting
@@ -74,11 +62,11 @@ export default tseslint.config(
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/no-unsafe-assignment": "warn",
-      "@typescript-eslint/no-unsafe-member-access": "warn",
-      "@typescript-eslint/no-unsafe-call": "warn",
-      "@typescript-eslint/no-unsafe-argument": "warn",
-      "@typescript-eslint/no-unsafe-return": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
       "@typescript-eslint/no-base-to-string": "error",
       // Number / boolean interpolation in template literals is
       // universally understood — `Found ${count} matches` reads

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,11 +31,11 @@ export default tseslint.config(
       //
       // Real concerns but high cost to fix in this PR. Surface in IDE +
       // lint output, don't gate. Tighten in subsequent focused PRs.
-      "@typescript-eslint/restrict-plus-operands": "warn",
-      "no-useless-escape": "warn",
-      "no-useless-assignment": "warn",
+      "@typescript-eslint/restrict-plus-operands": "error",
+      "no-useless-escape": "error",
+      "no-useless-assignment": "error",
       "no-control-regex": "warn",
-      "@typescript-eslint/no-require-imports": "warn",
+      "@typescript-eslint/no-require-imports": "error",
       // Mirrors myelin#127. `throw new Error(msg)` from a catch block
       // should pass `{ cause: err }` to preserve the underlying exception
       // chain for debuggability.
@@ -70,7 +70,7 @@ export default tseslint.config(
       // so genuine "awaiting a sync value" bugs get caught. Mirrors
       // myelin#123.
       "@typescript-eslint/await-thenable": "error",
-      "@typescript-eslint/no-empty-function": "warn",
+      "@typescript-eslint/no-empty-function": "error",
       "@typescript-eslint/no-non-null-assertion": "warn",
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/no-explicit-any": "warn",
@@ -79,7 +79,7 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-call": "warn",
       "@typescript-eslint/no-unsafe-argument": "warn",
       "@typescript-eslint/no-unsafe-return": "warn",
-      "@typescript-eslint/no-base-to-string": "warn",
+      "@typescript-eslint/no-base-to-string": "error",
       // Number / boolean interpolation in template literals is
       // universally understood — `Found ${count} matches` reads
       // cleanly. The rule still fires on `unknown`, `never`, `any`,
@@ -89,8 +89,8 @@ export default tseslint.config(
         "error",
         { allowNumber: true, allowBoolean: true },
       ],
-      "@typescript-eslint/return-await": "warn",
-      "@typescript-eslint/no-unused-expressions": "warn",
+      "@typescript-eslint/return-await": "error",
+      "@typescript-eslint/no-unused-expressions": "error",
       // Commander-style fluent chains pass method references as args
       // (`.option(handler)`); the rule mis-reads them as `this`-rebinding
       // hazards. Real binding issues still surface via test failures.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,7 +54,11 @@ export default tseslint.config(
       //   no-explicit-any ...... infra layers that bridge untyped surfaces
       //   no-unsafe-* .......... Bun.spawnSync / process / yaml-parsed
       //                           dynamic data flows through these
-      "@typescript-eslint/require-await": "warn",
+      // Production code has zero require-await sites — myelin#121's
+      // pattern: turn off in tests (adapter mocks have async signatures
+      // without I/O), promote to error elsewhere so new src violations
+      // gate the build.
+      "@typescript-eslint/require-await": "error",
       "@typescript-eslint/no-unnecessary-condition": "warn",
       "@typescript-eslint/await-thenable": "warn",
       "@typescript-eslint/no-empty-function": "warn",
@@ -67,7 +71,15 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-argument": "warn",
       "@typescript-eslint/no-unsafe-return": "warn",
       "@typescript-eslint/no-base-to-string": "warn",
-      "@typescript-eslint/restrict-template-expressions": "warn",
+      // Number / boolean interpolation in template literals is
+      // universally understood — `Found ${count} matches` reads
+      // cleanly. The rule still fires on `unknown`, `never`, `any`,
+      // and exotic objects — those carry real correctness signal.
+      // Mirrors myelin#122.
+      "@typescript-eslint/restrict-template-expressions": [
+        "error",
+        { allowNumber: true, allowBoolean: true },
+      ],
       "@typescript-eslint/return-await": "warn",
       "@typescript-eslint/no-unused-expressions": "warn",
       // Commander-style fluent chains pass method references as args
@@ -98,6 +110,14 @@ export default tseslint.config(
       "@typescript-eslint/restrict-template-expressions": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-deprecated": "off",
+      // Mocks of async-shaped interfaces (fetch / readFile / spawn
+      // wrappers, …) implement `() => Promise<T>` without I/O to
+      // await. The `async` keyword satisfies the type signature; the
+      // rule's "unnecessary" verdict in test code is pure noise.
+      // Mirrors myelin#121's test-override approach. Production code
+      // has zero require-await sites today; this override only affects
+      // tests.
+      "@typescript-eslint/require-await": "off",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,7 +53,7 @@ export default tseslint.config(
       //                           cannot prove it from generics
       //   no-empty-function ..... 25 → catch blocks with `{}` (intentional swallow)
       //   no-non-null-assertion . 23 → `result.files!` after success-narrow
-      //   prefer-nullish-coalescing  8 → idiomatic `||` for string defaults
+      //   prefer-nullish-coalescing  → 0 (promoted to error)
       //   no-explicit-any ...... infra layers that bridge untyped surfaces
       //   no-unsafe-* .......... Bun.spawnSync / process / yaml-parsed
       //                           dynamic data flows through these
@@ -72,7 +72,7 @@ export default tseslint.config(
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-empty-function": "warn",
       "@typescript-eslint/no-non-null-assertion": "warn",
-      "@typescript-eslint/prefer-nullish-coalescing": "warn",
+      "@typescript-eslint/prefer-nullish-coalescing": "error",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unsafe-assignment": "warn",
       "@typescript-eslint/no-unsafe-member-access": "warn",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "test:unit": "bun test test/unit/",
     "test:commands": "bun test test/commands/",
     "test:e2e": "bun test test/e2e/",
-    "fetch-cosign": "bun scripts/fetch-cosign.ts"
+    "fetch-cosign": "bun scripts/fetch-cosign.ts",
+    "lint": "eslint .",
+    "lint:errors": "eslint --quiet .",
+    "lint:fix": "eslint --fix ."
   },
   "dependencies": {
     "@noble/ed25519": "^3.1.0",
@@ -20,6 +23,12 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.0"
+    "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.2.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.3",
+    "@typescript-eslint/parser": "^8.59.3",
+    "eslint": "^10.3.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,7 @@ import {
 import { homedir } from "os";
 import { join } from "path";
 import { parseLibraryRef } from "./lib/artifact-installer.js";
+import { errorMessage } from "./lib/errors.js";
 
 const pkg = require("../package.json");
 
@@ -774,8 +775,8 @@ source
       addSource(config, newSource);
       await saveSources(paths.sourcesPath, config);
       console.log(`Added source "${name}" [${opts.tier}] (${opts.type})`);
-    } catch (err: any) {
-      console.error(`Error: ${err.message}`);
+    } catch (err) {
+      console.error(`Error: ${errorMessage(err)}`);
       process.exit(1);
     }
   });
@@ -808,8 +809,8 @@ source
       removeSource(config, name);
       await saveSources(paths.sourcesPath, config);
       console.log(`Removed source "${name}"`);
-    } catch (err: any) {
-      console.error(`Error: ${err.message}`);
+    } catch (err) {
+      console.error(`Error: ${errorMessage(err)}`);
       process.exit(1);
     }
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,7 +182,7 @@ program
         // exit code so scripts can tell deliberate-removal apart from
         // missing/network failures.
         if (download.quarantine) {
-          const colorEnabled = process.stderr.isTTY === true;
+          const colorEnabled = process.stderr.isTTY;
           for (const line of formatQuarantineMessage(
             formatPackageRef(pkgRef),
             download.quarantine,
@@ -535,7 +535,7 @@ program
     } else {
       // name is guaranteed non-null here — commander validates required args for single-package paths
       const libRef = parseLibraryRef(name!);
-      let upgradeName = libRef?.artifactName ?? name!;
+      const upgradeName = libRef?.artifactName ?? name!;
       let isLibraryUpgrade = false;
 
       if (!libRef?.artifactName) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,8 +97,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { parseLibraryRef } from "./lib/artifact-installer.js";
 import { errorMessage } from "./lib/errors.js";
-
-const pkg = require("../package.json");
+import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
 
@@ -205,7 +204,9 @@ program
         console.error(`  Expected: ${verify.expected}`);
         console.error(`  Actual:   ${verify.actual}`);
         console.error(`This could indicate a corrupted download or compromised package.`);
-        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        if (await Bun.file(download.tempPath).exists()) {
+          Bun.spawnSync(["rm", "-f", download.tempPath]);
+        }
         process.exit(1);
       }
       console.log(`SHA-256 verified`);
@@ -236,7 +237,9 @@ program
         } else {
           console.error(`This could indicate a compromised registry or a tampered manifest.`);
         }
-        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        if (await Bun.file(download.tempPath).exists()) {
+          Bun.spawnSync(["rm", "-f", download.tempPath]);
+        }
         process.exit(1);
       }
       if (sigResult.verified === true) {
@@ -261,7 +264,9 @@ program
       if (sigstoreResult.verified === false) {
         console.error(`Sigstore verification failed: ${sigstoreResult.reason}`);
         console.error(`This could indicate a tampered artifact or an unexpected signer.`);
-        await Bun.file(download.tempPath).exists() && Bun.spawnSync(["rm", "-f", download.tempPath]);
+        if (await Bun.file(download.tempPath).exists()) {
+          Bun.spawnSync(["rm", "-f", download.tempPath]);
+        }
         process.exit(1);
       }
       if (sigstoreResult.verified === true) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,7 +195,7 @@ program
         console.error(`${download.error}`);
         process.exit(1);
       }
-      console.log(`Downloaded ${(download.bytesDownloaded! / 1024).toFixed(0)} KB`);
+      console.log(`Downloaded ${((download.bytesDownloaded ?? 0) / 1024).toFixed(0)} KB`);
 
       // Verify SHA-256
       const verify = await verifyChecksum(download.tempPath, resolved.sha256);
@@ -538,23 +538,23 @@ program
       } else {
         console.log(formatUpgradeResults(results, { force: true }));
       }
-    } else {
-      // name is guaranteed non-null here — commander validates required args for single-package paths
-      const libRef = parseLibraryRef(name!);
-      const upgradeName = libRef?.artifactName ?? name!;
+    } else if (name) {
+      // Single-package path: prior branches handled the !name cases.
+      const libRef = parseLibraryRef(name);
+      const upgradeName = libRef?.artifactName ?? name;
       let isLibraryUpgrade = false;
 
       if (!libRef?.artifactName) {
         // No colon — check if name matches a library
         const { listByLibrary } = await import("./lib/db.js");
-        const libArtifacts = listByLibrary(db, name!);
+        const libArtifacts = listByLibrary(db, name);
         if (libArtifacts.length > 0) {
           isLibraryUpgrade = true;
         }
       }
 
       if (isLibraryUpgrade) {
-        const results = await upgradeLibrary(db, paths, host, name!, { force: opts.force });
+        const results = await upgradeLibrary(db, paths, host, name, { force: opts.force });
         console.log(formatUpgradeResults(results, { force: opts.force }));
       } else {
         const result = await upgradePackage(db, paths, host, upgradeName, { force: opts.force });
@@ -625,7 +625,7 @@ program
       if (result.success) {
         console.log(`\n✅ Scaffolded ${artifactType} at ${result.path}`);
         console.log(`\nFiles created:`);
-        for (const f of result.files!) {
+        for (const f of result.files ?? []) {
           console.log(`  ${f}`);
         }
       } else {
@@ -1142,7 +1142,7 @@ catalog
     const result = await catalogUse(paths, host, db, name);
 
     if (result.success) {
-      for (const item of result.installed!) {
+      for (const item of result.installed ?? []) {
         console.log(`Installed ${item.name} [${item.artifactType}]`);
       }
     } else {

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { listSkills, getAllActiveCapabilities } from "../lib/db.js";
-import type { AuditWarning, CapabilityRecord, RiskLevel } from "../types.js";
+import type { AuditWarning, CapabilityRecord } from "../types.js";
 
 export interface AuditResult {
   totalSkills: number;
@@ -152,7 +152,6 @@ export function formatAudit(result: AuditResult, verbose = false): string {
     lines.push(``);
     lines.push(`Per-skill capabilities:`);
     for (const [name, caps] of result.bySkill) {
-      const types = caps.map((c) => c.type);
       const summary: string[] = [];
       const reads = caps.filter((c) => c.type === "fs_read").length;
       const writes = caps.filter((c) => c.type === "fs_write").length;

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -31,7 +31,7 @@ export function audit(db: Database): AuditResult {
   // Build tier lookup from installed skills
   const tierBySkill = new Map<string, string>();
   for (const s of activeSkills) {
-    tierBySkill.set(s.name, s.tier || "custom");
+    tierBySkill.set(s.name, s.tier);
   }
 
   // Count capability surface

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { mkdir, cp, rm } from "fs/promises";
 import { homedir } from "os";
 import type { Database } from "bun:sqlite";
+import { errorMessage } from "../lib/errors.js";
 import type { ArcPaths, HostAdapter, CatalogEntry, ArtifactType } from "../types.js";
 import { MANIFEST_FILENAMES } from "../lib/manifest.js";
 import {
@@ -123,8 +124,8 @@ export async function catalogAdd(
     addEntry(config, entry, artifactType);
     await saveCatalog(arc.catalogPath, config);
     return { success: true, name: entry.name, artifactType };
-  } catch (err: any) {
-    return { success: false, error: err.message };
+  } catch (err) {
+    return { success: false, error: errorMessage(err) };
   }
 }
 
@@ -173,8 +174,8 @@ export async function catalogUse(
   let ordered: { entry: CatalogEntry; artifactType: ArtifactType }[];
   try {
     ordered = resolveDependencies(config, name);
-  } catch (err: any) {
-    return { success: false, error: err.message };
+  } catch (err) {
+    return { success: false, error: errorMessage(err) };
   }
 
   const installed: { name: string; artifactType: ArtifactType }[] = [];

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -292,14 +292,14 @@ export async function catalogPush(
   const tmpDir = join(arc.reposDir, `_push_${name}_${Date.now()}`);
   try {
     let cloneResult = Bun.spawnSync(
-      ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
+      ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", resolved.cloneUrl, tmpDir],
       { stdout: "pipe", stderr: "pipe" }
     );
 
     if (cloneResult.exitCode !== 0) {
       const sshUrl = `git@github.com:${resolved.org}/${resolved.repo}.git`;
       cloneResult = Bun.spawnSync(
-        ["git", "clone", "--depth", "1", "--branch", resolved.branch!, sshUrl, tmpDir],
+        ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", sshUrl, tmpDir],
         { stdout: "pipe", stderr: "pipe" }
       );
     }
@@ -542,14 +542,14 @@ async function installSkillEntry(
     const tmpDir = join(arc.reposDir, `_tmp_${entry.name}_${Date.now()}`);
     try {
       let cloneResult = Bun.spawnSync(
-        ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
+        ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", resolved.cloneUrl, tmpDir],
         { stdout: "pipe", stderr: "pipe" }
       );
 
       if (cloneResult.exitCode !== 0) {
         const sshUrl = `git@github.com:${resolved.org}/${resolved.repo}.git`;
         cloneResult = Bun.spawnSync(
-          ["git", "clone", "--depth", "1", "--branch", resolved.branch!, sshUrl, tmpDir],
+          ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", sshUrl, tmpDir],
           { stdout: "pipe", stderr: "pipe" }
         );
       }
@@ -693,14 +693,14 @@ async function installAgentEntry(
   const tmpDir = join(arc.reposDir, `_tmp_${entry.name}_${Date.now()}`);
   try {
     let cloneResult = Bun.spawnSync(
-      ["git", "clone", "--depth", "1", "--branch", resolved.branch!, resolved.cloneUrl, tmpDir],
+      ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", resolved.cloneUrl, tmpDir],
       { stdout: "pipe", stderr: "pipe" }
     );
 
     if (cloneResult.exitCode !== 0) {
       const sshUrl = `git@github.com:${resolved.org}/${resolved.repo}.git`;
       cloneResult = Bun.spawnSync(
-        ["git", "clone", "--depth", "1", "--branch", resolved.branch!, sshUrl, tmpDir],
+        ["git", "clone", "--depth", "1", "--branch", resolved.branch ?? "main", sshUrl, tmpDir],
         { stdout: "pipe", stderr: "pipe" }
       );
     }

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -19,7 +19,7 @@ import {
 import { resolveSource } from "../lib/source-resolver.js";
 import { readManifest } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
-import { createSymlink, createCliShim, extractAllCliInfo } from "../lib/symlinks.js";
+import { createSymlink, createCliShim } from "../lib/symlinks.js";
 
 // ── Result types ──────────────────────────────────────────────
 
@@ -31,7 +31,7 @@ export interface CatalogListResult {
 
 export interface CatalogSearchResult {
   success: boolean;
-  results?: Array<{ entry: CatalogEntry; artifactType: ArtifactType }>;
+  results?: { entry: CatalogEntry; artifactType: ArtifactType }[];
   error?: string;
 }
 
@@ -50,7 +50,7 @@ export interface CatalogRemoveResult {
 
 export interface CatalogUseResult {
   success: boolean;
-  installed?: Array<{ name: string; artifactType: ArtifactType }>;
+  installed?: { name: string; artifactType: ArtifactType }[];
   error?: string;
 }
 
@@ -62,7 +62,7 @@ export interface CatalogPushResult {
 
 export interface CatalogSyncResult {
   success: boolean;
-  synced?: Array<{ name: string; status: "ok" | "failed"; error?: string }>;
+  synced?: { name: string; status: "ok" | "failed"; error?: string }[];
   error?: string;
 }
 
@@ -170,14 +170,14 @@ export async function catalogUse(
   }
 
   // Resolve dependency tree
-  let ordered: Array<{ entry: CatalogEntry; artifactType: ArtifactType }>;
+  let ordered: { entry: CatalogEntry; artifactType: ArtifactType }[];
   try {
     ordered = resolveDependencies(config, name);
   } catch (err: any) {
     return { success: false, error: err.message };
   }
 
-  const installed: Array<{ name: string; artifactType: ArtifactType }> = [];
+  const installed: { name: string; artifactType: ArtifactType }[] = [];
 
   for (const { entry, artifactType } of ordered) {
     const result = await installEntry(arc, host, db, entry, artifactType, config);
@@ -214,7 +214,7 @@ export async function catalogSync(
     return { success: true, synced: [] };
   }
 
-  const synced: Array<{ name: string; status: "ok" | "failed"; error?: string }> = [];
+  const synced: { name: string; status: "ok" | "failed"; error?: string }[] = [];
 
   for (const item of installedItems) {
     const result = await installEntry(
@@ -383,7 +383,7 @@ export async function catalogPush(
  */
 export async function catalogPushCatalog(
   arc: ArcPaths,
-  host: HostAdapter
+  _host: HostAdapter
 ): Promise<{ success: boolean; error?: string }> {
   const catalogDir = join(arc.catalogPath, "..");
 

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -380,7 +380,13 @@ export async function catalogPush(
  *
  * @param host Unused today; threaded for #117 signature consistency. catalogPushCatalog
  *   only invokes git against the catalog file (arc state).
+ *
+ * Async signature matches the rest of the catalog command surface
+ * (catalogList, catalogAdd, catalogUse, …) which DO await readManifest /
+ * install. The push variant only shells out via Bun.spawnSync; keeping it
+ * sync would force every caller to special-case its return shape.
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function catalogPushCatalog(
   arc: ArcPaths,
   _host: HostAdapter

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -512,7 +512,7 @@ async function installSkillEntry(
   entry: CatalogEntry
 ): Promise<EntryInstallResult> {
   const resolved = resolveSource(entry.source);
-  const isCli = entry.has_cli || entry.bundle;
+  const isCli = entry.has_cli === true || entry.bundle === true;
   const baseDir = isCli ? arc.reposDir : host.paths.skillsDir;
   const installDir = join(baseDir, entry.name);
   const skillLinkDir = join(host.paths.skillsDir, entry.name);

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -632,7 +632,7 @@ async function installSkillEntry(
       install_path: installDir,
       skill_dir: isCli ? join(installDir, "skill") : installDir,
       status: "active",
-      artifact_type: (manifest?.type as ArtifactType) ?? "skill",
+      artifact_type: (manifest?.type ?? "skill") as ArtifactType,
       tier: "custom",
       customization_path: null,
       install_source: entry.source,

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -48,7 +48,7 @@ function keyPath(name: string): string {
 function validatePrincipal(p: unknown, index: number): asserts p is Principal {
   if (!p || typeof p !== "object") throw new Error(`principals[${index}]: not an object`);
   const r = p as Record<string, unknown>;
-  if (typeof r.id !== "string" || !DID_RE.test(r.id)) throw new Error(`principals[${index}].id: invalid DID "${r.id}"`);
+  if (typeof r.id !== "string" || !DID_RE.test(r.id)) throw new Error(`principals[${index}].id: invalid DID "${String(r.id)}"`);
   if (typeof r.public_key !== "string" || !BASE64_RE.test(r.public_key) || r.public_key.length < 40) {
     throw new Error(`principals[${index}].public_key: invalid (must be base64, ≥40 chars)`);
   }

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -192,7 +192,7 @@ export function importPrincipals(filePath: string): void {
     return;
   }
 
-  if (incoming.trusted_hubs?.length > 0) {
+  if (incoming.trusted_hubs.length > 0) {
     console.log(`  NOTE: trusted_hubs in import file ignored (security boundary — add manually if needed)`);
   }
 

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -60,7 +60,7 @@ function loadRegistry(): PrincipalRegistryFile {
   if (!existsSync(REGISTRY_PATH)) {
     return { version: 1, principals: [], trusted_hubs: [] };
   }
-  const raw = JSON.parse(readFileSync(REGISTRY_PATH, "utf-8"));
+  const raw = JSON.parse(readFileSync(REGISTRY_PATH, "utf-8")) as Partial<PrincipalRegistryFile>;
   if (raw.version !== 1 || !Array.isArray(raw.principals)) {
     throw new Error(`Invalid registry at ${REGISTRY_PATH}: expected version 1 with principals array`);
   }
@@ -178,14 +178,14 @@ export function importPrincipals(filePath: string): void {
 
   let incoming: PrincipalRegistryFile;
   try {
-    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    const raw = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<PrincipalRegistryFile>;
     if (raw.version !== 1 || !Array.isArray(raw.principals)) {
       throw new Error("expected { version: 1, principals: [...] }");
     }
     for (let i = 0; i < raw.principals.length; i++) {
       validatePrincipal(raw.principals[i], i);
     }
-    incoming = raw;
+    incoming = raw as PrincipalRegistryFile;
   } catch (err) {
     console.error(`Invalid principals file: ${err instanceof Error ? err.message : String(err)}`);
     process.exitCode = 1;

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -203,7 +203,7 @@ async function resolveMetafactoryInfo(
     const manifest: ArcManifest = {
       name: detail.name,
       version: detail.latest_version ?? "0.0.0",
-      type: (detail.type as ArcManifest["type"]) ?? "skill",
+      type: detail.type as ArcManifest["type"],
       description: detail.description ?? undefined,
       license: detail.license,
       author: detail.publisher.github_username
@@ -371,7 +371,7 @@ function formatRemoteInfo(result: InfoResult): string {
   if (!manifest || !remote) return "Package not found.";
 
   const lines: string[] = [];
-  const typeLabel = manifest.type ?? "skill";
+  const typeLabel = manifest.type;
 
   lines.push(`📦 ${manifest.name} v${manifest.version} (${typeLabel})`);
 
@@ -526,7 +526,7 @@ function formatInstalledLibraryInfo(result: InfoResult): string {
   const artifacts = libraryArtifacts ?? [];
 
   const name = manifest?.name ?? artifacts[0]?.library_name ?? "unknown";
-  const version = manifest?.version ?? artifacts[0]?.version ?? "?";
+  const version = manifest?.version ?? (artifacts.length > 0 ? artifacts[0].version : "?");
   const lines: string[] = [];
 
   lines.push(`\u{1F4DA} ${name} v${version} (library)`);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -273,7 +273,7 @@ function errorResult(error: string): InfoResult {
  */
 async function fetchReleaseNotesFromUrl(repoUrl: string, version: string): Promise<string | null> {
   const tag = `v${version}`;
-  const ghMatch = repoUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+  const ghMatch = /github\.com[:/]([^/]+)\/([^/.]+)/.exec(repoUrl);
   if (!ghMatch) return null;
 
   const nwo = `${ghMatch[1]}/${ghMatch[2]}`;

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -270,7 +270,13 @@ function errorResult(error: string): InfoResult {
 
 /**
  * Fetch release notes by repo URL and version tag.
+ *
+ * Async signature is the contract callers expect (mirrors
+ * fetchReleaseNotes etc.); the body shells out via Bun.spawnSync which
+ * is sync. Keeping the Promise wrapper preserves future async-fetch
+ * migration without callsite churn.
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 async function fetchReleaseNotesFromUrl(repoUrl: string, version: string): Promise<string | null> {
   const tag = `v${version}`;
   const ghMatch = /github\.com[:/]([^/]+)\/([^/.]+)/.exec(repoUrl);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -329,8 +329,8 @@ export function formatInfo(result: InfoResult): string {
   const lines: string[] = [
     `${skill.name} v${skill.version}`,
     `  Status: ${skill.status}`,
-    `  Tier: ${skill.tier || "custom"}`,
-    `  Source: ${skill.install_source || "direct"}`,
+    `  Tier: ${skill.tier}`,
+    `  Source: ${skill.install_source ?? "direct"}`,
     `  Repo: ${skill.repo_url}`,
     `  Path: ${skill.install_path}`,
     `  Installed: ${skill.installed_at}`,

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -545,8 +545,12 @@ function formatInstalledLibraryInfo(result: InfoResult): string {
   const byType = new Map<string, InstalledSkill[]>();
   for (const a of artifacts) {
     const type = a.artifact_type;
-    if (!byType.has(type)) byType.set(type, []);
-    byType.get(type)!.push(a);
+    let bucket = byType.get(type);
+    if (!bucket) {
+      bucket = [];
+      byType.set(type, bucket);
+    }
+    bucket.push(a);
   }
 
   lines.push("");

--- a/src/commands/init-resolve.ts
+++ b/src/commands/init-resolve.ts
@@ -52,7 +52,7 @@ export function resolveInitTarget(opts: {
 
   const name = inCwd ? cwdBasename : arg;
 
-  if (!name || /[\/\\]|\.\./.test(name)) {
+  if (!name || /[/\\]|\.\./.test(name)) {
     return {
       ok: false,
       reason: "invalid-name",

--- a/src/commands/init-resolve.ts
+++ b/src/commands/init-resolve.ts
@@ -50,7 +50,7 @@ export function resolveInitTarget(opts: {
   // name) or in a new subdir. Compute once.
   const inCwd = !arg || arg === "." || nameMatches;
 
-  const name = inCwd ? cwdBasename : arg!;
+  const name = inCwd ? cwdBasename : arg;
 
   if (!name || /[\/\\]|\.\./.test(name)) {
     return {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "path";
 import { existsSync, lstatSync, statSync } from "fs";
 import { mkdir } from "fs/promises";
 import { scaffoldEntriesFor, type ArtifactInitType } from "./init-scaffold.js";
+import { errorMessage, isErrno } from "../lib/errors.js";
 
 // Re-exports keep the public surface stable for callers (cli.ts, tests)
 // that imported from `./init.js` before the cycle-7 module split.
@@ -34,9 +35,9 @@ function validateTargetDir(targetDir: string): string | null {
   let lstat;
   try {
     lstat = lstatSync(targetDir);
-  } catch (err: any) {
-    if (err?.code === "ENOENT") return null; // doesn't exist — fine
-    return `Cannot access ${targetDir}: ${err?.message ?? err}`;
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return null; // doesn't exist — fine
+    return `Cannot access ${targetDir}: ${errorMessage(err)}`;
   }
   if (lstat.isSymbolicLink()) {
     try {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -9,6 +9,7 @@ import type {
   PackageTier,
 } from "../types.js";
 import type { Database } from "bun:sqlite";
+import { errorMessage } from "../lib/errors.js";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
 import { runScript, runLifecycleScripts } from "../lib/scripts.js";
@@ -182,11 +183,11 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   let manifest: ArcManifest | null = null;
   try {
     manifest = await readManifest(installPath);
-  } catch (err: any) {
+  } catch (err) {
     Bun.spawnSync(["rm", "-rf", installPath]);
     return {
       success: false,
-      error: `Failed to read manifest in ${repoUrl}: ${err.message}`,
+      error: `Failed to read manifest in ${repoUrl}: ${errorMessage(err)}`,
     };
   }
   if (!manifest) {
@@ -470,8 +471,8 @@ async function installLibrary(
   let artifactEntries: Awaited<ReturnType<typeof readLibraryArtifacts>>;
   try {
     artifactEntries = await readLibraryArtifacts(installPath, libraryManifest);
-  } catch (err: any) {
-    return { success: false, error: err.message };
+  } catch (err) {
+    return { success: false, error: errorMessage(err) };
   }
 
   // Filter to specific artifact if requested
@@ -754,9 +755,9 @@ async function installPerTarget(opts: {
     let targetHost;
     try {
       targetHost = resolveHost(targetId, opts.hostOverrides);
-    } catch (err: any) {
+    } catch (err) {
       await rollbackAll();
-      return { error: err?.message ?? `Failed to resolve host '${targetId}'` };
+      return { error: errorMessage(err) || `Failed to resolve host '${targetId}'` };
     }
 
     if (targetId === "darwin-launchd") {
@@ -778,10 +779,10 @@ async function installPerTarget(opts: {
           quiet: opts.quiet,
         });
         launchd.push(rec);
-      } catch (err: any) {
+      } catch (err) {
         await rollbackAll();
         return {
-          error: `darwin-launchd install failed: ${err?.message ?? err}`,
+          error: `darwin-launchd install failed: ${errorMessage(err)}`,
         };
       }
       continue;

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -123,7 +123,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     // Check if already installed in DB (by repo name or by scanning all skills)
     const allSkills = db
       .prepare("SELECT * FROM skills")
-      .all() as Array<{ name: string; status: string; repo_url: string; library_name: string | null }>;
+      .all() as { name: string; status: string; repo_url: string; library_name: string | null }[];
 
     const existingByUrl = allSkills.find((s) => s.repo_url === repoUrl && !s.library_name);
     if (existingByUrl) {
@@ -217,7 +217,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
         .prepare("SELECT name, status FROM skills WHERE name = ?")
         .get(dep.name) as { name: string; status: string } | null;
 
-      if (existing && existing.status === "active") {
+      if (existing?.status === "active") {
         continue; // Already installed
       }
 
@@ -289,7 +289,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   //     OS-supervision hosts last), call createArtifactSymlinks per target
   //     or installLaunchdArtifacts for darwin-launchd.
   //   - manifest.targets absent → existing single-host flow against opts.host.
-  let symlinkResult: { record: ArtifactSymlinkRecord; filesMissingSource: Array<{ source: string; target: string }> };
+  let symlinkResult: { record: ArtifactSymlinkRecord; filesMissingSource: { source: string; target: string }[] };
   let launchdRecords: LaunchdInstallRecord[] = [];
   if (manifest.targets && manifest.targets.length > 0) {
     const multi = await installPerTarget({
@@ -502,7 +502,7 @@ async function installLibrary(
   for (const { entry, manifest: artifactManifest } of artifactEntries) {
     // Check if this specific artifact is already installed
     const existing = getSkill(db, artifactManifest.name);
-    if (existing && existing.status === "active") {
+    if (existing?.status === "active") {
       if (!opts.yes) {
         console.log(`  ⏩ ${artifactManifest.name} already installed, skipping`);
       }
@@ -992,7 +992,7 @@ function checkoutVersionTag(
 async function promptHookConsent(
   packageName: string,
   tier: string,
-  hooks: Array<{ event: string; command: string; matcher?: string }>,
+  hooks: { event: string; command: string; matcher?: string }[],
   autoApprove?: boolean,
 ): Promise<boolean> {
   // Auto-approve for --yes flag or trusted tiers

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -174,7 +174,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       const checkoutResult = checkoutVersionTag(installPath, opts.pinnedVersion);
       if (!checkoutResult.success) {
         Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
-        return { success: false, error: checkoutResult.error! };
+        return { success: false, error: checkoutResult.error ?? "checkout failed" };
       }
     }
   }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -180,7 +180,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   }
 
   // 2. Read manifest
-  let manifest: ArcManifest | null = null;
+  let manifest: ArcManifest | null;
   try {
     manifest = await readManifest(installPath);
   } catch (err) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,6 +1,7 @@
 import type { ArcPaths } from "../types.js";
 import { loadSources, saveSources, findMetafactorySource } from "../lib/sources.js";
 import { initiateDeviceCode, pollForToken, openBrowser } from "../lib/device-auth.js";
+import { errorMessage } from "../lib/errors.js";
 
 export interface LoginOptions {
   paths: ArcPaths;
@@ -37,10 +38,10 @@ export async function login(opts: LoginOptions): Promise<LoginResult> {
   let deviceCode;
   try {
     deviceCode = await initiateDeviceCode(source.url);
-  } catch (err: any) {
+  } catch (err) {
     return {
       success: false,
-      error: `Cannot reach ${source.url}: ${err.message}`,
+      error: `Cannot reach ${source.url}: ${errorMessage(err)}`,
     };
   }
 

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -325,7 +325,7 @@ export async function addBot(name: string, opts: AddBotOptions): Promise<AddBotR
 
   nsc(["add", "user", "-a", account, "-n", name]);
 
-  let credsContent = "";
+  let credsContent: string;
   try {
     if (opts.pub) {
       for (const subj of opts.pub.split(",").map((s) => s.trim())) {

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -151,7 +151,7 @@ export function detectAccount(): string {
   }
   // Fallback: parse nsc env output (env writes to stderr)
   const output = nscWithStderr(["env"]);
-  const match = output.match(/Current Account\s+\|[^|]*\|\s+(\S+)/);
+  const match = /Current Account\s+\|[^|]*\|\s+(\S+)/.exec(output);
   if (match) return match[1];
   throw new ArcNatsCommandError(
     "ACCOUNT_NOT_FOUND",
@@ -174,7 +174,7 @@ function defaultCredsPath(name: string): string {
  * envelope's `jwt` field will be empty).
  */
 function extractJwt(credsContent: string): string {
-  const match = credsContent.match(/-----BEGIN NATS USER JWT-----\s*([\s\S]*?)\s*-----END NATS USER JWT-----/);
+  const match = /-----BEGIN NATS USER JWT-----\s*([\s\S]*?)\s*-----END NATS USER JWT-----/.exec(credsContent);
   if (!match) return "";
   return match[1].replace(/\s+/g, "");
 }

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -43,7 +43,7 @@ export type NscRunner = (args: string[]) => NscResult;
 const defaultRunner: NscRunner = (args) => {
   const result = Bun.spawnSync(["nsc", ...args], { stderr: "pipe", stdout: "pipe" });
   return {
-    exitCode: result.exitCode ?? -1,
+    exitCode: result.exitCode,
     stdout: result.stdout.toString(),
     stderr: result.stderr.toString(),
   };
@@ -141,8 +141,8 @@ export function detectAccount(): string {
   for (const candidate of NSC_CONFIG_CANDIDATES) {
     if (!existsSync(candidate)) continue;
     try {
-      const config = JSON.parse(readFileSync(candidate, "utf-8"));
-      if (config.account && typeof config.account === "string") {
+      const config = JSON.parse(readFileSync(candidate, "utf-8")) as { account?: unknown };
+      if (typeof config.account === "string") {
         return config.account;
       }
     } catch {

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -350,7 +350,10 @@ export async function addBot(name: string, opts: AddBotOptions): Promise<AddBotR
     if (json) {
       throw new ArcNatsCommandError(code, `Failed to configure user "${name}" — rolled back. Cause: ${cause}`);
     }
-    throw new Error(`Failed to configure user "${name}" — rolled back. Cause: ${cause}`);
+    throw new Error(
+      `Failed to configure user "${name}" — rolled back. Cause: ${cause}`,
+      { cause: err },
+    );
   }
 
   // Surface the durable pubkey (matches what cortex receives in JSON mode and

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -82,7 +82,9 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
   // 6. Dry run — validate and display, then clean up
   if (opts.dryRun) {
     if (tempTarball) {
-      await rm(tarballPath).catch(() => {});
+      await rm(tarballPath).catch(() => {
+        // best-effort cleanup; tarball may already be gone
+      });
     }
     return {
       success: true,
@@ -136,7 +138,9 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
   } finally {
     // Clean up temp tarball
     if (tempTarball) {
-      await rm(tarballPath).catch(() => {});
+      await rm(tarballPath).catch(() => {
+        // best-effort cleanup; tarball may already be gone
+      });
     }
   }
 }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -325,8 +325,8 @@ export async function remove(
       targets: manifest.targets,
       manifest,
       packageName: name,
-      hostOverrides: opts?.hostOverrides,
-      quiet: opts?.quiet,
+      hostOverrides: opts.hostOverrides,
+      quiet: opts.quiet,
     });
   } else if (isAction) {
     // Actions: remove action symlink
@@ -420,9 +420,9 @@ export async function remove(
     const postuninstallResult = runPostuninstallPhase(
       skill.install_path,
       manifest,
-      opts?.quiet,
+      opts.quiet,
     );
-    if (!postuninstallResult.success && !opts?.quiet) {
+    if (!postuninstallResult.success && !opts.quiet) {
       console.warn(`  ⚠ ${postuninstallResult.error}`);
     }
   }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -22,6 +22,7 @@ import {
 } from "../lib/hosts/registry.js";
 import { removeLaunchdArtifacts } from "../lib/hosts/launchd-install.js";
 import { isDarwinLaunchdHost } from "../lib/hosts/darwin-launchd.js";
+import { errorMessage, isErrno } from "../lib/errors.js";
 
 export interface RemoveResult {
   success: boolean;
@@ -462,9 +463,9 @@ async function removeProvidedFile(
   let stat;
   try {
     stat = await lstat(targetPath);
-  } catch (err: any) {
-    if (err?.code === "ENOENT") return; // already gone, nothing to do
-    console.warn(`  ⚠ provides.files cleanup: cannot stat ${targetPath}: ${err?.message ?? err}`);
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return; // already gone, nothing to do
+    console.warn(`  ⚠ provides.files cleanup: cannot stat ${targetPath}: ${errorMessage(err)}`);
     return;
   }
 
@@ -478,8 +479,8 @@ async function removeProvidedFile(
   let actualTarget: string;
   try {
     actualTarget = await readlink(targetPath);
-  } catch (err: any) {
-    console.warn(`  ⚠ provides.files cleanup: readlink failed on ${targetPath}: ${err?.message ?? err}`);
+  } catch (err) {
+    console.warn(`  ⚠ provides.files cleanup: readlink failed on ${targetPath}: ${errorMessage(err)}`);
     return;
   }
 
@@ -492,9 +493,9 @@ async function removeProvidedFile(
 
   try {
     await unlink(targetPath);
-  } catch (err: any) {
-    if (err?.code !== "ENOENT") {
-      console.warn(`  ⚠ provides.files cleanup: unlink failed on ${targetPath}: ${err?.message ?? err}`);
+  } catch (err) {
+    if (isErrno(err) && err.code !== "ENOENT") {
+      console.warn(`  ⚠ provides.files cleanup: unlink failed on ${targetPath}: ${errorMessage(err)}`);
     }
   }
 }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -319,7 +319,7 @@ export async function remove(
 
   // Multi-target path (arc#140 P5): walk targets in reverse install order.
   // No-op when manifest is missing (we still try to clean DB/repo below).
-  if (manifest && manifest.targets && manifest.targets.length > 0) {
+  if (manifest?.targets && manifest.targets.length > 0) {
     await removePerTarget({
       targets: manifest.targets,
       manifest,

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -293,7 +293,7 @@ export async function remove(
       installPath: skill.install_path,
       scriptPath: manifest.scripts.preremove,
       hookName: "preremove",
-      quiet: opts.yes || opts.quiet,
+      quiet: opts.yes === true || opts.quiet === true,
     });
     if (!preResult.success && !preResult.skipped) {
       console.warn(

--- a/src/commands/self-update.ts
+++ b/src/commands/self-update.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { join } from "path";
 
 export interface SelfUpdateResult {
@@ -120,7 +121,7 @@ export function checkSelfUpdate(): SelfUpdateCheck {
 
   let currentVersion: string;
   try {
-    const raw = require(pkgJsonPath);
+    const raw = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { version: string };
     currentVersion = raw.version;
   } catch {
     return { currentVersion: "unknown", latestVersion: null, updateAvailable: false };

--- a/src/commands/self-update.ts
+++ b/src/commands/self-update.ts
@@ -21,7 +21,7 @@ export async function selfUpdate(): Promise<SelfUpdateResult> {
   // Read current version
   let oldVersion: string;
   try {
-    const pkg = await Bun.file(pkgJsonPath).json();
+    const pkg = (await Bun.file(pkgJsonPath).json()) as { version: string };
     oldVersion = pkg.version;
   } catch {
     return { success: false, oldVersion: "unknown", newVersion: "unknown", commitsPulled: 0, error: "Could not read package.json" };
@@ -96,7 +96,7 @@ export async function selfUpdate(): Promise<SelfUpdateResult> {
   try {
     // Re-read from disk (not cached)
     const raw = await Bun.file(pkgJsonPath).text();
-    const pkg = JSON.parse(raw);
+    const pkg = JSON.parse(raw) as { version: string };
     newVersion = pkg.version;
   } catch {
     newVersion = oldVersion;

--- a/src/commands/upgrade-core.ts
+++ b/src/commands/upgrade-core.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 import { existsSync, readdirSync, lstatSync, readlinkSync } from "fs";
 import { mkdir } from "fs/promises";
 import type { Database } from "bun:sqlite";
+import { errorMessage } from "../lib/errors.js";
 import { listSkills } from "../lib/db.js";
 import { createSymlink, isValidSymlink, getSymlinkTarget } from "../lib/symlinks.js";
 
@@ -158,14 +159,14 @@ export async function upgradeCore(
           detail: `Target not found: ${link.target}`,
         });
       }
-    } catch (err: any) {
+    } catch (err) {
       steps.push({
         action: "persistent-symlink",
         target: link.name,
         status: "failed",
-        detail: err.message,
+        detail: errorMessage(err),
       });
-      errors.push(`Failed to create ${link.name} symlink: ${err.message}`);
+      errors.push(`Failed to create ${link.name} symlink: ${errorMessage(err)}`);
     }
   }
 
@@ -220,15 +221,15 @@ export async function upgradeCore(
           detail: `Source not found: ${effectiveSource}`,
         });
       }
-    } catch (err: any) {
+    } catch (err) {
       steps.push({
         action: "skill-symlink",
         target: skill.name,
         status: "failed",
-        detail: err.message,
+        detail: errorMessage(err),
       });
       errors.push(
-        `Failed to symlink skill ${skill.name}: ${err.message}`
+        `Failed to symlink skill ${skill.name}: ${errorMessage(err)}`
       );
     }
   }
@@ -250,12 +251,12 @@ export async function upgradeCore(
           detail: `${binLink} → ${skill.install_path}`,
         });
       }
-    } catch (err: any) {
+    } catch (err) {
       steps.push({
         action: "bin-symlink",
         target: skill.name,
         status: "failed",
-        detail: err.message,
+        detail: errorMessage(err),
       });
     }
   }
@@ -280,14 +281,14 @@ export async function upgradeCore(
       status: "created",
       detail: `${config.claudeSymlink} → ${newReleaseDir}`,
     });
-  } catch (err: any) {
+  } catch (err) {
     steps.push({
       action: "main-symlink",
       target: config.claudeSymlink,
       status: "failed",
-      detail: err.message,
+      detail: errorMessage(err),
     });
-    errors.push(`Failed to swap main symlink: ${err.message}`);
+    errors.push(`Failed to swap main symlink: ${errorMessage(err)}`);
   }
 
   // 7. Validate
@@ -405,9 +406,9 @@ async function carryForwardConfigSymlinks(
               detail: `${newLink} → ${target}`,
             });
           }
-        } catch (err: any) {
+        } catch (err) {
           errors.push(
-            `Failed to carry forward ${entry}/${subEntry}: ${err.message}`
+            `Failed to carry forward ${entry}/${subEntry}: ${errorMessage(err)}`
           );
         }
       }

--- a/src/commands/upgrade-core.ts
+++ b/src/commands/upgrade-core.ts
@@ -1,6 +1,6 @@
-import { join, dirname, basename } from "path";
+import { join } from "path";
 import { existsSync, readdirSync, lstatSync, readlinkSync } from "fs";
-import { mkdir, readdir } from "fs/promises";
+import { mkdir } from "fs/promises";
 import type { Database } from "bun:sqlite";
 import { listSkills } from "../lib/db.js";
 import { createSymlink, isValidSymlink, getSymlinkTarget } from "../lib/symlinks.js";
@@ -97,16 +97,16 @@ export async function upgradeCore(
   let previousVersion: string | undefined;
   const currentTarget = await getSymlinkTarget(config.claudeSymlink);
   if (currentTarget) {
-    const match = currentTarget.match(/Releases\/(v[\d.]+)\//);
+    const match = /Releases\/(v[\d.]+)\//.exec(currentTarget);
     if (match) previousVersion = match[1];
   }
 
   // 2. Create persistent symlinks
-  const persistentLinks: Array<{
+  const persistentLinks: {
     name: string;
     linkPath: string;
     target: string;
-  }> = [
+  }[] = [
     {
       name: ".env",
       linkPath: join(newReleaseDir, ".env"),
@@ -420,9 +420,9 @@ async function carryForwardConfigSymlinks(
  */
 async function validate(
   releaseDir: string,
-  config: UpgradeConfig
-): Promise<Array<{ check: string; detail: string }>> {
-  const failures: Array<{ check: string; detail: string }> = [];
+  _config: UpgradeConfig
+): Promise<{ check: string; detail: string }[]> {
+  const failures: { check: string; detail: string }[] = [];
 
   // Check core persistent symlinks
   const checks = [

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import type { ArcPaths, HostAdapter, InstalledSkill, SourcesConfig, RulesTemplate } from "../types.js";
+import type { ArcPaths, HostAdapter, RulesTemplate } from "../types.js";
 import type { Database } from "bun:sqlite";
 import { listSkills, getSkill, listByLibrary } from "../lib/db.js";
 import { readManifest, readLibraryArtifacts } from "../lib/manifest.js";
@@ -59,7 +59,7 @@ function compareSemver(a: string, b: string): number {
 export async function checkUpgrades(
   db: Database,
   arc: ArcPaths,
-  host: HostAdapter,
+  _host: HostAdapter,
 ): Promise<UpgradeCheckResult[]> {
   const installed = listSkills(db).filter((s) => s.status === "active");
   const sources = await loadSources(arc.sourcesPath);
@@ -429,7 +429,7 @@ export async function upgradeLibrary(
   // Discover and install new artifacts added to the library manifest since last install
   if (gitRoot) {
     const rootManifest = await readManifest(gitRoot);
-    if (rootManifest && rootManifest.type === "library") {
+    if (rootManifest?.type === "library") {
       let manifestArtifacts: Awaited<ReturnType<typeof readLibraryArtifacts>>;
       try {
         manifestArtifacts = await readLibraryArtifacts(gitRoot, rootManifest);

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -77,8 +77,8 @@ export async function createArtifactSymlinks(opts: {
   consumerDir?: string;
   quiet?: boolean;
 }): Promise<{
-  filesCreated: Array<{ source: string; target: string }>;
-  filesMissingSource: Array<{ source: string; target: string }>;
+  filesCreated: { source: string; target: string }[];
+  filesMissingSource: { source: string; target: string }[];
   record: ArtifactSymlinkRecord;
 }> {
   const { type, manifest, arc, host, installDir, quiet } = opts;
@@ -99,7 +99,7 @@ export async function createArtifactSymlinks(opts: {
   // (manifest typo, repo drift) is now stopped with zero filesystem mutation,
   // so install can return cleanly without producing orphan symlinks.
   const declaredFiles = manifest.provides?.files ?? [];
-  const filesMissingSource: Array<{ source: string; target: string }> = [];
+  const filesMissingSource: { source: string; target: string }[] = [];
   for (const file of declaredFiles) {
     const sourcePath = join(installDir, file.source);
     if (!existsSync(sourcePath)) {
@@ -270,7 +270,7 @@ export async function createArtifactSymlinks(opts: {
   // multi-artifact package using a different primary type. See issue #84.
   // The pre-validation pass above guarantees every source exists by the time
   // we get here, so we can fearlessly create symlinks without partial-state risk.
-  const filesCreated: Array<{ source: string; target: string }> = [];
+  const filesCreated: { source: string; target: string }[] = [];
   for (const file of declaredFiles) {
     const sourcePath = join(installDir, file.source);
     const targetPath = file.target.replace(/^~/, homedir());

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import type { ArtifactType, ArcManifest, ArcPaths, HostAdapter } from "../types.js";
+import { errorMessage, isErrno } from "./errors.js";
 import {
   createSymlink,
   createCliShim,
@@ -302,18 +303,18 @@ export async function rollbackArtifactSymlinks(record: ArtifactSymlinkRecord): P
   for (const link of record.symlinks) {
     try {
       await removeSymlink(link);
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
-        console.warn(`  ⚠ rollback: failed to remove symlink ${link}: ${err?.message ?? err}`);
+    } catch (err) {
+      if (!isErrno(err) || err.code !== "ENOENT") {
+        console.warn(`  ⚠ rollback: failed to remove symlink ${link}: ${errorMessage(err)}`);
       }
     }
   }
   for (const name of record.shims.names) {
     try {
       await removeCliShim(record.shims.dir, name);
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
-        console.warn(`  ⚠ rollback: failed to remove shim ${name}: ${err?.message ?? err}`);
+    } catch (err) {
+      if (!isErrno(err) || err.code !== "ENOENT") {
+        console.warn(`  ⚠ rollback: failed to remove shim ${name}: ${errorMessage(err)}`);
       }
     }
   }

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -76,7 +76,9 @@ export async function withTempDir<T>(
   try {
     return await fn(tempDir);
   } finally {
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {
+      // best-effort cleanup
+    });
   }
 }
 
@@ -213,7 +215,9 @@ export async function createBundle(
   const { sha256, sizeBytes, fileCount } = await getBundleStats(tarballName);
 
   if (sizeBytes > MAX_PACKAGE_SIZE) {
-    await rm(tarballName).catch(() => {});
+    await rm(tarballName).catch(() => {
+      // best-effort cleanup
+    });
     const sizeMb = (sizeBytes / 1024 / 1024).toFixed(1);
     const hint =
       "If this is a monorepo, pass a package subdirectory (e.g. `arc bundle packages/my-pkg`), " +

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -103,8 +103,10 @@ const VALID_TYPES = [
   "pipeline", "rules", "library", "action",
 ];
 
-/** Validate a manifest for publishing (stricter than install validation) */
-export function validateForPublish(manifest: ArcManifest): PublishValidation {
+/** Validate a manifest for publishing (stricter than install validation).
+ * Accepts Partial because YAML may produce a structurally-incomplete object
+ * even when the type pretends every field is present. */
+export function validateForPublish(manifest: Partial<ArcManifest>): PublishValidation {
   const errors: string[] = [];
   const warnings: string[] = [];
 

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -83,11 +83,11 @@ export function findEntry(
 export function searchCatalog(
   config: CatalogConfig,
   keyword: string
-): Array<{ entry: CatalogEntry; artifactType: ArtifactType }> {
+): { entry: CatalogEntry; artifactType: ArtifactType }[] {
   const lower = keyword.toLowerCase();
-  const results: Array<{ entry: CatalogEntry; artifactType: ArtifactType }> = [];
+  const results: { entry: CatalogEntry; artifactType: ArtifactType }[] = [];
 
-  const sections: Array<{ entries: CatalogEntry[]; type: ArtifactType }> = [
+  const sections: { entries: CatalogEntry[]; type: ArtifactType }[] = [
     { entries: config.catalog.skills, type: "skill" },
     { entries: config.catalog.agents, type: "agent" },
     { entries: config.catalog.prompts, type: "prompt" },
@@ -125,7 +125,7 @@ export function listCatalog(
 ): CatalogListItem[] {
   const items: CatalogListItem[] = [];
 
-  const sections: Array<{ entries: CatalogEntry[]; type: ArtifactType }> = [
+  const sections: { entries: CatalogEntry[]; type: ArtifactType }[] = [
     { entries: config.catalog.skills, type: "skill" },
     { entries: config.catalog.agents, type: "agent" },
     { entries: config.catalog.prompts, type: "prompt" },
@@ -204,8 +204,8 @@ export function removeEntry(
 export function resolveDependencies(
   config: CatalogConfig,
   entryName: string,
-  visited: Set<string> = new Set()
-): Array<{ entry: CatalogEntry; artifactType: ArtifactType }> {
+  visited = new Set<string>()
+): { entry: CatalogEntry; artifactType: ArtifactType }[] {
   if (visited.has(entryName)) {
     throw new Error(`Circular dependency detected: ${entryName}`);
   }
@@ -216,7 +216,7 @@ export function resolveDependencies(
     throw new Error(`Entry "${entryName}" not found in catalog`);
   }
 
-  const result: Array<{ entry: CatalogEntry; artifactType: ArtifactType }> = [];
+  const result: { entry: CatalogEntry; artifactType: ArtifactType }[] = [];
 
   if (found.entry.requires?.length) {
     for (const ref of found.entry.requires) {

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -19,21 +19,23 @@ export async function loadCatalog(
 ): Promise<CatalogConfig | null> {
   try {
     const content = await readFile(catalogPath, "utf-8");
-    const parsed = YAML.parse(content) as CatalogConfig;
+    const raw = YAML.parse(content) as Partial<CatalogConfig> | null;
 
-    if (!parsed.defaults || !parsed.catalog) {
+    if (!raw?.defaults || !raw.catalog) {
       throw new Error(
         "Invalid catalog.yaml: missing required sections (defaults, catalog)"
       );
     }
 
-    // Ensure arrays exist even if empty in YAML
-    parsed.catalog.skills ??= [];
-    parsed.catalog.agents ??= [];
-    parsed.catalog.prompts ??= [];
-    parsed.catalog.tools ??= [];
+    // Ensure arrays exist even if empty in YAML (the type asserts they're
+    // required, but YAML lets them be omitted).
+    const cat = raw.catalog as Partial<CatalogConfig["catalog"]>;
+    cat.skills ??= [];
+    cat.agents ??= [];
+    cat.prompts ??= [];
+    cat.tools ??= [];
 
-    return parsed;
+    return raw as CatalogConfig;
   } catch (err) {
     if (isErrno(err) && err.code === "ENOENT") return null;
     throw err;

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types.js";
 import { getSkill } from "./db.js";
 import { parseDependencyRef } from "./source-resolver.js";
+import { isErrno } from "./errors.js";
 import type { Database } from "bun:sqlite";
 
 /**
@@ -33,8 +34,8 @@ export async function loadCatalog(
     parsed.catalog.tools ??= [];
 
     return parsed;
-  } catch (err: any) {
-    if (err.code === "ENOENT") return null;
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return null;
     throw err;
   }
 }

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -13,6 +13,7 @@
 import { writeFile, unlink } from "fs/promises";
 import { join } from "path";
 import type { RegistrySource } from "../types.js";
+import { errorMessage } from "./errors.js";
 import { verifySigstoreBundle, type VerifySigstoreResult } from "./cosign.js";
 
 const FETCH_TIMEOUT_MS = 30_000;
@@ -63,8 +64,8 @@ export async function downloadSigstoreBundle(
     const path = join(tempDir, `arc-bundle-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.bundle`);
     await writeFile(path, body);
     return { path };
-  } catch (err: any) {
-    return { error: `bundle download failed: ${err?.message ?? err}` };
+  } catch (err) {
+    return { error: `bundle download failed: ${errorMessage(err)}` };
   }
 }
 

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -112,6 +112,8 @@ export async function verifyPackageSigstore(
     }
     return { verified: false, reason: result.error ?? "cosign verification failed" };
   } finally {
-    await unlink(dl.path).catch(() => {});
+    await unlink(dl.path).catch(() => {
+      // best-effort cleanup
+    });
   }
 }

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -7,6 +7,7 @@
 import { join } from "path";
 import { existsSync } from "fs";
 import { writeFile, mkdir, chmod } from "fs/promises";
+import { errorMessage } from "./errors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -128,8 +129,8 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
 
     process.stderr.write(`cosign ${COSIGN_VERSION} downloaded and verified.\n`);
     return { path: destPath };
-  } catch (err: any) {
-    return { error: `Failed to fetch cosign: ${err.message ?? err}` };
+  } catch (err) {
+    return { error: `Failed to fetch cosign: ${errorMessage(err)}` };
   }
 }
 

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -90,8 +90,8 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
     const checksumText = await checksumResp.text();
     let expectedHash: string | undefined;
     for (const line of checksumText.split("\n")) {
-      const match = line.match(/^([a-f0-9]{64})\s+(.+)$/);
-      if (match && match[2].trim() === platform.binaryName) {
+      const match = /^([a-f0-9]{64})\s+(.+)$/.exec(line);
+      if (match?.[2].trim() === platform.binaryName) {
         expectedHash = match[1];
         break;
       }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,10 +11,10 @@ import type {
  */
 export function openDatabase(dbPath: string): Database {
   const db = new Database(dbPath, { create: true });
-  db.exec("PRAGMA journal_mode=WAL;");
-  db.exec("PRAGMA foreign_keys=ON;");
+  db.run("PRAGMA journal_mode=WAL;");
+  db.run("PRAGMA foreign_keys=ON;");
 
-  db.exec(`
+  db.run(`
     CREATE TABLE IF NOT EXISTS skills (
       name TEXT PRIMARY KEY,
       version TEXT NOT NULL,
@@ -30,36 +30,36 @@ export function openDatabase(dbPath: string): Database {
 
   // Migration: add artifact_type column to existing databases
   try {
-    db.exec(`ALTER TABLE skills ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'skill'`);
+    db.run(`ALTER TABLE skills ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'skill'`);
   } catch {
     // Column already exists — expected for new or already-migrated databases
   }
 
   // Migration: add tier and customization_path columns
   try {
-    db.exec(`ALTER TABLE skills ADD COLUMN tier TEXT NOT NULL DEFAULT 'custom'`);
+    db.run(`ALTER TABLE skills ADD COLUMN tier TEXT NOT NULL DEFAULT 'custom'`);
   } catch {
     // Column already exists
   }
   try {
-    db.exec(`ALTER TABLE skills ADD COLUMN customization_path TEXT`);
+    db.run(`ALTER TABLE skills ADD COLUMN customization_path TEXT`);
   } catch {
     // Column already exists
   }
   try {
-    db.exec(`ALTER TABLE skills ADD COLUMN install_source TEXT`);
+    db.run(`ALTER TABLE skills ADD COLUMN install_source TEXT`);
   } catch {
     // Column already exists
   }
 
   // Migration: add library_name column for library-sourced artifacts
   try {
-    db.exec(`ALTER TABLE skills ADD COLUMN library_name TEXT`);
+    db.run(`ALTER TABLE skills ADD COLUMN library_name TEXT`);
   } catch {
     // Column already exists
   }
 
-  db.exec(`
+  db.run(`
     CREATE TABLE IF NOT EXISTS capabilities (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       skill_name TEXT NOT NULL,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -95,11 +95,11 @@ export function recordInstall(
     skill.install_path,
     skill.skill_dir,
     skill.status,
-    skill.artifact_type || "skill",
-    skill.tier || manifest.tier || "custom",
-    skill.customization_path || null,
-    skill.install_source || null,
-    skill.library_name || null,
+    skill.artifact_type,
+    skill.tier,
+    skill.customization_path,
+    skill.install_source,
+    skill.library_name,
     skill.installed_at || now,
     skill.updated_at || now
   );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -156,11 +156,9 @@ export function getSkill(
   db: Database,
   name: string
 ): InstalledSkill | null {
-  return (
-    (db
-      .prepare("SELECT * FROM skills WHERE name = ?")
-      .get(name) as InstalledSkill) ?? null
-  );
+  return db
+    .prepare("SELECT * FROM skills WHERE name = ?")
+    .get(name) as InstalledSkill | null;
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -27,6 +27,9 @@ export function errorMessage(err: unknown): string {
       return Object.prototype.toString.call(err);
     }
   }
+  // After all the narrowing branches above, err must be a primitive
+  // (number, boolean, bigint, symbol, function) — String() is safe.
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
   return String(err);
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,57 @@
+/**
+ * Narrow an `unknown` caught value (per TypeScript 4.4+ default catch type)
+ * into a printable string. Replaces the legacy `catch (err: any)
+ * { ... err.message ... }` shape that violates `no-unsafe-member-access`.
+ *
+ * Usage:
+ *   } catch (err) {
+ *     console.error(`failed: ${errorMessage(err)}`);
+ *   }
+ *
+ * Why a helper instead of inlining `err instanceof Error ? err.message : String(err)`?
+ *  - 35+ catch sites in src/ before this refactor; one helper kills the
+ *    repetition.
+ *  - The string-form `String(err)` produces `"[object Object]"` for plain
+ *    objects, which is unhelpful; this helper falls back to `JSON.stringify`
+ *    for those before degrading further. Empty / nullish errors get a
+ *    fixed sentinel so the call site never logs a bare empty string.
+ */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err === undefined || err === null) return "unknown error";
+  if (typeof err === "string") return err;
+  if (typeof err === "object") {
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return Object.prototype.toString.call(err);
+    }
+  }
+  return String(err);
+}
+
+/**
+ * Same shape as {@link errorMessage} but returns the unwrapped `Error`
+ * when one is present, otherwise wraps the original value. Useful for
+ * `throw new Error(..., { cause })` rethrows where the cause field
+ * needs an Error instance.
+ */
+export function asError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(errorMessage(err));
+}
+
+/**
+ * Type guard for Node.js errno errors (ENOENT, EEXIST, EACCES, …).
+ * Replaces the `catch (err: any) { if (err.code === "ENOENT") }` shape
+ * — under strict ESLint the bare `err.code` access is an unsafe-member.
+ *
+ * Usage:
+ *   } catch (err) {
+ *     if (isErrno(err) && err.code === "ENOENT") return null;
+ *     throw err;
+ *   }
+ */
+export function isErrno(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { createSymlink, removeSymlink } from "./symlinks.js";
-import type { ArcManifest, ExtensionEntry } from "../types.js";
+import type { ArcManifest } from "../types.js";
 
 /**
  * Wire extensions declared in a package manifest.

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -10,19 +10,17 @@ import { existsSync, readFileSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import type { HooksDeclaration, InlineHook, HooksConfigRef } from "../types.js";
+import type { HooksDeclaration, InlineHook } from "../types.js";
 
 /** A single hook entry in settings.json's hooks.<event> array */
 interface SettingsHookGroup {
   _pai_pkg?: string;
   matcher?: string;
-  hooks: Array<{ type: string; command: string }>;
+  hooks: { type: string; command: string }[];
 }
 
 /** The hooks section of settings.json */
-interface SettingsHooks {
-  [event: string]: SettingsHookGroup[];
-}
+type SettingsHooks = Record<string, SettingsHookGroup[]>;
 
 /** Minimal settings.json structure (preserves unknown fields) */
 interface Settings {
@@ -86,12 +84,12 @@ export function resolveHooksFromManifest(
   }
 
   // Format 2: config-file reference
-  const configRef = hooks as HooksConfigRef;
+  const configRef = hooks;
   if (!configRef.claude_code?.config) return null;
 
   const configPath = join(installPath, configRef.claude_code.config);
 
-  let configData: Record<string, Array<{ type?: string; command: string }>>;
+  let configData: Record<string, { type?: string; command: string }[]>;
   try {
     const raw = readFileSync(configPath, "utf-8");
     const parsed = JSON.parse(raw);
@@ -171,8 +169,8 @@ function resolveCommandPaths(
  */
 export function findMissingHookFiles(
   hooks: InlineHook[],
-): Array<{ event: string; command: string; missingPath: string }> {
-  const issues: Array<{ event: string; command: string; missingPath: string }> = [];
+): { event: string; command: string; missingPath: string }[] {
+  const issues: { event: string; command: string; missingPath: string }[] = [];
   // Tokens that direct shell I/O — the next path-like token is an output
   // destination, not a required file. ">>" / "<<" are caught by .startsWith.
   const REDIRECT_OPS = new Set([">", ">>", "<", "<<", "|", "&>", "2>", "2>>", "1>"]);
@@ -184,7 +182,7 @@ export function findMissingHookFiles(
         continue;
       }
       const stripped = tokens[i].replace(/^['"]|['"]$/g, "");
-      if (!stripped || !stripped.startsWith("/")) continue;
+      if (!stripped?.startsWith("/")) continue;
       if (!existsSync(stripped)) {
         issues.push({ event: hook.event, command: hook.command, missingPath: stripped });
       }
@@ -202,7 +200,7 @@ export function findMissingHookFiles(
  */
 export async function registerHooks(
   packageName: string,
-  hooks: Array<{ event: string; command: string; matcher?: string }>,
+  hooks: { event: string; command: string; matcher?: string }[],
   settingsPath: string,
 ): Promise<void> {
   const settings = await readSettings(settingsPath);
@@ -266,7 +264,7 @@ export async function removeHooks(
 export function listPackageHooks(
   packageName: string,
   settingsPath: string,
-): Array<{ event: string; command: string }> {
+): { event: string; command: string }[] {
   if (!existsSync(settingsPath)) return [];
 
   let settings: Settings;
@@ -280,7 +278,7 @@ export function listPackageHooks(
 
   if (!settings.hooks) return [];
 
-  const results: Array<{ event: string; command: string }> = [];
+  const results: { event: string; command: string }[] = [];
 
   for (const [event, entries] of Object.entries(settings.hooks)) {
     for (const entry of entries) {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -267,7 +267,6 @@ export function listPackageHooks(
 
   let settings: Settings;
   try {
-    const { readFileSync } = require("fs");
     const raw = readFileSync(settingsPath, "utf-8");
     settings = JSON.parse(raw) as Settings;
   } catch {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -85,14 +85,16 @@ export function resolveHooksFromManifest(
 
   // Format 2: config-file reference
   const configRef = hooks;
-  if (!configRef.claude_code?.config) return null;
+  if (!configRef.claude_code.config) return null;
 
   const configPath = join(installPath, configRef.claude_code.config);
 
-  let configData: Record<string, { type?: string; command: string }[]>;
+  interface HookEntry { type?: string; command: string }
+  type HookMap = Record<string, HookEntry[]>;
+  let configData: HookMap;
   try {
     const raw = readFileSync(configPath, "utf-8");
-    const parsed = JSON.parse(raw);
+    const parsed = JSON.parse(raw) as { hooks?: HookMap } & HookMap;
     // The JSON file has either { hooks: { Event: [...] } } or { Event: [...] }
     configData = parsed.hooks ?? parsed;
   } catch {
@@ -182,7 +184,7 @@ export function findMissingHookFiles(
         continue;
       }
       const stripped = tokens[i].replace(/^['"]|['"]$/g, "");
-      if (!stripped?.startsWith("/")) continue;
+      if (!stripped.startsWith("/")) continue;
       if (!existsSync(stripped)) {
         issues.push({ event: hook.event, command: hook.command, missingPath: stripped });
       }
@@ -208,6 +210,9 @@ export async function registerHooks(
   settings.hooks ??= {};
 
   for (const hook of hooks) {
+    // Record<string, T> indexing is typed as always-defined without
+    // noUncheckedIndexedAccess; the runtime check is still needed.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!settings.hooks[hook.event]) {
       settings.hooks[hook.event] = [];
     }

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -205,9 +205,7 @@ export async function registerHooks(
 ): Promise<void> {
   const settings = await readSettings(settingsPath);
 
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
+  settings.hooks ??= {};
 
   for (const hook of hooks) {
     if (!settings.hooks[hook.event]) {

--- a/src/lib/hosts/launchd-install.ts
+++ b/src/lib/hosts/launchd-install.ts
@@ -66,7 +66,7 @@ export function buildLaunchdTokens(opts: {
  */
 export function renderPlist(template: string, tokens: LaunchdTokens): string {
   return template.replace(/\{\{([A-Za-z0-9_-]+)\}\}/g, (match, key: string) => {
-    return key in tokens ? tokens[key]! : match;
+    return key in tokens ? tokens[key] : match;
   });
 }
 

--- a/src/lib/hosts/launchd-install.ts
+++ b/src/lib/hosts/launchd-install.ts
@@ -1,13 +1,14 @@
 import { existsSync } from "fs";
 import { mkdir, readFile, unlink } from "fs/promises";
 import { homedir } from "os";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import type {
   ArcManifest,
   DarwinLaunchdHostPaths,
   HostAdapter,
 } from "../../types.js";
 import { createSymlink, removeSymlink } from "../symlinks.js";
+import { errorMessage, isErrno } from "../errors.js";
 
 /**
  * Token substitution map for plist rendering.
@@ -116,7 +117,7 @@ export async function installLaunchdArtifacts(opts: {
     }
     // The binary's name in PATH is the basename of provides.binary —
     // a manifest declaring `binary: bin/sage` lands as `~/bin/sage`.
-    const binName = provides.binary.split("/").pop()!;
+    const binName = basename(provides.binary);
     const binLinkPath = join(opts.host.paths.binDir, binName);
     await mkdir(opts.host.paths.binDir, { recursive: true });
     await createSymlink(sourceBinPath, binLinkPath);
@@ -147,7 +148,7 @@ export async function installLaunchdArtifacts(opts: {
     // The plist filename lives in the manifest path's basename — a
     // manifest declaring `plist: services/ai.meta-factory.sage.plist`
     // lands as `~/Library/LaunchAgents/ai.meta-factory.sage.plist`.
-    const plistName = provides.plist.split("/").pop()!;
+    const plistName = basename(provides.plist);
     const plistTargetPath = join(opts.host.paths.plistDir, plistName);
     await mkdir(dirname(plistTargetPath), { recursive: true });
     await Bun.write(plistTargetPath, rendered);
@@ -185,7 +186,7 @@ export async function removeLaunchdArtifacts(opts: {
   const provides = opts.manifest.provides ?? {};
 
   if (provides.binary) {
-    const binName = provides.binary.split("/").pop()!;
+    const binName = basename(provides.binary);
     const binLinkPath = join(opts.host.paths.binDir, binName);
     try {
       await unlink(binLinkPath);
@@ -193,17 +194,17 @@ export async function removeLaunchdArtifacts(opts: {
       if (!opts.quiet) {
         console.log(`  ✓ Binary unlinked: ${binLinkPath}`);
       }
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
+    } catch (err) {
+      if (isErrno(err) && err.code !== "ENOENT") {
         console.warn(
-          `  ⚠ remove: failed to unlink launchd binary ${binLinkPath}: ${err?.message ?? err}`,
+          `  ⚠ remove: failed to unlink launchd binary ${binLinkPath}: ${errorMessage(err)}`,
         );
       }
     }
   }
 
   if (provides.plist) {
-    const plistName = provides.plist.split("/").pop()!;
+    const plistName = basename(provides.plist);
     const plistPath = join(opts.host.paths.plistDir, plistName);
     try {
       await unlink(plistPath);
@@ -211,10 +212,10 @@ export async function removeLaunchdArtifacts(opts: {
       if (!opts.quiet) {
         console.log(`  ✓ Plist removed: ${plistPath}`);
       }
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
+    } catch (err) {
+      if (isErrno(err) && err.code !== "ENOENT") {
         console.warn(
-          `  ⚠ remove: failed to unlink launchd plist ${plistPath}: ${err?.message ?? err}`,
+          `  ⚠ remove: failed to unlink launchd plist ${plistPath}: ${errorMessage(err)}`,
         );
       }
     }
@@ -240,10 +241,10 @@ export async function rollbackLaunchdArtifacts(
   if (record.binSymlink) {
     try {
       await removeSymlink(record.binSymlink);
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
+    } catch (err) {
+      if (isErrno(err) && err.code !== "ENOENT") {
         console.warn(
-          `  ⚠ rollback: failed to remove launchd binary symlink ${record.binSymlink}: ${err?.message ?? err}`,
+          `  ⚠ rollback: failed to remove launchd binary symlink ${record.binSymlink}: ${errorMessage(err)}`,
         );
       }
     }
@@ -252,10 +253,10 @@ export async function rollbackLaunchdArtifacts(
     try {
       // Plist is a rendered file (not a symlink). Plain unlink.
       await unlink(record.plistPath);
-    } catch (err: any) {
-      if (err?.code !== "ENOENT") {
+    } catch (err) {
+      if (isErrno(err) && err.code !== "ENOENT") {
         console.warn(
-          `  ⚠ rollback: failed to remove launchd plist ${record.plistPath}: ${err?.message ?? err}`,
+          `  ⚠ rollback: failed to remove launchd plist ${record.plistPath}: ${errorMessage(err)}`,
         );
       }
     }

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -43,7 +43,7 @@ export async function readManifest(
   // skills/tools/prompts must continue to fail at the root if missing.
   const agentDir = join(dir, "agent");
   const agentResult = await readManifestFromDir(agentDir);
-  if (agentResult && agentResult.type === "agent") {
+  if (agentResult?.type === "agent") {
     return agentResult;
   }
   return null;
@@ -153,7 +153,7 @@ export function normalizeCapabilities(manifest: ArcManifest, filename: string): 
 
   const shorthand: string[] = [];
   const invalid: unknown[] = [];
-  const normalized: Array<{ domain: string; reason: string }> = [];
+  const normalized: { domain: string; reason: string }[] = [];
 
   for (const entry of caps.network as unknown[]) {
     if (typeof entry === "string") shorthand.push(entry);
@@ -222,12 +222,12 @@ export function validateTargets(manifest: ArcManifest, filename: string): void {
         `Invalid ${filename}: unknown target host '${entry}'. Known: ${KNOWN_HOST_IDS.join(", ")}`,
       );
     }
-    if (seen.has(entry as HostId)) {
+    if (seen.has(entry)) {
       throw new Error(
         `Invalid ${filename}: duplicate target '${entry}' in 'targets'`,
       );
     }
-    seen.add(entry as HostId);
+    seen.add(entry);
   }
 }
 
@@ -348,12 +348,12 @@ function validateLibraryManifest(parsed: ArcManifest, filename: string): void {
 export async function readLibraryArtifacts(
   libraryDir: string,
   manifest: ArcManifest,
-): Promise<Array<{ entry: import("../types.js").LibraryArtifactEntry; manifest: ArcManifest }>> {
+): Promise<{ entry: import("../types.js").LibraryArtifactEntry; manifest: ArcManifest }[]> {
   if (manifest.type !== "library" || !manifest.artifacts) {
     return [];
   }
 
-  const results: Array<{ entry: import("../types.js").LibraryArtifactEntry; manifest: ArcManifest }> = [];
+  const results: { entry: import("../types.js").LibraryArtifactEntry; manifest: ArcManifest }[] = [];
 
   for (const entry of manifest.artifacts) {
     const artifactDir = join(libraryDir, entry.path);

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -135,9 +135,11 @@ export function normalizeNetworkEntry(
   if (typeof entry === "string") {
     return { domain: entry, reason: "" };
   }
-  if (entry && typeof entry === "object" && typeof (entry as any).domain === "string") {
-    const obj = entry as { domain: string; reason?: unknown };
-    return { domain: obj.domain, reason: typeof obj.reason === "string" ? obj.reason : "" };
+  if (entry && typeof entry === "object") {
+    const obj = entry as { domain?: unknown; reason?: unknown };
+    if (typeof obj.domain === "string") {
+      return { domain: obj.domain, reason: typeof obj.reason === "string" ? obj.reason : "" };
+    }
   }
   return null;
 }

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import YAML from "yaml";
 import type { ArcManifest, HostId, RiskLevel } from "../types.js";
 import { KNOWN_HOST_IDS } from "../types.js";
+import { isErrno } from "./errors.js";
 
 /** Preferred manifest filename (new name). */
 export const MANIFEST_FILENAME = "arc-manifest.yaml";
@@ -114,8 +115,8 @@ async function readManifestFromDir(
       validateLifecycle(parsed, filename);
 
       return parsed;
-    } catch (err: any) {
-      if (err.code === "ENOENT") continue;
+    } catch (err) {
+      if (isErrno(err) && err.code === "ENOENT") continue;
       throw err;
     }
   }

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -198,15 +198,17 @@ export async function fetchMetafactoryRegistry(
         return await readCachedRegistry(cachePath, source);
       }
 
-      const body = (await response.json()) as MetafactoryPackageListResponse;
-      if (!body.packages || !Array.isArray(body.packages)) {
+      const body = (await response.json()) as Partial<MetafactoryPackageListResponse>;
+      if (!Array.isArray(body.packages)) {
         debugLog(`Invalid response from ${source.name}: missing packages array`);
         return await readCachedRegistry(cachePath, source);
       }
       allPackages.push(...body.packages);
 
       // Check if there are more pages
-      if (body.packages.length < body.per_page || allPackages.length >= body.total) {
+      const perPage = body.per_page ?? body.packages.length;
+      const total = body.total ?? allPackages.length;
+      if (body.packages.length < perPage || allPackages.length >= total) {
         break;
       }
       page++;

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -224,7 +224,7 @@ export async function fetchMetafactoryRegistry(
   debugLog(`Fetched ${allPackages.length} packages from ${source.name}`);
 
   // Cache the result
-  await cacheRegistry(cachePath, source, config).catch((_err) => {
+  await cacheRegistry(cachePath, source, config).catch((_err: unknown) => {
     // Cache write failure is non-fatal
     debugLog(`Failed to cache results for ${source.name}`);
   });

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -182,23 +182,23 @@ export async function fetchMetafactoryRegistry(
 
       if (response.status === 401 || response.status === 403) {
         process.stderr.write(`Access denied by ${source.name}. The registry may require authentication for this endpoint.\n`);
-        return readCachedRegistry(cachePath, source);
+        return await readCachedRegistry(cachePath, source);
       }
 
       if (response.status === 429) {
         process.stderr.write(`Rate limited by ${source.name}. Try again later.\n`);
-        return readCachedRegistry(cachePath, source);
+        return await readCachedRegistry(cachePath, source);
       }
 
       if (!response.ok) {
         debugLog(`API error from ${source.name}: ${response.status}`);
-        return readCachedRegistry(cachePath, source);
+        return await readCachedRegistry(cachePath, source);
       }
 
       const body = (await response.json()) as MetafactoryPackageListResponse;
       if (!body.packages || !Array.isArray(body.packages)) {
         debugLog(`Invalid response from ${source.name}: missing packages array`);
-        return readCachedRegistry(cachePath, source);
+        return await readCachedRegistry(cachePath, source);
       }
       allPackages.push(...body.packages);
 

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -133,10 +133,13 @@ function convertToRegistryConfig(packages: MetafactoryPackageListItem[]): Regist
     // pipeline, action, rules all route to skills — arc's registry model treats them
     // as skill subtypes. Separate arrays exist in RegistryConfig but are only used
     // by REGISTRY.yaml sources that explicitly categorize them.
+    if (artifactType === "component") {
+      config.registry.components ??= [];
+    }
     const target = artifactType === "tool" ? config.registry.tools
       : artifactType === "agent" ? config.registry.agents
       : artifactType === "prompt" ? config.registry.prompts
-      : artifactType === "component" ? config.registry.components!
+      : artifactType === "component" ? config.registry.components ?? []
       : config.registry.skills;
     target.push(entry);
   }

--- a/src/lib/metafactory-api.ts
+++ b/src/lib/metafactory-api.ts
@@ -133,9 +133,9 @@ function convertToRegistryConfig(packages: MetafactoryPackageListItem[]): Regist
     // pipeline, action, rules all route to skills — arc's registry model treats them
     // as skill subtypes. Separate arrays exist in RegistryConfig but are only used
     // by REGISTRY.yaml sources that explicitly categorize them.
-    const target = artifactType === "tool" ? config.registry.tools!
-      : artifactType === "agent" ? config.registry.agents!
-      : artifactType === "prompt" ? config.registry.prompts!
+    const target = artifactType === "tool" ? config.registry.tools
+      : artifactType === "agent" ? config.registry.agents
+      : artifactType === "prompt" ? config.registry.prompts
       : artifactType === "component" ? config.registry.components!
       : config.registry.skills;
     target.push(entry);

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -36,10 +36,11 @@ function resolveConfigRoot(override?: string): string {
   const usingOverride = !!override;
   const defaultConfigRoot = join(home, ".config", "metafactory");
 
+  const envConfigRoot = process.env.ARC_CONFIG_ROOT;
   const configRoot =
     override ??
-    (usingEnvVar
-      ? process.env.ARC_CONFIG_ROOT!.replace(/^~/, home)
+    (envConfigRoot
+      ? envConfigRoot.replace(/^~/, home)
       : defaultConfigRoot);
 
   if (!usingEnvVar && !usingOverride) {

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -79,8 +79,10 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
   // Network: arc uses [{ domain, reason }] (string shorthand "example.com" is
   // normalised at readManifest, but coerce defensively here in case a manifest
   // was constructed in-memory without going through readManifest — issue #79).
-  // Server schema requires { domain }.
-  const network = (caps.network ?? []).flatMap((n): { domain: string }[] => {
+  // Server schema requires { domain }. The type asserts every entry is an
+  // object, but legacy YAML may have plain strings — cast through unknown.
+  const networkEntries = (caps.network ?? []) as unknown[];
+  const network = networkEntries.flatMap((n): { domain: string }[] => {
     if (typeof n === "string") return [{ domain: n }];
     if (n && typeof n === "object") {
       const obj = n as { domain?: unknown };

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -82,7 +82,10 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
   // Server schema requires { domain }.
   const network = (caps.network ?? []).flatMap((n): { domain: string }[] => {
     if (typeof n === "string") return [{ domain: n }];
-    if (n && typeof (n as any).domain === "string") return [{ domain: (n as any).domain }];
+    if (n && typeof n === "object") {
+      const obj = n as { domain?: unknown };
+      if (typeof obj.domain === "string") return [{ domain: obj.domain }];
+    }
     return [];
   });
 

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -63,7 +63,7 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
   const caps = manifest.capabilities ?? {};
 
   // Filesystem: arc uses { read: [path], write: [path] }, server uses [{ path, access }]
-  const filesystem: Array<{ path: string; access: string }> = [];
+  const filesystem: { path: string; access: string }[] = [];
   for (const p of (caps.filesystem?.read ?? [])) {
     filesystem.push({ path: p, access: "read" });
   }
@@ -75,14 +75,14 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
   // normalised at readManifest, but coerce defensively here in case a manifest
   // was constructed in-memory without going through readManifest — issue #79).
   // Server schema requires { domain }.
-  const network = (caps.network ?? []).flatMap((n): Array<{ domain: string }> => {
+  const network = (caps.network ?? []).flatMap((n): { domain: string }[] => {
     if (typeof n === "string") return [{ domain: n }];
     if (n && typeof (n as any).domain === "string") return [{ domain: (n as any).domain }];
     return [];
   });
 
   // Bash → subprocess
-  const subprocess: Array<{ command: string }> = [];
+  const subprocess: { command: string }[] = [];
   if (caps.bash?.allowed) {
     for (const cmd of (caps.bash.restricted_to ?? [])) {
       subprocess.push({ command: cmd });

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -31,8 +31,13 @@ function formatServerError(err: unknown): string | undefined {
     const obj = err as { message?: unknown; error?: unknown };
     if (typeof obj.message === "string") return obj.message;
     if (typeof obj.error === "string") return obj.error;
-    try { return JSON.stringify(err); } catch { return String(err); }
+    try { return JSON.stringify(err); } catch {
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      return String(err);
+    }
   }
+  // After narrowing above, err is a primitive — String() is safe.
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
   return String(err);
 }
 

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -466,7 +466,7 @@ export async function extractPackage(
   }
 
   // Clean up tarball -- cleanup failure is non-fatal
-  await unlink(tarballPath).catch((_err) => {});
+  await unlink(tarballPath).catch((_err: unknown) => {});
 
   // Verify manifest exists
   const hasManifest = existsSync(join(extractedPath, "arc-manifest.yaml")) ||

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -21,12 +21,12 @@ export function parsePackageRef(input: string): PackageRef | null {
   if (input.startsWith("http") || input.startsWith("git@") || input.startsWith("file://")) return null;
   if (input.startsWith("./") || input.startsWith("/") || input.startsWith("~")) return null;
 
-  const match = input.match(PACKAGE_REF_RE);
+  const match = PACKAGE_REF_RE.exec(input);
   if (!match) return null;
 
   return {
-    scope: match[1]!,
-    name: match[2]!,
+    scope: match[1],
+    name: match[2],
     version: match[3] || undefined,
   };
 }
@@ -335,7 +335,7 @@ export async function downloadPackage(
   const tempPath = join(tempDir, `arc-download-${Date.now()}.tar.gz`);
 
   const headers: Record<string, string> = {};
-  if (source && source.token && getSourceType(source) === "metafactory") {
+  if (source?.token && getSourceType(source) === "metafactory") {
     headers.Authorization = `Bearer ${source.token}`;
   }
 

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -204,6 +204,10 @@ function banner(label: string, palette: string, colorEnabled: boolean): string {
  * legitimate prose punctuation; everything else gets replaced with U+FFFD.
  */
 function sanitizeForTerminal(s: string): string {
+  // Intentional control-char range — we're stripping terminal control
+  // sequences that could spoof banner output. Newline (\x0a) and tab
+  // (\x09) survive because they're legitimate prose punctuation.
+  // eslint-disable-next-line no-control-regex
   return s.replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g, "�");
 }
 

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -465,8 +465,9 @@ export async function extractPackage(
     };
   }
 
-  // Clean up tarball -- cleanup failure is non-fatal
-  await unlink(tarballPath).catch((_err: unknown) => {});
+  await unlink(tarballPath).catch((_err: unknown) => {
+    // best-effort cleanup; tarball may already be gone
+  });
 
   // Verify manifest exists
   const hasManifest = existsSync(join(extractedPath, "arc-manifest.yaml")) ||

--- a/src/lib/registry-signing.ts
+++ b/src/lib/registry-signing.ts
@@ -100,7 +100,7 @@ export async function verifyRegistrySignature(
     const pubBuf = pubBytes.buffer.slice(pubBytes.byteOffset, pubBytes.byteOffset + pubBytes.byteLength) as ArrayBuffer;
     const sigBuf = sigBytes.buffer.slice(sigBytes.byteOffset, sigBytes.byteOffset + sigBytes.byteLength) as ArrayBuffer;
     const msgBytes = new TextEncoder().encode(manifestCanonical);
-    const msgBuf = msgBytes.buffer.slice(msgBytes.byteOffset, msgBytes.byteOffset + msgBytes.byteLength) as ArrayBuffer;
+    const msgBuf = msgBytes.buffer.slice(msgBytes.byteOffset, msgBytes.byteOffset + msgBytes.byteLength);
 
     const key = await crypto.subtle.importKey(
       "raw",

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -19,20 +19,21 @@ export async function loadRegistry(
 ): Promise<RegistryConfig | null> {
   try {
     const content = await readFile(registryPath, "utf-8");
-    const parsed = YAML.parse(content) as RegistryConfig;
+    const raw = YAML.parse(content) as Partial<RegistryConfig> | null;
 
-    if (!parsed.registry) {
+    if (!raw?.registry) {
       throw new Error("Invalid registry.yaml: missing 'registry' section");
     }
 
-    parsed.registry.skills ??= [];
-    parsed.registry.agents ??= [];
-    parsed.registry.prompts ??= [];
-    parsed.registry.tools ??= [];
-    parsed.registry.components ??= [];
-    parsed.registry.rules ??= [];
+    const reg = raw.registry as Partial<RegistryConfig["registry"]>;
+    reg.skills ??= [];
+    reg.agents ??= [];
+    reg.prompts ??= [];
+    reg.tools ??= [];
+    reg.components ??= [];
+    reg.rules ??= [];
 
-    return parsed;
+    return raw as RegistryConfig;
   } catch (err) {
     if (isErrno(err) && err.code === "ENOENT") return null;
     throw err;

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -8,6 +8,7 @@ import type {
   CatalogEntry,
 } from "../types.js";
 import { findEntry } from "./catalog.js";
+import { isErrno } from "./errors.js";
 
 /**
  * Load and parse registry.yaml from the given path.
@@ -32,8 +33,8 @@ export async function loadRegistry(
     parsed.registry.rules ??= [];
 
     return parsed;
-  } catch (err: any) {
-    if (err.code === "ENOENT") return null;
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return null;
     throw err;
   }
 }

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -44,11 +44,11 @@ export async function loadRegistry(
 export function searchRegistry(
   config: RegistryConfig,
   keyword: string
-): Array<{ entry: RegistryEntry; artifactType: ArtifactType }> {
+): { entry: RegistryEntry; artifactType: ArtifactType }[] {
   const lower = keyword.toLowerCase();
-  const results: Array<{ entry: RegistryEntry; artifactType: ArtifactType }> = [];
+  const results: { entry: RegistryEntry; artifactType: ArtifactType }[] = [];
 
-  const sections: Array<{ entries: RegistryEntry[]; type: ArtifactType }> = [
+  const sections: { entries: RegistryEntry[]; type: ArtifactType }[] = [
     { entries: config.registry.skills, type: "skill" },
     { entries: config.registry.agents, type: "agent" },
     { entries: config.registry.prompts, type: "prompt" },
@@ -156,7 +156,7 @@ export function addFromRegistry(
  * Format registry search results for display.
  */
 export function formatRegistrySearch(
-  results: Array<{ entry: RegistryEntry; artifactType: ArtifactType }>
+  results: { entry: RegistryEntry; artifactType: ArtifactType }[]
 ): string {
   if (!results.length) return "No matches found in registry.";
 

--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -17,6 +17,33 @@ function cacheFileName(source: RegistrySource): string {
   return `${source.name}.yaml`;
 }
 
+/**
+ * Normalize a YAML-parsed registry document into RegistryConfig shape.
+ * Returns `null` if the document doesn't have the required `registry`
+ * key, otherwise fills every optional sub-array with `[]` so callers
+ * can read them without defensive guards.
+ *
+ * Centralizes the YAML-parse boundary so the `parsed?.registry` /
+ * `??= []` defensive pattern lives in one place rather than spreading
+ * across every fetch path (16 no-unnecessary-condition warnings on the
+ * pre-extract code surface).
+ */
+function normalizeRegistry(parsed: unknown): RegistryConfig | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  // The cast nests Partial into the sub-fields so the `??= []` assignments
+  // below compile against an actually-nullable shape. RegistryConfig's
+  // declared shape lies about post-parse: YAML may omit any array.
+  const r = parsed as { registry?: Partial<RegistryConfig["registry"]> };
+  if (!r.registry || typeof r.registry !== "object") return null;
+  r.registry.skills ??= [];
+  r.registry.agents ??= [];
+  r.registry.prompts ??= [];
+  r.registry.tools ??= [];
+  r.registry.components ??= [];
+  r.registry.rules ??= [];
+  return r as RegistryConfig;
+}
+
 async function isCacheFresh(
   cachePath: string,
   source: RegistrySource
@@ -53,15 +80,7 @@ export async function fetchRemoteRegistry(
     const filePath = source.url.replace("file://", "");
     try {
       const content = await readFile(filePath, "utf-8");
-      const parsed = YAML.parse(content) as RegistryConfig;
-      if (!parsed?.registry) return null;
-      parsed.registry.skills ??= [];
-      parsed.registry.agents ??= [];
-      parsed.registry.prompts ??= [];
-      parsed.registry.tools ??= [];
-      parsed.registry.components ??= [];
-      parsed.registry.rules ??= [];
-      return parsed;
+      return normalizeRegistry(YAML.parse(content));
     } catch (err) {
       process.stderr.write(`Warning: failed to read local source "${source.name}": ${filePath}: ${errorMessage(err)}\n`);
       return null;
@@ -74,8 +93,8 @@ export async function fetchRemoteRegistry(
   if (!forceRefresh && (await isCacheFresh(cachePath, source))) {
     try {
       const content = await readFile(cached, "utf-8");
-      const parsed = YAML.parse(content) as RegistryConfig;
-      if (parsed?.registry) return parsed;
+      const parsed = normalizeRegistry(YAML.parse(content));
+      if (parsed) return parsed;
     } catch {
       // Cache corrupt, fetch fresh
     }
@@ -125,15 +144,8 @@ export async function fetchRemoteRegistry(
     }
 
     const text = await response.text();
-    const parsed = YAML.parse(text) as RegistryConfig;
-
-    if (!parsed?.registry) return null;
-
-    parsed.registry.skills ??= [];
-    parsed.registry.agents ??= [];
-    parsed.registry.prompts ??= [];
-    parsed.registry.tools ??= [];
-    parsed.registry.components ??= [];
+    const parsed = normalizeRegistry(YAML.parse(text));
+    if (!parsed) return null;
 
     // Cache the result
     if (!existsSync(cachePath)) {
@@ -150,8 +162,8 @@ export async function fetchRemoteRegistry(
     if (existsSync(cached)) {
       try {
         const content = await readFile(cached, "utf-8");
-        const parsed = YAML.parse(content) as RegistryConfig;
-        if (parsed?.registry) {
+        const parsed = normalizeRegistry(YAML.parse(content));
+        if (parsed) {
           process.stderr.write(`   Using stale cache for "${source.name}"\n`);
           return parsed;
         }

--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -9,6 +9,7 @@ import type {
   SourcedSearchResult,
 } from "../types.js";
 import { searchRegistry, findRegistryEntry } from "./registry.js";
+import { errorMessage } from "./errors.js";
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -61,8 +62,8 @@ export async function fetchRemoteRegistry(
       parsed.registry.components ??= [];
       parsed.registry.rules ??= [];
       return parsed;
-    } catch (err: any) {
-      process.stderr.write(`Warning: failed to read local source "${source.name}": ${filePath}: ${err.message ?? err}\n`);
+    } catch (err) {
+      process.stderr.write(`Warning: failed to read local source "${source.name}": ${filePath}: ${errorMessage(err)}\n`);
       return null;
     }
   }
@@ -141,10 +142,10 @@ export async function fetchRemoteRegistry(
     await writeFile(cached, text, "utf-8");
 
     return parsed;
-  } catch (err: any) {
+  } catch (err) {
     // Network failure — warn and try stale cache
     process.stderr.write(
-      `Warning: network error fetching source "${source.name}": ${err.message ?? err}\n`,
+      `Warning: network error fetching source "${source.name}": ${errorMessage(err)}\n`,
     );
     if (existsSync(cached)) {
       try {

--- a/src/lib/remote-registry.ts
+++ b/src/lib/remote-registry.ts
@@ -7,11 +7,8 @@ import type {
   RegistrySource,
   SourcesConfig,
   SourcedSearchResult,
-  ArtifactType,
-  RegistryEntry,
-  PackageTier,
 } from "../types.js";
-import { loadRegistry, searchRegistry, findRegistryEntry } from "./registry.js";
+import { searchRegistry, findRegistryEntry } from "./registry.js";
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -96,7 +93,7 @@ export async function fetchRemoteRegistry(
     const rewritten = rewriteRawToContentsApi(source.url);
     if (rewritten) {
       fetchUrl = rewritten;
-      headers["Accept"] = "application/vnd.github.raw";
+      headers.Accept = "application/vnd.github.raw";
       headers["X-GitHub-Api-Version"] = "2022-11-28";
     }
 
@@ -104,7 +101,7 @@ export async function fetchRemoteRegistry(
     if (fetchUrl.includes("github")) {
       const token = process.env.GITHUB_TOKEN ?? getGhToken();
       if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
+        headers.Authorization = `Bearer ${token}`;
       }
     }
 
@@ -217,7 +214,7 @@ export async function findInAllSources(
       artifactType: found.artifactType,
       sourceName: source.name,
       sourceTier: source.tier,
-    } as SourcedSearchResult;
+    };
   });
 
   const results = await Promise.all(fetches);
@@ -230,9 +227,9 @@ export async function findInAllSources(
 export async function updateAllSources(
   sources: SourcesConfig,
   cachePath: string
-): Promise<Array<{ name: string; status: "ok" | "failed"; count?: number }>> {
+): Promise<{ name: string; status: "ok" | "failed"; count?: number }[]> {
   const enabledSources = sources.sources.filter((s) => s.enabled);
-  const results: Array<{ name: string; status: "ok" | "failed"; count?: number }> = [];
+  const results: { name: string; status: "ok" | "failed"; count?: number }[] = [];
 
   for (const source of enabledSources) {
     const registry = await fetchRemoteRegistry(source, cachePath, true);
@@ -296,12 +293,10 @@ export function formatSourcedSearch(results: SourcedSearchResult[]): string {
  * the response body is the raw file content (same shape as the raw URL).
  */
 export function rewriteRawToContentsApi(url: string): string | null {
-  const match = url.match(
-    /^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/,
-  );
+  const match = /^https:\/\/raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/.exec(url);
   if (!match) return null;
   const [, owner, repo, ref, path] = match;
-  return `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref!)}`;
+  return `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
 }
 
 /** Try to get GitHub token from gh CLI auth */

--- a/src/lib/repo-name.ts
+++ b/src/lib/repo-name.ts
@@ -14,7 +14,7 @@ export function extractRepoName(url: string): string {
   }
   // SSH: git@github.com:user/repo.git
   else {
-    const sshMatch = url.match(/[:\/]([^\/]+)\.git$/);
+    const sshMatch = /[:\/]([^\/]+)\.git$/.exec(url);
     if (sshMatch) {
       name = sshMatch[1];
     } else {

--- a/src/lib/repo-name.ts
+++ b/src/lib/repo-name.ts
@@ -14,7 +14,7 @@ export function extractRepoName(url: string): string {
   }
   // SSH: git@github.com:user/repo.git
   else {
-    const sshMatch = /[:\/]([^\/]+)\.git$/.exec(url);
+    const sshMatch = /[:/]([^/]+)\.git$/.exec(url);
     if (sshMatch) {
       name = sshMatch[1];
     } else {

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -159,14 +159,18 @@ async function injectSections(
   const byPosition = new Map<string, string[]>();
   for (const section of sections) {
     const pos = section.position;
-    if (!byPosition.has(pos)) byPosition.set(pos, []);
+    let bucket = byPosition.get(pos);
+    if (!bucket) {
+      bucket = [];
+      byPosition.set(pos, bucket);
+    }
 
     try {
       const content = await readFile(join(consumerDir, section.file), "utf-8");
-      byPosition.get(pos)!.push(content.trimEnd());
-    } catch (_err: any) {
+      bucket.push(content.trimEnd());
+    } catch {
       // Section file missing — skip with warning comment
-      byPosition.get(pos)!.push(`<!-- Warning: section file not found: ${section.file} -->`);
+      bucket.push(`<!-- Warning: section file not found: ${section.file} -->`);
     }
   }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -13,6 +13,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import YAML from "yaml";
 import type { RulesTemplate, RulesConfig } from "../types.js";
+import { errorMessage, isErrno } from "./errors.js";
 
 export interface GenerateResult {
   target: string;
@@ -66,15 +67,15 @@ async function generateSingleRule(
   try {
     const configContent = await readFile(configPath, "utf-8");
     config = YAML.parse(configContent) as RulesConfig;
-  } catch (err: any) {
-    if (err.code === "ENOENT") {
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") {
       // No config file — skip optional templates, error on required
       if (tmpl.optional) {
         return { target, success: true }; // silently skip
       }
       return { target, success: false, error: `Config file not found: ${tmpl.config}` };
     }
-    return { target, success: false, error: `Failed to read config: ${err.message}` };
+    return { target, success: false, error: `Failed to read config: ${errorMessage(err)}` };
   }
 
   // 2. Check if this format is opted-in (for optional templates)

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -92,7 +92,7 @@ async function generateSingleRule(
   let templateContent: string;
   try {
     templateContent = await readFile(templatePath, "utf-8");
-  } catch (_err: any) {
+  } catch {
     return { target, success: false, error: `Template not found: ${tmpl.source}` };
   }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -91,7 +91,7 @@ async function generateSingleRule(
   let templateContent: string;
   try {
     templateContent = await readFile(templatePath, "utf-8");
-  } catch (err: any) {
+  } catch (_err: any) {
     return { target, success: false, error: `Template not found: ${tmpl.source}` };
   }
 
@@ -151,7 +151,7 @@ function substitutePlaceholders(template: string, config: RulesConfig): string {
  */
 async function injectSections(
   template: string,
-  sections: Array<{ position: string; file: string }>,
+  sections: { position: string; file: string }[],
   consumerDir: string,
 ): Promise<string> {
   // Group sections by position
@@ -163,7 +163,7 @@ async function injectSections(
     try {
       const content = await readFile(join(consumerDir, section.file), "utf-8");
       byPosition.get(pos)!.push(content.trimEnd());
-    } catch (err: any) {
+    } catch (_err: any) {
       // Section file missing — skip with warning comment
       byPosition.get(pos)!.push(`<!-- Warning: section file not found: ${section.file} -->`);
     }

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -83,11 +83,11 @@ export interface RunLifecycleResult {
   /** Phase name, echoed for caller convenience. */
   phase: string;
   /** Per-script results in declared order. Empty when scriptPaths is empty. */
-  steps: Array<{
+  steps: {
     scriptPath: string;
     exitCode: number | null;
     skipped: boolean;
-  }>;
+  }[];
   /** The script that failed, if any — last entry of `steps` when !success. */
   failedAt?: string;
 }

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -34,13 +34,13 @@ export async function loadSources(
   }
 
   const content = await readFile(sourcesPath, "utf-8");
-  const parsed = YAML.parse(content) as SourcesConfig;
+  const parsed = YAML.parse(content) as Partial<SourcesConfig> | null;
 
   if (!parsed?.sources || !Array.isArray(parsed.sources)) {
     return createDefaultSources();
   }
 
-  return parsed;
+  return parsed as SourcesConfig;
 }
 
 export function createDefaultSources(): SourcesConfig {

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -67,7 +67,7 @@ export function validateSource(source: RegistrySource): { valid: boolean; error?
   const type = getSourceType(source);
 
   // Validate type value
-  if (source.type && !VALID_SOURCE_TYPES.includes(source.type as SourceType)) {
+  if (source.type && !VALID_SOURCE_TYPES.includes(source.type)) {
     return { valid: false, error: `Invalid source type "${source.type}". Valid types: ${VALID_SOURCE_TYPES.join(", ")}` };
   }
 

--- a/src/lib/symlinks.ts
+++ b/src/lib/symlinks.ts
@@ -1,4 +1,4 @@
-import { symlink, unlink, readlink, lstat, mkdir, writeFile, chmod, rename } from "fs/promises";
+import { symlink, unlink, readlink, lstat, mkdir, writeFile, rename } from "fs/promises";
 import { join, dirname, basename } from "path";
 import type { ArcManifest } from "../types.js";
 
@@ -103,7 +103,7 @@ export function extractCliInfo(
  */
 export function extractAllCliInfo(
   manifest: ArcManifest
-): Array<{ binName: string; scriptPath: string; command: string }> {
+): { binName: string; scriptPath: string; command: string }[] {
   if (!manifest.provides?.cli?.length) return [];
 
   return manifest.provides.cli.map((cli) => {

--- a/src/lib/symlinks.ts
+++ b/src/lib/symlinks.ts
@@ -1,6 +1,7 @@
 import { symlink, unlink, readlink, lstat, mkdir, writeFile, rename } from "fs/promises";
 import { join, dirname, basename } from "path";
 import type { ArcManifest } from "../types.js";
+import { isErrno } from "./errors.js";
 
 /**
  * Create a symlink, ensuring the parent directory exists.
@@ -22,8 +23,8 @@ export async function createSymlink(
     } else if (stat.isFile()) {
       await unlink(linkPath);
     }
-  } catch (err: any) {
-    if (err.code !== "ENOENT") throw err;
+  } catch (err) {
+    if (!isErrno(err) || err.code !== "ENOENT") throw err;
   }
 
   await symlink(target, linkPath);
@@ -41,8 +42,8 @@ export async function removeSymlink(linkPath: string): Promise<boolean> {
       return true;
     }
     return false;
-  } catch (err: any) {
-    if (err.code === "ENOENT") return false;
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return false;
     throw err;
   }
 }
@@ -157,8 +158,8 @@ export async function removeCliShim(
   try {
     await unlink(shimPath);
     return true;
-  } catch (err: any) {
-    if (err.code === "ENOENT") return false;
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return false;
     throw err;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ export interface Capabilities {
     read?: string[];
     write?: string[];
   };
-  network?: Array<{ domain: string; reason: string }>;
+  network?: { domain: string; reason: string }[];
   bash?: {
     allowed: boolean;
     restricted_to?: string[];
@@ -145,9 +145,9 @@ export interface RulesTemplate {
 /** Rules config schema (claude-md.yaml in consumer repo) */
 export interface RulesConfig {
   template: string;
-  generate?: Array<{ format: string }>;
-  sections?: Array<{ position: string; file: string }>;
-  extra_labels?: Array<{ name: string }>;
+  generate?: { format: string }[];
+  sections?: { position: string; file: string }[];
+  extra_labels?: { name: string }[];
   /** Placeholder values — any key not in the above is a placeholder */
   [key: string]: unknown;
 }
@@ -163,7 +163,15 @@ export interface RulesConfig {
  * the dashboard can render an accurate provenance badge.
  */
 export interface AgentRuntime {
-  substrate: "claude-code" | "codex" | "pi-dev" | "custom-binary" | string;
+  // The `& {}` trick preserves autocomplete for the known literals while
+  // still accepting arbitrary strings (custom substrate names). Without it,
+  // the union collapses to `string` and tooling loses the known-literal hints.
+  substrate:
+    | "claude-code"
+    | "codex"
+    | "pi-dev"
+    | "custom-binary"
+    | (string & {});
   mode: "in-process" | "standalone";
   capabilities?: string[];
 }
@@ -208,19 +216,19 @@ export interface LifecycleScripts {
 }
 
 /** Inline hook array format (e.g. Grove) */
-export type InlineHook = {
+export interface InlineHook {
   event: string;
   command: string;
   matcher?: string;
-};
+}
 
 /** Config-file hook format (e.g. Miner) — references a JSON file */
-export type HooksConfigRef = {
+export interface HooksConfigRef {
   claude_code: {
     config: string;
     description?: string;
   };
-};
+}
 
 /** Union of both hook declaration formats in arc-manifest.yaml */
 export type HooksDeclaration = InlineHook[] | HooksConfigRef;
@@ -273,15 +281,15 @@ export interface ArcManifest {
     github: string;
     verified?: boolean;
   };
-  authors?: Array<{
+  authors?: {
     name: string;
     github: string;
     verified?: boolean;
-  }>;
+  }[];
   provides?: {
     skill?: SkillTrigger[];
     cli?: CliProvider[];
-    files?: Array<{ source: string; target: string }>;
+    files?: { source: string; target: string }[];
     templates?: RulesTemplate[];
     hooks?: HooksDeclaration;
     /**

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -557,9 +557,9 @@ describe("install provides.files (issue #84)", () => {
   async function buildRepoWithProvides(opts: {
     name: string;
     extraFiles?: Record<string, string>;
-    providesFiles?: Array<{ source: string; target: string }>;
-    providesHooks?: Array<{ event: string; command: string }>;
-    providesCli?: Array<{ command: string; name: string }>;
+    providesFiles?: { source: string; target: string }[];
+    providesHooks?: { event: string; command: string }[];
+    providesCli?: { command: string; name: string }[];
     postinstall?: { path: string; content: string };
   }): Promise<string> {
     const repoDir = join(env.root, `mock-${opts.name}`);

--- a/test/commands/nats-revoke.test.ts
+++ b/test/commands/nats-revoke.test.ts
@@ -146,7 +146,7 @@ describe("removeBot — server-side revocation", () => {
     const errSpy = mock(() => undefined);
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = errSpy;
 
     try {
@@ -181,7 +181,7 @@ describe("removeBot — server-side revocation", () => {
     const exitSpy = mock(() => { throw new Error("process.exit called"); });
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = mock(() => undefined);
 
     try {
@@ -257,7 +257,7 @@ describe("reissueBot — server-side revocation of OLD pubkey", () => {
     const exitSpy = mock(() => { throw new Error("process.exit called"); });
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = mock(() => undefined);
 
     try {
@@ -297,7 +297,7 @@ describe("reissueBot — server-side revocation of OLD pubkey", () => {
     const exitSpy = mock(() => { throw new Error("process.exit called"); });
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = mock(() => undefined);
 
     try {
@@ -371,7 +371,7 @@ describe("getUserPubKey — error surface", () => {
     const exitSpy = mock(() => { throw new Error("process.exit called"); });
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = mock(() => undefined);
 
     try {
@@ -399,7 +399,7 @@ describe("getUserPubKey — error surface", () => {
     const exitSpy = mock(() => { throw new Error("process.exit called"); });
     const origExit = process.exit;
     const origErr = console.error;
-    process.exit = exitSpy as unknown as typeof process.exit;
+    process.exit = exitSpy;
     console.error = mock(() => undefined);
 
     try {

--- a/test/commands/remove-hooks-137.test.ts
+++ b/test/commands/remove-hooks-137.test.ts
@@ -127,14 +127,14 @@ describe("arc#137 — remove cleans hooks even when manifest is unreadable", () 
 
     // Sanity: entry present before remove
     const before = await readSettings();
-    const beforeEntries = (before.hooks?.SessionStart ?? []) as Array<{ _pai_pkg?: string }>;
+    const beforeEntries = (before.hooks?.SessionStart ?? []) as { _pai_pkg?: string }[];
     expect(beforeEntries.some((h) => h._pai_pkg === name)).toBe(true);
 
     const result = await remove(env.db, env.arc, env.host, name, { yes: true });
     expect(result.success).toBe(true);
 
     const after = await readSettings();
-    const afterEntries = (after.hooks?.SessionStart ?? []) as Array<{ _pai_pkg?: string }>;
+    const afterEntries = (after.hooks?.SessionStart ?? []) as { _pai_pkg?: string }[];
     expect(afterEntries.some((h) => h._pai_pkg === name)).toBe(false);
     // Unrelated package untouched
     expect(afterEntries.some((h) => h._pai_pkg === "OtherPackage")).toBe(true);
@@ -156,7 +156,7 @@ describe("arc#137 — remove cleans hooks even when manifest is unreadable", () 
     // Pre-fix this would still contain the BetaSkill entry — null manifest
     // short-circuited the removeHooks call.
     const after = await readSettings();
-    const afterEntries = (after.hooks?.SessionStart ?? []) as Array<{ _pai_pkg?: string }>;
+    const afterEntries = (after.hooks?.SessionStart ?? []) as { _pai_pkg?: string }[];
     expect(afterEntries.some((h) => h._pai_pkg === name)).toBe(false);
     expect(afterEntries.some((h) => h._pai_pkg === "OtherPackage")).toBe(true);
   });
@@ -174,7 +174,7 @@ describe("arc#137 — remove cleans hooks even when manifest is unreadable", () 
     expect(result.success).toBe(true);
 
     const after = await readSettings();
-    const afterEntries = (after.hooks?.SessionStart ?? []) as Array<{ _pai_pkg?: string }>;
+    const afterEntries = (after.hooks?.SessionStart ?? []) as { _pai_pkg?: string }[];
     expect(afterEntries.some((h) => h._pai_pkg === name)).toBe(false);
     expect(afterEntries.some((h) => h._pai_pkg === "OtherPackage")).toBe(true);
   });
@@ -201,7 +201,7 @@ describe("arc#137 — remove cleans hooks even when manifest is unreadable", () 
     expect(result.success).toBe(true);
 
     const after = await readSettings();
-    const afterEntries = (after.hooks?.SessionStart ?? []) as Array<{ _pai_pkg?: string }>;
+    const afterEntries = (after.hooks?.SessionStart ?? []) as { _pai_pkg?: string }[];
     expect(afterEntries.length).toBe(1);
     expect(afterEntries[0]._pai_pkg).toBe("OtherPackage");
   });

--- a/test/commands/remove-multitarget-i140.test.ts
+++ b/test/commands/remove-multitarget-i140.test.ts
@@ -50,8 +50,8 @@ const hostOverrides = () => ({
 async function makeStandaloneBotRepo(opts: {
   name: string;
   lifecycle?: {
-    preuninstall?: Array<{ path: string; content: string }>;
-    postuninstall?: Array<{ path: string; content: string }>;
+    preuninstall?: { path: string; content: string }[];
+    postuninstall?: { path: string; content: string }[];
   };
 }): Promise<{ url: string }> {
   const repoDir = join(env.root, `mock-${opts.name}`);
@@ -85,7 +85,7 @@ async function makeStandaloneBotRepo(opts: {
     ? `lifecycle:
 ${Object.entries(opts.lifecycle)
   .filter(([, arr]) => arr && arr.length > 0)
-  .map(([phase, arr]) => `  ${phase}:\n${arr!.map((s) => `    - ${s.path}`).join("\n")}`)
+  .map(([phase, arr]) => `  ${phase}:\n${arr.map((s) => `    - ${s.path}`).join("\n")}`)
   .join("\n")}
 `
     : "";

--- a/test/commands/search.test.ts
+++ b/test/commands/search.test.ts
@@ -201,7 +201,7 @@ describe("searchAcrossSources", () => {
     };
     // Suppress stderr from fetchRemoteRegistry warnings
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const result = await searchAcrossSources(config, env.arc.cachePath);
       expect(result.warnings.length).toBe(1);
@@ -229,7 +229,7 @@ describe("searchAcrossSources", () => {
 
     // Suppress stderr from fetchRemoteRegistry warnings
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const result = await searchAcrossSources(config, env.arc.cachePath);
       expect(result.results.length).toBe(1);

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -453,9 +453,9 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
   test("tests never touch real ~/.claude or ~/.config", () => {
     // Verify test paths don't point to real directories
-    expect(env.host.paths.root).not.toContain(Bun.env.HOME + "/.claude");
+    expect(env.host.paths.root).not.toContain(`${Bun.env.HOME ?? ""}/.claude`);
     expect(env.arc.configRoot).not.toContain(
-      Bun.env.HOME + "/.config/metafactory"
+      `${Bun.env.HOME ?? ""}/.config/metafactory`,
     );
     expect(env.host.paths.root).toContain("arc-test-");
   });

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -449,10 +449,12 @@ function buildYaml(obj: any, indent = 0): string {
     } else if (typeof val === "object") {
       out += `${pad}${key}:\n`;
       out += buildYaml(val, indent + 1);
-    } else if (typeof val === "boolean") {
+    } else if (typeof val === "boolean" || typeof val === "number" || typeof val === "string") {
       out += `${pad}${key}: ${val}\n`;
     } else {
-      out += `${pad}${key}: ${val}\n`;
+      // Fallback for unexpected types (bigint, symbol, function); JSON.stringify
+      // gives a sensible "null"/quoted representation.
+      out += `${pad}${key}: ${JSON.stringify(val)}\n`;
     }
   }
 

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -89,19 +89,19 @@ export async function createMockSkillRepo(
     version?: string;
     author?: string;
     /** Use authors array format instead of singular author */
-    authors?: Array<{ name: string; github: string }>;
+    authors?: { name: string; github: string }[];
     /** Artifact type: skill (default), tool, agent, prompt, component, pipeline, action */
     type?: "skill" | "tool" | "agent" | "prompt" | "component" | "pipeline" | "action";
     withCli?: boolean;
     withoutManifest?: boolean;
     capabilities?: {
-      network?: Array<{ domain: string; reason: string }>;
+      network?: { domain: string; reason: string }[];
       filesystem?: { read?: string[]; write?: string[] };
       bash?: { allowed: boolean; restricted_to?: string[] };
       secrets?: string[];
     };
     /** Additional CLI entries beyond the default one */
-    extraCli?: Array<{ name: string; command: string }>;
+    extraCli?: { name: string; command: string }[];
     /** Lifecycle scripts to declare in the manifest and create on disk */
     scripts?: {
       preinstall?: { path: string; content: string };
@@ -112,7 +112,7 @@ export async function createMockSkillRepo(
     };
     /** provides.files entries to declare in the manifest. Source files
      *  are created on disk so install can symlink them. */
-    files?: Array<{ source: string; target: string; content?: string }>;
+    files?: { source: string; target: string; content?: string }[];
     /**
      * Ordered lifecycle script arrays (arc#140). Each phase is an ordered
      * list of `{ path, content }`. The helper writes each script to disk
@@ -120,10 +120,10 @@ export async function createMockSkillRepo(
      * the array of paths in declared order.
      */
     lifecycle?: {
-      preinstall?: Array<{ path: string; content: string }>;
-      postinstall?: Array<{ path: string; content: string }>;
-      preuninstall?: Array<{ path: string; content: string }>;
-      postuninstall?: Array<{ path: string; content: string }>;
+      preinstall?: { path: string; content: string }[];
+      postinstall?: { path: string; content: string }[];
+      preuninstall?: { path: string; content: string }[];
+      postuninstall?: { path: string; content: string }[];
     };
   }
 ): Promise<MockSkillRepo> {
@@ -248,7 +248,7 @@ export async function createMockSkillRepo(
         lifecycle: Object.fromEntries(
           Object.entries(opts.lifecycle)
             .filter(([, arr]) => arr && arr.length > 0)
-            .map(([phase, arr]) => [phase, arr!.map((s) => s.path)]),
+            .map(([phase, arr]) => [phase, arr.map((s) => s.path)]),
         ),
       } : {}),
     };
@@ -307,13 +307,13 @@ export async function createMockLibraryRepo(
     name: string;
     version?: string;
     author?: string;
-    artifacts: Array<{
+    artifacts: {
       path: string;
       name: string;
       type: "skill" | "tool" | "agent" | "prompt" | "pipeline" | "component" | "action";
       version?: string;
       description?: string;
-    }>;
+    }[];
   }
 ): Promise<MockLibraryRepo> {
   const repoDir = join(root, `mock-lib-${opts.name}`);

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -154,7 +154,7 @@ describe("validateForPublish", () => {
       version: "1.0.0",
       type: "skill",
       description: "A test skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
   });
@@ -173,7 +173,7 @@ describe("validateForPublish", () => {
       name: "My Skill!",
       version: "1.0.0",
       type: "skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes("name"))).toBe(true);
   });
@@ -192,7 +192,7 @@ describe("validateForPublish", () => {
       name: "my-skill",
       version: "not-semver",
       type: "skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes("semver"))).toBe(true);
   });
@@ -202,7 +202,7 @@ describe("validateForPublish", () => {
       name: "my-skill",
       version: "1.0.0",
       type: "skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(true);
     expect(result.warnings.some((w) => w.includes("description"))).toBe(true);
   });
@@ -212,7 +212,7 @@ describe("validateForPublish", () => {
       name: "my-skill",
       version: "1.0.0",
       type: "invalid" as any,
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes("type"))).toBe(true);
   });

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -163,7 +163,7 @@ describe("validateForPublish", () => {
     const result = validateForPublish({
       version: "1.0.0",
       type: "skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes("name"))).toBe(true);
   });
@@ -182,7 +182,7 @@ describe("validateForPublish", () => {
     const result = validateForPublish({
       name: "my-skill",
       type: "skill",
-    } as ArcManifest);
+    });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.includes("version"))).toBe(true);
   });

--- a/test/unit/catalog.test.ts
+++ b/test/unit/catalog.test.ts
@@ -191,7 +191,7 @@ describe("listCatalog", () => {
     const config = sampleCatalog();
     const items = listCatalog(config, env.db);
     expect(items).toHaveLength(4); // 3 skills + 1 agent
-    expect(items.every((i) => i.installed === false)).toBe(true);
+    expect(items.every((i) => !i.installed)).toBe(true);
   });
 });
 

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -47,7 +47,7 @@ describe("ensureCosignBinary", () => {
   test("returns path or error", async () => {
     // Suppress stderr from potential download messages
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const result = await ensureCosignBinary();
       expect(result.path !== undefined || result.error !== undefined).toBe(true);
@@ -64,7 +64,7 @@ describe("verifySigstoreBundle", () => {
   test("returns invalid for nonexistent artifact and bundle", async () => {
     // Suppress stderr from potential download messages
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const result = await verifySigstoreBundle(
         "/nonexistent/artifact.tar.gz",

--- a/test/unit/db.test.ts
+++ b/test/unit/db.test.ts
@@ -43,7 +43,7 @@ describe("Database", () => {
       .prepare(
         "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
       )
-      .all() as Array<{ name: string }>;
+      .all() as { name: string }[];
 
     const names = tables.map((t) => t.name);
     expect(names).toContain("skills");

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -564,7 +564,7 @@ describe("findMissingHookFiles", () => {
     // is an output sink, not a required input file. Validation must skip it.
     const handler = join(tmpDir, "ok.ts");
     await writeFile(handler, "// ok\n");
-    const missingSink = "/tmp/arc-test-redirect-" + Date.now() + ".log";
+    const missingSink = `/tmp/arc-test-redirect-${Date.now()}.log`;
     const issues = findMissingHookFiles([
       { event: "Stop", command: `${handler} > ${missingSink}` },
       { event: "Stop", command: `${handler} 2> ${missingSink}` },

--- a/test/unit/launchd-install.test.ts
+++ b/test/unit/launchd-install.test.ts
@@ -42,7 +42,7 @@ function fakeAgentManifest(overrides: Partial<ArcManifest> = {}): ArcManifest {
     version: "0.1.0",
     type: "agent",
     ...overrides,
-  } as ArcManifest;
+  };
 }
 
 describe("renderPlist", () => {

--- a/test/unit/manifest.test.ts
+++ b/test/unit/manifest.test.ts
@@ -564,7 +564,7 @@ describe("normalizeCapabilities", () => {
 describe("readManifest — network shorthand (#79)", () => {
   test("string-form network entries parse into object form", async () => {
     const orig = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       await Bun.write(
         join(tempDir, MANIFEST_FILENAME),

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -47,7 +47,7 @@ function makeManifest(overrides?: Partial<ArcManifest>): ArcManifest {
     type: "skill",
     description: "A test",
     ...overrides,
-  } as ArcManifest;
+  };
 }
 
 // ── extractReadme ────────────────────────────────────────────
@@ -326,7 +326,7 @@ describe("toServerManifest — network capability coercion", () => {
     // Simulates a manifest that bypassed readManifest normalisation.
     const m = makeManifest({
       capabilities: {
-        network: ["github.com", "agentskills.io"] as unknown as Array<{ domain: string; reason: string }>,
+        network: ["github.com", "agentskills.io"] as unknown as { domain: string; reason: string }[],
       },
     });
     const server = toServerManifest(m, "test");
@@ -345,11 +345,11 @@ describe("toServerManifest — network capability coercion", () => {
           null,
           undefined,
           42,
-        ] as unknown as Array<{ domain: string; reason: string }>,
+        ] as unknown as { domain: string; reason: string }[],
       },
     });
     const server = toServerManifest(m, "test");
-    const netCaps = (server.capabilities as any).network as Array<{ domain: unknown }>;
+    const netCaps = (server.capabilities as any).network as { domain: unknown }[];
     for (const entry of netCaps) {
       expect(typeof entry.domain).toBe("string");
       expect(entry.domain).not.toBe("");

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -529,7 +529,7 @@ describe("downloadPackage", () => {
   // origin (R2/S3/CDN), the bearer token must not reach the redirect target.
   test("strips Authorization on cross-origin redirect", async () => {
     const originalFetch = globalThis.fetch;
-    const requests: Array<{ url: string; auth: string | null }> = [];
+    const requests: { url: string; auth: string | null }[] = [];
     globalThis.fetch = mockFetch(async (input: any, init?: any) => {
       const url = typeof input === "string" ? input : input.url;
       const headers = new Headers(init?.headers);
@@ -600,7 +600,7 @@ describe("downloadPackage", () => {
     // Internal redirect (e.g. /v1/storage/download/abc → /v2/storage/download/abc
     // on the same origin) is part of the auth surface; strip would break installs.
     const originalFetch = globalThis.fetch;
-    const requests: Array<{ url: string; auth: string | null }> = [];
+    const requests: { url: string; auth: string | null }[] = [];
     globalThis.fetch = mockFetch(async (input: any, init?: any) => {
       const url = typeof input === "string" ? input : input.url;
       const headers = new Headers(init?.headers);

--- a/test/unit/registry-signing.test.ts
+++ b/test/unit/registry-signing.test.ts
@@ -27,7 +27,7 @@ async function generateKeypair() {
     { name: "Ed25519" },
     true,
     ["sign", "verify"],
-  )) as CryptoKeyPair;
+  ));
   const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
   return { kp, rawPubBase64: bytesToBase64(new Uint8Array(raw)) };
 }

--- a/test/unit/remote-registry.test.ts
+++ b/test/unit/remote-registry.test.ts
@@ -72,7 +72,7 @@ describe("fetchRemoteRegistry", () => {
 
     // Capture stderr to keep test output clean
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const result = await fetchRemoteRegistry(source, env.arc.cachePath);
       expect(result).toBeNull();
@@ -219,7 +219,7 @@ describe("searchAllSources", () => {
 
     // Suppress stderr warnings from failed fetches
     const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as any;
+    process.stderr.write = (() => true);
     try {
       const results = await searchAllSources(
         sources,

--- a/test/unit/sources.test.ts
+++ b/test/unit/sources.test.ts
@@ -341,6 +341,11 @@ describe("token handling", () => {
     await Bun.write(env.arc.sourcesPath, YAML.stringify(config));
 
     const loaded = await loadSources(env.arc.sourcesPath);
+    // The test name says it all: confirm empty-string token is `||`-falsy
+    // (downstream code uses `if (token)` for "auth required" gating).
+    // Cannot use `??` here — `??` returns the empty string unchanged,
+    // which would defeat the assertion's purpose.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     expect(loaded.sources[0].token || undefined).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds ESLint (v10) + typescript-eslint v8 with the strict + stylistic type-checked presets. Configured to gate on real bugs (error) and surface preferences (warn) without churning the existing ~15k-LOC src in one PR.

**Final state:** 0 errors, 633 warnings, 861 tests still pass.

## Scripts

| Command | Purpose |
|---------|---------|
| \`bun run lint\` | Surface everything (advisory) |
| \`bun run lint:errors\` | Errors-only gate (CI-friendly) |
| \`bun run lint:fix\` | Auto-fix what's auto-fixable |

## Rule policy

**Error (gate the build):**
- \`no-floating-promises\`, \`no-misused-promises\` — forgotten awaits + async in wrong positions
- \`no-deprecated\` — block new uses of dying APIs
- \`no-redundant-type-constituents\` — catches union members shadowed by wider types (e.g. \`"a" | string\`)
- \`no-unused-vars\` — dead imports + locals (\`_\`-prefix opts out)

**Warn (surfaced, deferred for focused sweep PRs):**
\`require-await\`, \`no-unnecessary-condition\`, \`await-thenable\`, \`no-empty-function\`, \`no-non-null-assertion\`, \`prefer-nullish-coalescing\`, \`no-explicit-any\`, \`no-unsafe-*\` family, \`no-base-to-string\`, \`restrict-template-expressions\`, \`return-await\`, \`no-unused-expressions\`, \`unbound-method\`, \`use-unknown-in-catch-callback-variable\`, \`restrict-plus-operands\`, \`no-useless-escape\`, \`no-useless-assignment\`, \`no-control-regex\`, \`no-require-imports\`, \`preserve-caught-error\`

**Off in tests:** \`no-explicit-any\`, \`no-non-null-assertion\`, \`no-unsafe-*\`, \`no-floating-promises\`, \`no-misused-promises\`, \`restrict-template-expressions\`, \`no-unused-vars\`, \`no-deprecated\` (tests intentionally exercise edge cases the rules guard against).

## Manual fixes applied

- Dropped unused imports across 8 src files (audit / catalog / upgrade-core / upgrade / extensions / hooks / remote-registry / symlinks)
- Prefixed unused params with \`_\` (catalog.catalogPushCatalog, upgrade-core.validate, upgrade.checkUpgrades)
- Prefixed unused caught errors with \`_\` (lib/rules.ts × 2)
- \`db.exec(...)\` → \`db.run(...)\` × 9 in lib/db.ts (Bun.sqlite \`exec\` is deprecated)
- \`AgentRuntime.substrate\` uses the \`& {}\` autocomplete-preservation trick

## Follow-up PRs

Each warn-level category becomes a focused PR that promotes its rule to error after a sweep:
- \`require-await\` (~94 violations — mostly removing redundant \`async\`)
- \`no-unnecessary-condition\` (~63 — existsSync idioms)
- \`no-non-null-assertion\` (~23 — narrow with type guards)
- … etc

## Test plan

- [x] \`bun test\` — 861/0
- [x] \`bun run lint:errors\` — exit 0
- [x] \`bun run lint\` — exit 1, 633 warnings (advisory)
- [x] CLI smoke: \`arc init test-blueprint\` still scaffolds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)