### PR TITLE
fix(nats): validateSubject throws ArcNatsCommandError(VALIDATION_ERROR)

### DIFF
--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -133,7 +133,14 @@ function validateBotName(name: string, json = false): void {
 
 function validateSubject(subject: string): void {
   if (!NATS_SUBJECT_RE.test(subject)) {
-    throw new Error(`Invalid NATS subject: "${subject}" — only alphanumeric, dots, wildcards, hyphens, underscores allowed`);
+    // arc#136: must be ArcNatsCommandError("VALIDATION_ERROR") so --json mode
+    // reports the right code. A plain Error falls into the catch-all that
+    // rewrites it as ROLLBACK_FAILED, which is misleading for a pre-create
+    // input-validation failure.
+    throw new ArcNatsCommandError(
+      "VALIDATION_ERROR",
+      `Invalid NATS subject: "${subject}" — only alphanumeric, dots, wildcards, hyphens, underscores allowed`,
+    );
   }
 }
 

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -330,22 +330,25 @@ export async function addBot(name: string, opts: AddBotOptions): Promise<AddBotR
     if (!json) console.log(`Removed existing user: ${name}`);
   }
 
+  // arc#136 fail-fast: validate every subject before any nsc state changes,
+  // so a bad --pub/--sub doesn't trigger a real `nsc add user` + rollback
+  // round-trip for what is purely an input-validation failure. Split here
+  // (rather than re-splitting inside the try below) so the same list is used
+  // twice without divergence.
+  const pubSubjects = opts.pub ? opts.pub.split(",").map((s) => s.trim()) : [];
+  const subSubjects = opts.sub ? opts.sub.split(",").map((s) => s.trim()) : [];
+  for (const subj of pubSubjects) validateSubject(subj);
+  for (const subj of subSubjects) validateSubject(subj);
+
   nsc(["add", "user", "-a", account, "-n", name]);
 
   let credsContent: string;
   try {
-    if (opts.pub) {
-      for (const subj of opts.pub.split(",").map((s) => s.trim())) {
-        validateSubject(subj);
-        nsc(["edit", "user", "-a", account, "-n", name, "--allow-pub", subj]);
-      }
+    for (const subj of pubSubjects) {
+      nsc(["edit", "user", "-a", account, "-n", name, "--allow-pub", subj]);
     }
-
-    if (opts.sub) {
-      for (const subj of opts.sub.split(",").map((s) => s.trim())) {
-        validateSubject(subj);
-        nsc(["edit", "user", "-a", account, "-n", name, "--allow-sub", subj]);
-      }
+    for (const subj of subSubjects) {
+      nsc(["edit", "user", "-a", account, "-n", name, "--allow-sub", subj]);
     }
 
     credsContent = nsc(["generate", "creds", "-a", account, "-n", name]);

--- a/test/commands/nats-json.test.ts
+++ b/test/commands/nats-json.test.ts
@@ -182,16 +182,22 @@ describe("addBot --json: error envelope", () => {
 
   // arc#136: validateSubject used to throw a plain Error, which the addBot
   // catch-all rewrote as ROLLBACK_FAILED — the wrong code for an input
-  // validation failure. The fix makes it throw VALIDATION_ERROR directly.
-  test("arc#136: VALIDATION_ERROR (not ROLLBACK_FAILED) for an invalid --pub subject", async () => {
-    const runner = buildRunner({
-      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
+  // validation failure. The fix makes it throw VALIDATION_ERROR directly,
+  // AND hoists validation above `nsc add user` so a bad subject never
+  // triggers a real create + rollback round-trip in the first place.
+  test("arc#136: VALIDATION_ERROR for an invalid --pub subject; fail-fast, no add/delete user", async () => {
+    const calls: string[] = [];
+    const handler = buildRunner({
+      "describe user": (a) => a.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
       "add user": () => ok("added"),
       "edit user": () => ok("edited"),
       "delete user": () => ok("deleted"),
       "generate creds": () => ok(FAKE_CREDS),
     });
-    __setNscRunnerForTests(runner);
+    __setNscRunnerForTests((args) => {
+      calls.push(`${args[0]} ${args[1] ?? ""}`.trim());
+      return handler(args);
+    });
 
     let err: unknown;
     try {
@@ -207,17 +213,25 @@ describe("addBot --json: error envelope", () => {
     expect(err).toBeInstanceOf(ArcNatsCommandError);
     expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
     expect((err as ArcNatsCommandError).message).toContain("Invalid NATS subject");
+    // Fail-fast: validation happens BEFORE any state-changing nsc calls,
+    // so neither `add user` nor the rollback `delete user` ran.
+    expect(calls).not.toContain("add user");
+    expect(calls).not.toContain("delete user");
   });
 
-  test("arc#136: VALIDATION_ERROR for an invalid --sub subject", async () => {
-    const runner = buildRunner({
-      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
+  test("arc#136: VALIDATION_ERROR for an invalid --sub subject; fail-fast", async () => {
+    const calls: string[] = [];
+    const handler = buildRunner({
+      "describe user": (a) => a.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
       "add user": () => ok("added"),
       "edit user": () => ok("edited"),
       "delete user": () => ok("deleted"),
       "generate creds": () => ok(FAKE_CREDS),
     });
-    __setNscRunnerForTests(runner);
+    __setNscRunnerForTests((args) => {
+      calls.push(`${args[0]} ${args[1] ?? ""}`.trim());
+      return handler(args);
+    });
 
     let err: unknown;
     try {
@@ -232,6 +246,8 @@ describe("addBot --json: error envelope", () => {
     }
     expect(err).toBeInstanceOf(ArcNatsCommandError);
     expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
+    expect(calls).not.toContain("add user");
+    expect(calls).not.toContain("delete user");
   });
 });
 

--- a/test/commands/nats-json.test.ts
+++ b/test/commands/nats-json.test.ts
@@ -179,6 +179,60 @@ describe("addBot --json: error envelope", () => {
     expect(err).toBeInstanceOf(ArcNatsCommandError);
     expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
   });
+
+  // arc#136: validateSubject used to throw a plain Error, which the addBot
+  // catch-all rewrote as ROLLBACK_FAILED — the wrong code for an input
+  // validation failure. The fix makes it throw VALIDATION_ERROR directly.
+  test("arc#136: VALIDATION_ERROR (not ROLLBACK_FAILED) for an invalid --pub subject", async () => {
+    const runner = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
+      "add user": () => ok("added"),
+      "edit user": () => ok("edited"),
+      "delete user": () => ok("deleted"),
+      "generate creds": () => ok(FAKE_CREDS),
+    });
+    __setNscRunnerForTests(runner);
+
+    let err: unknown;
+    try {
+      await addBot(TEST_BOT, {
+        account: TEST_ACCOUNT,
+        output: CUSTOM_OUT,
+        json: true,
+        pub: "valid.subject,bad subject with spaces",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
+    expect((err as ArcNatsCommandError).message).toContain("Invalid NATS subject");
+  });
+
+  test("arc#136: VALIDATION_ERROR for an invalid --sub subject", async () => {
+    const runner = buildRunner({
+      "describe user": (args) => args.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
+      "add user": () => ok("added"),
+      "edit user": () => ok("edited"),
+      "delete user": () => ok("deleted"),
+      "generate creds": () => ok(FAKE_CREDS),
+    });
+    __setNscRunnerForTests(runner);
+
+    let err: unknown;
+    try {
+      await addBot(TEST_BOT, {
+        account: TEST_ACCOUNT,
+        output: CUSTOM_OUT,
+        json: true,
+        sub: "ok.subject,$(evil-shell-meta)",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
+  });
 });
 
 // ── reissueBot ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

\`validateSubject\` previously threw a plain \`Error\`, which fell into the \`addBot\` catch-all and got rewritten as \`ROLLBACK_FAILED\` in \`--json\` mode. That's the wrong code for an input-validation failure (per the taxonomy in \`docs/integrations/cortex-creds.md\`). The fix throws \`ArcNatsCommandError(\"VALIDATION_ERROR\", ...)\` directly.

## Files

- \`src/commands/nats.ts\` — replace plain \`Error\` with typed error
- \`test/commands/nats-json.test.ts\` — two regression tests covering invalid \`--pub\` and \`--sub\` subjects

## Test plan

- [x] \`bun test test/commands/nats-json.test.ts\` — 19 pass
- [x] \`bun test\` (full suite) — 865 pass, 3 pre-existing skips, 0 fail
- [x] \`bun run tsc --noEmit\` — clean

Closes #136
Refs #131, #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)