### PR TITLE
feat(login): add --scope option to request packages:write tokens

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.26.2
+version: 0.27.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -828,16 +828,16 @@ program
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .option("-f, --force", "Re-authenticate even if already logged in")
   .option(
-    "--scope <scope>",
-    "Requested token scope (e.g. packages:read, packages:write). Server defaults to packages:read.",
+    "--token-scope <scope>",
+    "Requested token scope (e.g. packages:read, packages:write). Server defaults to packages:read. Named --token-scope to avoid collision with `arc publish --scope <namespace>`.",
   )
-  .action(async (opts: { source?: string; force?: boolean; scope?: string }) => {
+  .action(async (opts: { source?: string; force?: boolean; tokenScope?: string }) => {
     const paths = createArcPaths();
     const result = await login({
       paths,
       sourceName: opts.source,
       force: opts.force,
-      scope: opts.scope,
+      scope: opts.tokenScope,
     });
 
     if (result.success) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -827,9 +827,18 @@ program
   .description("Authenticate with metafactory registry (required for publishing only)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .option("-f, --force", "Re-authenticate even if already logged in")
-  .action(async (opts: { source?: string; force?: boolean }) => {
+  .option(
+    "--scope <scope>",
+    "Requested token scope (e.g. packages:read, packages:write). Server defaults to packages:read.",
+  )
+  .action(async (opts: { source?: string; force?: boolean; scope?: string }) => {
     const paths = createArcPaths();
-    const result = await login({ paths, sourceName: opts.source, force: opts.force });
+    const result = await login({
+      paths,
+      sourceName: opts.source,
+      force: opts.force,
+      scope: opts.scope,
+    });
 
     if (result.success) {
       console.log(`Logged in to ${result.sourceName}`);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,6 +7,13 @@ export interface LoginOptions {
   paths: ArcPaths;
   sourceName?: string;
   force?: boolean;
+  /**
+   * Requested token scope. Marketplace server defaults to `packages:read`
+   * if unset. Pass `packages:write` to obtain a token authorised for
+   * `arc publish`. Other values are forwarded as-is so the server's allow
+   * list remains the single source of truth.
+   */
+  scope?: string;
 }
 
 export interface LoginResult {
@@ -58,6 +65,7 @@ export async function login(opts: LoginOptions): Promise<LoginResult> {
   const result = await pollForToken(source.url, deviceCode.device_code, {
     interval: deviceCode.interval,
     expiresIn: deviceCode.expires_in,
+    scope: opts.scope,
     onPoll: (_attempt, elapsed) => {
       const remaining = deviceCode.expires_in - elapsed;
       process.stdout.write(`\rWaiting for approval... (${remaining}s remaining) `);

--- a/src/lib/device-auth.ts
+++ b/src/lib/device-auth.ts
@@ -3,6 +3,14 @@ import type { DeviceCodeResponse, DeviceVerifyResponse, DeviceAuthResult } from 
 interface PollOptions {
   interval: number;
   expiresIn: number;
+  /**
+   * Token scope to request. The marketplace server defaults to
+   * `packages:read` when unset; pass `packages:write` to obtain a token
+   * authorised for `arc publish`. The web-side approval step is the
+   * authoritative gate — server may reject if the approver hasn't been
+   * granted the requested scope.
+   */
+  scope?: string;
   onPoll?: (attempt: number, elapsed: number) => void;
 }
 
@@ -52,7 +60,9 @@ export async function pollForToken(
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ device_code: deviceCode }),
+        body: JSON.stringify(
+          opts.scope ? { device_code: deviceCode, scope: opts.scope } : { device_code: deviceCode },
+        ),
         signal: AbortSignal.timeout(10_000),
       });
 

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -4,21 +4,49 @@ import { login } from "../../src/commands/login.js";
 import { saveSources } from "../../src/lib/sources.js";
 import type { SourcesConfig } from "../../src/types.js";
 
-// Mock device-auth to prevent real network calls and browser opens
-mock.module("../../src/lib/device-auth.js", () => ({
-  initiateDeviceCode: async () => ({
-    device_code: "test-device-code",
-    user_code: "TEST-CODE",
-    verification_uri: "https://example.com/auth",
-    interval: 1,
-    expires_in: 5,
-  }),
-  pollForToken: async () => ({
-    success: false,
-    error: "Mock: approval timed out",
-  }),
-  openBrowser: () => false,
-}));
+// Baseline device-auth mock — prevents real network calls + browser opens.
+// Tests that need to capture pollForToken args install a per-test mock via
+// `installCapturingDeviceAuth(captured)` and the afterEach below restores
+// this baseline so subsequent tests see a clean module.
+const installBaselineDeviceAuth = () => {
+  mock.module("../../src/lib/device-auth.js", () => ({
+    initiateDeviceCode: async () => ({
+      device_code: "test-device-code",
+      user_code: "TEST-CODE",
+      verification_uri: "https://example.com/auth",
+      interval: 1,
+      expires_in: 5,
+    }),
+    pollForToken: async () => ({
+      success: false,
+      error: "Mock: approval timed out",
+    }),
+    openBrowser: () => false,
+  }));
+};
+installBaselineDeviceAuth();
+
+const installCapturingDeviceAuth = (captured: { scope?: string; seen?: boolean }) => {
+  mock.module("../../src/lib/device-auth.js", () => ({
+    initiateDeviceCode: async () => ({
+      device_code: "test-device-code",
+      user_code: "TEST-CODE",
+      verification_uri: "https://example.com/auth",
+      interval: 1,
+      expires_in: 5,
+    }),
+    pollForToken: async (
+      _baseUrl: string,
+      _deviceCode: string,
+      opts: { scope?: string },
+    ) => {
+      captured.scope = opts.scope;
+      captured.seen = true;
+      return { success: false, error: "Mock: approval timed out" };
+    },
+    openBrowser: () => false,
+  }));
+};
 
 let env: TestEnv;
 
@@ -109,28 +137,16 @@ describe("login - already logged in", () => {
 });
 
 describe("login - scope option", () => {
-  test("forwards opts.scope to pollForToken", async () => {
-    const captured: { scope?: string } = {};
+  // Restore the baseline mock after each capturing-mock test so subsequent
+  // describe blocks (existing or added later) don't inherit the capturing
+  // version — mock.module replaces globally for the test process.
+  afterEach(() => {
+    installBaselineDeviceAuth();
+  });
 
-    // Capture pollForToken args via a per-test mock override
-    mock.module("../../src/lib/device-auth.js", () => ({
-      initiateDeviceCode: async () => ({
-        device_code: "test-device-code",
-        user_code: "TEST-CODE",
-        verification_uri: "https://example.com/auth",
-        interval: 1,
-        expires_in: 5,
-      }),
-      pollForToken: async (
-        _baseUrl: string,
-        _deviceCode: string,
-        opts: { scope?: string },
-      ) => {
-        captured.scope = opts.scope;
-        return { success: false, error: "Mock: approval timed out" };
-      },
-      openBrowser: () => false,
-    }));
+  test("forwards opts.scope to pollForToken", async () => {
+    const captured: { scope?: string; seen?: boolean } = {};
+    installCapturingDeviceAuth(captured);
 
     await saveSources(env.arc.sourcesPath, metafactorySource());
     await login({ paths: env.arc, scope: "packages:write" });
@@ -139,27 +155,8 @@ describe("login - scope option", () => {
   });
 
   test("omits scope from pollForToken when not provided", async () => {
-    const captured: { scope?: string; seen: boolean } = { seen: false };
-
-    mock.module("../../src/lib/device-auth.js", () => ({
-      initiateDeviceCode: async () => ({
-        device_code: "test-device-code",
-        user_code: "TEST-CODE",
-        verification_uri: "https://example.com/auth",
-        interval: 1,
-        expires_in: 5,
-      }),
-      pollForToken: async (
-        _baseUrl: string,
-        _deviceCode: string,
-        opts: { scope?: string },
-      ) => {
-        captured.scope = opts.scope;
-        captured.seen = true;
-        return { success: false, error: "Mock: approval timed out" };
-      },
-      openBrowser: () => false,
-    }));
+    const captured: { scope?: string; seen?: boolean } = {};
+    installCapturingDeviceAuth(captured);
 
     await saveSources(env.arc.sourcesPath, metafactorySource());
     await login({ paths: env.arc });

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -107,3 +107,64 @@ describe("login - already logged in", () => {
     expect(result.error).not.toContain("Already logged in");
   });
 });
+
+describe("login - scope option", () => {
+  test("forwards opts.scope to pollForToken", async () => {
+    const captured: { scope?: string } = {};
+
+    // Capture pollForToken args via a per-test mock override
+    mock.module("../../src/lib/device-auth.js", () => ({
+      initiateDeviceCode: async () => ({
+        device_code: "test-device-code",
+        user_code: "TEST-CODE",
+        verification_uri: "https://example.com/auth",
+        interval: 1,
+        expires_in: 5,
+      }),
+      pollForToken: async (
+        _baseUrl: string,
+        _deviceCode: string,
+        opts: { scope?: string },
+      ) => {
+        captured.scope = opts.scope;
+        return { success: false, error: "Mock: approval timed out" };
+      },
+      openBrowser: () => false,
+    }));
+
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    await login({ paths: env.arc, scope: "packages:write" });
+
+    expect(captured.scope).toBe("packages:write");
+  });
+
+  test("omits scope from pollForToken when not provided", async () => {
+    const captured: { scope?: string; seen: boolean } = { seen: false };
+
+    mock.module("../../src/lib/device-auth.js", () => ({
+      initiateDeviceCode: async () => ({
+        device_code: "test-device-code",
+        user_code: "TEST-CODE",
+        verification_uri: "https://example.com/auth",
+        interval: 1,
+        expires_in: 5,
+      }),
+      pollForToken: async (
+        _baseUrl: string,
+        _deviceCode: string,
+        opts: { scope?: string },
+      ) => {
+        captured.scope = opts.scope;
+        captured.seen = true;
+        return { success: false, error: "Mock: approval timed out" };
+      },
+      openBrowser: () => false,
+    }));
+
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    await login({ paths: env.arc });
+
+    expect(captured.seen).toBe(true);
+    expect(captured.scope).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

\`arc publish\` requires a \`packages:write\` token, but \`arc login\` only ever requested the marketplace's default scope (\`packages:read\`). The marketplace server has accepted a \`scope\` field on \`POST /api/v1/auth/cli/verify\` since the route was added — but arc never sent it.

Discovered while trying to publish \`@mellanon/code-review\` v0.3.2 to the dev marketplace ([meta-factory#476](https://github.com/the-metafactory/meta-factory/issues/476)). Server-side, \`scope: packages:write\` is supported (verified at \`meta-factory/src/__tests__/cli-auth.test.ts:\\\"supports packages:write scope\\\"\` and \`src/routes/cli-auth.ts:228\`). Client-side, the device-code request body was hardcoded to \`{ device_code: deviceCode }\` with no scope.

Net effect today: **no one can \`arc publish\` via the CLI device-code flow** because read-only tokens reject the publish endpoint, and \`arc login\` unhelpfully reports a stale read-only token as \"Already logged in\".

## What changes

Thread \`scope\` through three layers, all opt-in:

\`\`\`diff
 # src/cli.ts — login command
   .option("-f, --force", "Re-authenticate even if already logged in")
+  .option(
+    "--scope <scope>",
+    "Requested token scope (e.g. packages:read, packages:write). Server defaults to packages:read.",
+  )

 # src/commands/login.ts — LoginOptions
   sourceName?: string;
   force?: boolean;
+  scope?: string;

 # src/lib/device-auth.ts — pollForToken request body
-  body: JSON.stringify({ device_code: deviceCode }),
+  body: JSON.stringify(
+    opts.scope ? { device_code: deviceCode, scope: opts.scope } : { device_code: deviceCode },
+  ),
\`\`\`

When \`--scope\` is not passed, the verify request body is byte-identical to before — so the server's default-to-\`packages:read\` behaviour is preserved and no existing call-site has to change. This is a strict superset of the old flow.

Server-side scope policy stays authoritative. arc just forwards the requested value; the marketplace's \`/auth/cli/verify\` handler validates and rejects anything it doesn't recognise (current allow list: \`packages:read\`, \`packages:write\`).

## Usage

\`\`\`bash
arc login --source metafactory-dev --scope packages:write --force
\`\`\`

After approval through the web flow (where the server confirms the user is authorised for the requested scope), arc receives a write-scoped token, persists it, and \`arc publish\` works against that source.

## Tests

Two new tests in \`test/commands/login.test.ts\` capture the forwarding behaviour:
- \`forwards opts.scope to pollForToken\` — when \`scope\` is provided, it reaches the device-auth layer
- \`omits scope from pollForToken when not provided\` — preserves the legacy request shape

Full suite: 8 pass, 0 fail. \`bunx tsc --noEmit\` clean.

## Why this matters beyond the immediate unblock

- Unblocks [meta-factory#476](https://github.com/the-metafactory/meta-factory/issues/476) — publish code-review v0.3.2 to dev marketplace.
- Prerequisite for [meta-factory#478](https://github.com/the-metafactory/meta-factory/issues/478) — every package migration off REGISTRY.yaml needs \`arc publish\`, which needs a write token.
- Without this, the publishing leg of the marketplace product is non-functional via the CLI auth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)