### PR TITLE
fix(cli): clarify login scope + actionable install error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.27.1
+
+### Fixed
+
+- **`arc login` help text and install-time error are now actionable** (closes [#156](https://github.com/the-metafactory/arc/issues/156)).
+  - `arc login` description previously claimed "required for publishing only"; install also needs authentication. Updated to "required for installs and publishing".
+  - `arc logout` description likewise expanded to acknowledge that signed-in installs are affected.
+  - 401/403 from a metafactory storage endpoint now hints at the next step: if no bearer was sent, `Run \`arc login\` first`; if a bearer was sent and rejected, `Token rejected — run \`arc login --force\` to refresh.` HTTP status code included for diagnosis.
+
 ## 0.24.0
 
 ### Changed

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.27.0
+version: 0.27.1
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -824,7 +824,7 @@ source
 
 program
   .command("login")
-  .description("Authenticate with metafactory registry (required for publishing only)")
+  .description("Authenticate with metafactory registry (required for installs and publishing)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .option("-f, --force", "Re-authenticate even if already logged in")
   .option(
@@ -852,7 +852,7 @@ program
 
 program
   .command("logout")
-  .description("Remove authentication from metafactory source (only affects publishing)")
+  .description("Remove authentication from metafactory source (signed-in installs and publishing will require re-login)")
   .option("-s, --source <name>", "Target source name (default: first metafactory source)")
   .action(async (opts: { source?: string }) => {
     const paths = createArcPaths();

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -352,7 +352,16 @@ export async function downloadPackage(
       });
 
       if (response.status === 401 || response.status === 403) {
-        return { success: false, error: "Access denied by storage endpoint." };
+        // Different hint depending on whether arc had a token to begin with.
+        // No token → user just needs to log in (install requires auth per DD-46).
+        // Token present → token was rejected (expired/revoked/wrong DB) → re-login.
+        const hint = headers.Authorization
+          ? "Token rejected — run `arc login --force` to refresh."
+          : "Run `arc login` first (install requires authentication).";
+        return {
+          success: false,
+          error: `Access denied by storage endpoint (HTTP ${response.status}). ${hint}`,
+        };
       }
       if (response.status === 404) {
         return { success: false, error: "Package artifact not found at storage endpoint." };


### PR DESCRIPTION
## Summary

Two install-time UX gaps Andreas hit running `arc install @metafactory/soma@0.1.3` (tracked in #156):

1. **`arc login --help` claimed login is "required for publishing only"** — but install also requires authentication. Users see "Access denied" on install and assume arc is broken, not that they need to log in.
2. **`Access denied by storage endpoint.` was an unactionable dead-end** — same message whether the user has no token at all (run `arc login`) or has a stale one (run `arc login --force`).

Closes #156.

## Changes

- `arc login` description: now states it's required for installs and publishing.
- `arc logout` description: notes signed-in installs are also affected.
- `downloadPackage()` 401/403 handling: branches on whether a bearer was offered, emits one of:
  - `Access denied by storage endpoint (HTTP 401). Run \`arc login\` first (install requires authentication).`
  - `Access denied by storage endpoint (HTTP 401). Token rejected — run \`arc login --force\` to refresh.`
- Patch bump 0.27.0 → 0.27.1 with CHANGELOG entry.

## Test plan

- [x] `bun test ./test/unit/registry-install.test.ts` — 63 pass. Existing assertions use `toContain("Access denied")`, still match.
- [x] `bunx tsc --noEmit` — clean.

Paired with the meta-factory side fix (the-metafactory/meta-factory#491) that emits a proper `WWW-Authenticate` challenge — once both ship, RFC-6750-aware clients get the canonical signal off the wire and arc users get an actionable error today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)