### PR TITLE
fix(install): clean error on duplicate-name install + prominent Sigstore-missing warning

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,10 +177,14 @@ program
       // Resolved name is known here (no clone needed), so we save the bytes.
       const existingRow = getSkill(db, resolved.name);
       if (existingRow && !existingRow.library_name) {
-        const sameVersion = existingRow.version === resolved.version;
-        const hint = sameVersion
-          ? `Run \`arc remove ${resolved.name}\` first to reinstall.`
-          : `Run \`arc upgrade ${resolved.name}\`, or \`arc remove ${resolved.name}\` first if the existing install can't be upgraded in place.`;
+        let hint: string;
+        if (existingRow.status === "disabled") {
+          hint = `Run \`arc enable ${resolved.name}\` to re-enable it, or \`arc remove ${resolved.name}\` first if you want a clean install.`;
+        } else if (existingRow.version === resolved.version) {
+          hint = `Already at v${resolved.version}. Run \`arc remove ${resolved.name}\` first to reinstall.`;
+        } else {
+          hint = `Run \`arc upgrade ${resolved.name}\`, or \`arc remove ${resolved.name}\` first if the existing install can't be upgraded in place.`;
+        }
         console.error(`'${resolved.name}' v${existingRow.version} is already installed (status: ${existingRow.status}). ${hint}`);
         process.exit(1);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { Command } from "commander";
 import { createArcPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
-import { openDatabase } from "./lib/db.js";
+import { openDatabase, getSkill } from "./lib/db.js";
 import { install, parseNameVersion } from "./commands/install.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
 import { info, formatInfo, formatInfoJson } from "./commands/info.js";
@@ -111,7 +111,8 @@ program
   .description("Install a skill from git URL, or by name from the registry")
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--pin <version>", "Pin to a specific version (git tag)")
-  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string }) => {
+  .option("--strict-signing", "Refuse to install if Sigstore signature is missing on an official-tier package")
+  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; strictSigning?: boolean }) => {
     // Non-TTY guard: fail loud rather than silently half-installing
     if (!opts.yes && !process.stdin.isTTY) {
       console.error("Error: arc install requires an interactive terminal for capability confirmation.");
@@ -171,6 +172,18 @@ program
       }
 
       console.log(`Found ${formatPackageRef(pkgRef)} v${resolved.version} in ${resolved.source.name} [${resolved.source.tier}]`);
+
+      // arc#158: bail before download if a row already exists for this name.
+      // Resolved name is known here (no clone needed), so we save the bytes.
+      const existingRow = getSkill(db, resolved.name);
+      if (existingRow && !existingRow.library_name) {
+        const sameVersion = existingRow.version === resolved.version;
+        const hint = sameVersion
+          ? `Run \`arc remove ${resolved.name}\` first to reinstall.`
+          : `Run \`arc upgrade ${resolved.name}\`, or \`arc remove ${resolved.name}\` first if the existing install can't be upgraded in place.`;
+        console.error(`'${resolved.name}' v${existingRow.version} is already installed (status: ${existingRow.status}). ${hint}`);
+        process.exit(1);
+      }
 
       // Download. Anonymous by default (DD-80); the resolved source is passed
       // through so an auth-gated metafactory storage endpoint receives the
@@ -269,8 +282,25 @@ program
         }
         process.exit(1);
       }
+      // arc#160: a missing Sigstore signature on an official-tier source is
+      // a real risk, not a side note. Promote it to a prominent warning, and
+      // let --strict-signing turn it into a hard failure.
+      let sigstoreVerified = false;
       if (sigstoreResult.verified === true) {
         console.log(`Sigstore signature verified (${sigstoreResult.reason})`);
+        sigstoreVerified = true;
+      } else if (resolved.source.tier === "official") {
+        console.warn(`⚠️  Sigstore signature MISSING for official-tier package`);
+        console.warn(`   ${sigstoreResult.reason}`);
+        console.warn(`   SHA-256 and registry signature are verified, but the package itself is not Sigstore-signed.`);
+        console.warn(`   This means the identity that produced the bytes cannot be cryptographically attested.`);
+        if (opts.strictSigning) {
+          console.error(`Refusing to install: --strict-signing is set and Sigstore signature is missing.`);
+          if (await Bun.file(download.tempPath).exists()) {
+            Bun.spawnSync(["rm", "-f", download.tempPath]);
+          }
+          process.exit(1);
+        }
       } else {
         console.warn(`Sigstore signature: ${sigstoreResult.reason}`);
       }
