### PR TITLE
fix(catalog): refuse to silently overwrite foreign installs

### DIFF
--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -22,6 +22,25 @@ import { readManifest } from "../lib/manifest.js";
 import { recordInstall, getSkill } from "../lib/db.js";
 import { createSymlink, createCliShim } from "../lib/symlinks.js";
 
+// ── Source-string normalisation (arc#170 review) ───────────────
+//
+// `install_source` is stored verbatim from catalog.yaml. Yaml edits between
+// install and refresh (https↔http, trailing `/` or `.git`, casing in the
+// protocol+host part) would otherwise misclassify a legitimate `catalogSync`
+// refresh as a foreign install and refuse it. This helper canonicalises both
+// sides of the equality comparison; it deliberately does NOT touch path /
+// branch / SSH-host text since drift there reflects real operator intent.
+export function normalizeCatalogSource(source: string): string {
+  let s = source.trim();
+  // Strip trailing `.git` (with optional trailing slash).
+  s = s.replace(/\.git\/?$/i, "");
+  // Strip trailing slashes.
+  s = s.replace(/\/+$/, "");
+  // Lowercase protocol + host portion of http(s) URLs only.
+  s = s.replace(/^(https?:\/\/[^/]+)/i, (m) => m.toLowerCase());
+  return s;
+}
+
 // ── Result types ──────────────────────────────────────────────
 
 export interface CatalogListResult {
@@ -529,7 +548,10 @@ async function installSkillEntry(
   // `isRefresh` path below unconditionally DELETEs the row before INSERT,
   // which would clobber operator state.
   const existingRow = getSkill(db, entry.name);
-  const isRefresh = existingRow !== null && existingRow.install_source === entry.source;
+  const isRefresh =
+    existingRow !== null &&
+    existingRow.install_source !== null &&
+    normalizeCatalogSource(existingRow.install_source) === normalizeCatalogSource(entry.source);
   if (existingRow && !isRefresh) {
     let hint: string;
     if (existingRow.status === "disabled") {
@@ -537,9 +559,12 @@ async function installSkillEntry(
     } else {
       hint = `Run \`arc remove ${entry.name}\` first if you want to replace it with this catalog entry's source.`;
     }
+    const sourceLabel = existingRow.library_name
+      ? `library:${existingRow.library_name}`
+      : existingRow.install_source ?? "direct";
     return {
       success: false,
-      error: `'${entry.name}' v${existingRow.version} is already installed from a different source (${existingRow.install_source ?? "direct"}; status: ${existingRow.status}). ${hint}`,
+      error: `'${entry.name}' v${existingRow.version} is already installed from a different source (${sourceLabel}; status: ${existingRow.status}). ${hint}`,
     };
   }
 

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -522,7 +522,26 @@ async function installSkillEntry(
     return { success: false, error: `Refusing to install: name "${entry.name}" would escape install directory` };
   }
 
-  const isRefresh = getSkill(db, entry.name) !== null;
+  // arc#170: distinguish "refresh of THIS catalog entry" from "row exists
+  // from somewhere else". If a foreign install (e.g. `arc install` from a
+  // direct URL, or a different catalog source) registered the same name,
+  // catalog use must refuse rather than silently overwrite — the existing
+  // `isRefresh` path below unconditionally DELETEs the row before INSERT,
+  // which would clobber operator state.
+  const existingRow = getSkill(db, entry.name);
+  const isRefresh = existingRow !== null && existingRow.install_source === entry.source;
+  if (existingRow && !isRefresh) {
+    let hint: string;
+    if (existingRow.status === "disabled") {
+      hint = `Run \`arc enable ${entry.name}\` to re-enable it, or \`arc remove ${entry.name}\` first if you want a clean install from this catalog entry.`;
+    } else {
+      hint = `Run \`arc remove ${entry.name}\` first if you want to replace it with this catalog entry's source.`;
+    }
+    return {
+      success: false,
+      error: `'${entry.name}' v${existingRow.version} is already installed from a different source (${existingRow.install_source ?? "direct"}; status: ${existingRow.status}). ${hint}`,
+    };
+  }
 
   if (resolved.type === "local") {
     // For CLI skills: find the repo root (walk up from skill dir to find arc-manifest.yaml)

--- a/test/commands/catalog.test.ts
+++ b/test/commands/catalog.test.ts
@@ -16,6 +16,7 @@ import {
   catalogSync,
   formatCatalogList,
   formatCatalogSearch,
+  normalizeCatalogSource,
 } from "../../src/commands/catalog.js";
 
 let env: TestEnv;
@@ -404,6 +405,152 @@ describe("catalogUse", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("arc enable");
     expect(result.error).toContain("disabled");
+  });
+
+  test("arc#170: refuses foreign library install of the same name", async () => {
+    await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
+
+    // Prior row from a library install (install_source: "library:foo",
+    // library_name: "foo"). The error message should surface the library
+    // name rather than the raw "library:foo" string.
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, install_source, library_name, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "Research",
+        "0.3.0",
+        "git@github.com:foo/foo-library.git",
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "custom",
+        "library:foo",
+        "foo",
+        now,
+        now,
+      );
+
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("library:foo");
+    expect(result.error).toContain("arc remove");
+  });
+
+  test("arc#170: refuses foreign install when the conflicting row is from a different catalog source", async () => {
+    await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
+
+    // Foreign install was registered by a different catalog entry whose
+    // `source:` points at a different repo. install_source format is exactly
+    // what catalog.ts records (the raw catalog `source` string).
+    const now = new Date().toISOString();
+    const foreignSource = "https://github.com/other-org/other-research/blob/main/SKILL.md";
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, install_source, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "Research",
+        "1.0.0",
+        foreignSource,
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "custom",
+        foreignSource,
+        now,
+        now,
+      );
+
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(foreignSource);
+    expect(result.error).toContain("different source");
+  });
+
+  test("arc#170: format drift (trailing .git / slash / case) still counts as a refresh of the same source", async () => {
+    await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
+
+    // The catalog entry's source (set in sampleCatalog) for `Research` is a
+    // *local* path — those normalise to themselves. Verify the equality
+    // discriminator survives a trailing-slash drift.
+    const cat = sampleCatalog(env.root);
+    const original = cat.catalog.skills.find((s) => s.name === "Research")!.source;
+
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, install_source, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "Research",
+        "1.0.0",
+        original,
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "custom",
+        // Drift: trailing slash + uppercase scheme variant simulating yaml edit
+        original + "/",
+        now,
+        now,
+      );
+
+    // Refresh should succeed — same logical source despite the trailing /.
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("normalizeCatalogSource", () => {
+  test("strips trailing .git", () => {
+    expect(normalizeCatalogSource("https://github.com/o/r.git")).toBe(
+      "https://github.com/o/r",
+    );
+    expect(normalizeCatalogSource("https://github.com/o/r.git/")).toBe(
+      "https://github.com/o/r",
+    );
+  });
+
+  test("strips trailing slashes", () => {
+    expect(normalizeCatalogSource("https://example.com/path///")).toBe(
+      "https://example.com/path",
+    );
+  });
+
+  test("lowercases protocol + host on http(s) URLs only", () => {
+    expect(normalizeCatalogSource("HTTPS://GitHub.com/Org/Repo")).toBe(
+      "https://github.com/Org/Repo",
+    );
+    // Local paths are unchanged
+    expect(normalizeCatalogSource("/Users/Foo/Bar.md")).toBe("/Users/Foo/Bar.md");
+    // SSH-style URLs: leave case intact (host part is technical, drift unlikely)
+    expect(normalizeCatalogSource("git@github.com:Org/Repo.git")).toBe(
+      "git@github.com:Org/Repo",
+    );
+  });
+
+  test("idempotent", () => {
+    const s = "https://github.com/o/r/blob/main/skill.md";
+    expect(normalizeCatalogSource(normalizeCatalogSource(s))).toBe(
+      normalizeCatalogSource(s),
+    );
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeCatalogSource("  https://example.com/x.git  ")).toBe(
+      "https://example.com/x",
+    );
   });
 });
 

--- a/test/commands/catalog.test.ts
+++ b/test/commands/catalog.test.ts
@@ -334,6 +334,77 @@ describe("catalogUse", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("not found");
   });
+
+  // arc#170: refuse rather than silently overwrite when a row for the same
+  // name already exists from a different source (e.g. a prior `arc install`
+  // from a direct URL, or another catalog entry).
+  test("arc#170: refuses to overwrite a foreign install of the same name", async () => {
+    await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
+
+    // Pre-existing row with a *different* install_source — simulates
+    // `arc install` from a direct URL (or a different catalog source).
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, install_source, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "Research",
+        "1.0.0",
+        "git@github.com:other/research.git",
+        "/legacy/path",
+        "/legacy/path",
+        "active",
+        "skill",
+        "custom",
+        "git@github.com:other/research.git",
+        now,
+        now,
+      );
+
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("already installed from a different source");
+    expect(result.error).toContain("arc remove");
+
+    // Critical: the foreign DB row must not have been overwritten.
+    const row = getSkill(env.db, "Research");
+    expect(row).not.toBeNull();
+    expect(row!.install_source).toBe("git@github.com:other/research.git");
+    expect(row!.version).toBe("1.0.0");
+  });
+
+  test("arc#170: same-name disabled foreign install hints at `arc enable`", async () => {
+    await createMockSkillDir(env.root, "mock-skills/Research", { name: "Research" });
+    await saveCatalog(env.arc.catalogPath, sampleCatalog(env.root));
+
+    const now = new Date().toISOString();
+    env.db
+      .prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, install_source, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "Research",
+        "1.0.0",
+        "git@github.com:other/research.git",
+        "/legacy/path",
+        "/legacy/path",
+        "disabled",
+        "skill",
+        "custom",
+        "git@github.com:other/research.git",
+        now,
+        now,
+      );
+
+    const result = await catalogUse(env.arc, env.host, env.db, "Research");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("arc enable");
+    expect(result.error).toContain("disabled");
+  });
 });
 
 describe("catalogSync", () => {


### PR DESCRIPTION
## Summary

Catalog use was silently clobbering foreign installs of the same name. The existing \`isRefresh\` check classified ANY same-name row as a refresh and unconditionally \`DELETE\`d it before \`INSERT\`. So if you had run \`arc install\` from a direct URL first, then \`arc catalog use\` of the same name, the foreign install would be wiped out without warning.

Worse than the UNIQUE crash #165 eliminated on the install paths — this version destroys operator state.

## Fix

Narrow \`isRefresh\` to "row exists AND \`install_source\` matches this catalog entry's source." Foreign rows now route to a refuse path with the same hint shape \`install.ts\` uses (\`arc remove\` first, or \`arc enable\` if disabled).

## Files

- \`src/commands/catalog.ts\` — guard inserted between row lookup and the DELETE/INSERT path
- \`test/commands/catalog.test.ts\` — two regression tests (foreign active install, foreign disabled install)

## Test plan

- [x] \`bun test test/commands/catalog.test.ts\` — 20 pass
- [x] \`bun test\` (full suite) — 881 pass, 3 pre-existing skips, 0 fail
- [x] \`bun run tsc --noEmit\` — clean
- [x] Asserts the foreign DB row is unchanged after refusal (no silent overwrite)

Closes #170
Refs #158, #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)