@@ -296,7 +326,13 @@ program
         sourceTier: resolved.source.tier,
       });
       if (result.success) {
-        console.log(`Installed ${result.name} v${result.version} (verified)`);
+        // arc#160: don't claim "(verified)" on the final line when only the
+        // registry signature and checksum were validated — Sigstore is the
+        // signature that attests to producer identity.
+        const verifyLabel = sigstoreVerified
+          ? "(verified)"
+          : "(SHA-256 + registry signature verified; Sigstore signature MISSING)";
+        console.log(`Installed ${result.name} v${result.version} ${verifyLabel}`);
       } else {
         console.error(`${result.error}`);
         process.exit(1);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -206,10 +206,21 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   if (!opts.libraryName) {
     const existingByName = getSkill(db, manifest.name);
     if (existingByName && !existingByName.library_name) {
-      const sameVersion = existingByName.version === manifest.version;
-      const hint = sameVersion
-        ? `Run \`arc remove ${manifest.name}\` first to reinstall.`
-        : `Run \`arc upgrade ${manifest.name}\`, or \`arc remove ${manifest.name}\` first if the existing install can't be upgraded in place.`;
+      // Clean up the clone we just made (other early-exits in this function
+      // do the same — preExtractedPath comes from the registry pipeline and
+      // owns its own cleanup).
+      if (!opts.preExtractedPath) {
+        Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
+      }
+
+      let hint: string;
+      if (existingByName.status === "disabled") {
+        hint = `Run \`arc enable ${manifest.name}\` to re-enable it, or \`arc remove ${manifest.name}\` first if you want a clean install.`;
+      } else if (existingByName.version === manifest.version) {
+        hint = `Already at v${manifest.version}. Run \`arc remove ${manifest.name}\` first to reinstall.`;
+      } else {
+        hint = `Run \`arc upgrade ${manifest.name}\`, or \`arc remove ${manifest.name}\` first if the existing install can't be upgraded in place.`;
+      }
       return {
         success: false,
         error: `'${manifest.name}' v${existingByName.version} is already installed (status: ${existingByName.status}). ${hint}`,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -199,6 +199,24 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     };
   }
 
+  // arc#158: catch same-name installs the repo_url check missed (e.g. legacy
+  // tarball install whose stored repo_url no longer matches the registry one).
+  // Without this, recordInstall would crash on the PRIMARY KEY constraint
+  // after all the work was done.
+  if (!opts.libraryName) {
+    const existingByName = getSkill(db, manifest.name);
+    if (existingByName && !existingByName.library_name) {
+      const sameVersion = existingByName.version === manifest.version;
+      const hint = sameVersion
+        ? `Run \`arc remove ${manifest.name}\` first to reinstall.`
+        : `Run \`arc upgrade ${manifest.name}\`, or \`arc remove ${manifest.name}\` first if the existing install can't be upgraded in place.`;
+      return {
+        success: false,
+        error: `'${manifest.name}' v${existingByName.version} is already installed (status: ${existingByName.status}). ${hint}`,
+      };
+    }
+  }
+
   // 2a. Library detection — delegate to per-artifact installs
   if (manifest.type === "library") {
     return installLibrary(opts, installPath, manifest);

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -507,6 +507,87 @@ describe("install command", () => {
     expect(result.error).toContain("already installed");
     expect(result.error).toContain("0.1.3");
     expect(result.error).toMatch(/arc upgrade|arc remove/);
+
+    // arc#158 review: clone leak — the install path we just cloned must be
+    // cleaned up, mirroring the other early-exit paths in install.ts.
+    const repoDir = join(env.arc.reposDir, "mock-DupeSkill");
+    expect(existsSync(repoDir)).toBe(false);
+  });
+
+  test("arc#158: disabled-status duplicate hints at `arc enable`", async () => {
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "DisabledSkill",
+        "0.1.0",
+        "@metafactory/DisabledSkill@0.1.0",
+        "/legacy/path",
+        "/legacy/path",
+        "disabled",
+        "skill",
+        "official",
+        now,
+        now,
+      );
+
+    const repo = await createMockSkillRepo(env.root, {
+      name: "DisabledSkill",
+      version: "0.2.0",
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host,
+      db: env.db,
+      repoUrl: repo.url,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("status: disabled");
+    expect(result.error).toContain("arc enable");
+  });
+
+  test("arc#158: same-version duplicate hints to remove first (not upgrade)", async () => {
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "SameVersionSkill",
+        "1.0.0",
+        "@metafactory/SameVersionSkill@1.0.0",
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "official",
+        now,
+        now,
+      );
+
+    const repo = await createMockSkillRepo(env.root, {
+      name: "SameVersionSkill",
+      version: "1.0.0",
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host,
+      db: env.db,
+      repoUrl: repo.url,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Already at v1.0.0");
+    expect(result.error).toContain("arc remove");
+    // No `arc upgrade` suggestion when versions match — that would just no-op.
+    expect(result.error).not.toContain("arc upgrade");
   });
 
   test("installs pinned version by checking out git tag", async () => {

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -466,6 +466,49 @@ describe("install command", () => {
     expect(result.error).toContain("already installed");
   });
 
+  test("arc#158: rejects same-name install from a different repo URL without crashing", async () => {
+    // Simulate the bug case: a row for the same name exists but with a
+    // different repo_url (e.g., legacy tarball install registered as
+    // "@scope/name@1.0.0", now the user tries a fresh git URL). Previously
+    // this surfaced as a SQLite UNIQUE constraint stack trace from
+    // recordInstall. The fix returns an actionable error instead.
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "DupeSkill",
+        "0.1.3",
+        "@metafactory/DupeSkill@0.1.3",
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "official",
+        now,
+        now,
+      );
+
+    const repo = await createMockSkillRepo(env.root, {
+      name: "DupeSkill",
+      version: "0.1.4",
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host,
+      db: env.db,
+      repoUrl: repo.url,
+      yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("already installed");
+    expect(result.error).toContain("0.1.3");
+    expect(result.error).toMatch(/arc upgrade|arc remove/);
+  });
+
   test("installs pinned version by checking out git tag", async () => {
     const repo = await createMockSkillRepo(env.root, {
       name: "VersionedSkill",


### PR DESCRIPTION
## Summary

- **arc#158/arc#116** — `arc install` no longer crashes with a SQLite UNIQUE constraint stack trace when a row for the same package name already exists. Returns an actionable message pointing at `arc upgrade` or `arc remove`, and bails *before* downloading on the registry path.
- **arc#160** — On official-tier sources, a missing Sigstore signature now prints a prominent multi-line ⚠️ warning. Final "Installed …" line drops the misleading "(verified)" suffix when only SHA-256 + registry signature were validated. Added `--strict-signing` opt-in flag that turns missing Sigstore into a hard failure.

## Files

- `src/commands/install.ts` — post-manifest name check (URL install path)
- `src/cli.ts` — pre-download name check (registry path) + Sigstore UX + `--strict-signing` flag
- `test/commands/install.test.ts` — regression test for the legacy-tarball duplicate-name case

## Test plan

- [x] `bun test` — 864 pass, 3 pre-existing skips, 0 fail
- [x] `bun run tsc --noEmit` — clean
- [x] New test reproduces the exact arc#158 bug shape (different repo_url, same name) and verifies clean error
- [ ] Manual: `arc install @metafactory/soma` against a fresh DB → clean install with warning
- [ ] Manual: `arc install @metafactory/soma --strict-signing` → hard fail

Closes #158
Closes #116
Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)