### PR TITLE
fix(nats): typed NSC_COMMAND_FAILED error for nsc shell-out failures

### DIFF
--- a/docs/integrations/cortex-creds.md
+++ b/docs/integrations/cortex-creds.md
@@ -50,6 +50,7 @@ Consumers can branch on either exit code or `ok` — both signals are authoritat
 | Code | When |
 |---|---|
 | `NSC_NOT_INSTALLED` | `nsc` binary missing from `$PATH`. Install: `brew install nats-io/nats-tools/nsc`. |
+| `NSC_COMMAND_FAILED` | An `nsc <subcommand>` exited non-zero (e.g. signing-key missing, permission denied, malformed account state). The error `message` field carries the nsc subcommand name and the captured stderr. |
 | `USER_NOT_FOUND` | Bot user does not exist under the named account (revoke / reissue path). |
 | `ACCOUNT_NOT_FOUND` | Operator account cannot be detected (no nsc config, no `--account` flag). |
 | `ALREADY_EXISTS` | User or creds file already exists at the target path and `--force` was not passed. |

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -105,6 +105,21 @@ export function __setNscInstallCheckForTests(next: (() => boolean) | null): void
   nscInstallCheck = next ?? (() => Bun.spawnSync(["which", "nsc"], { stdout: "pipe" }).exitCode === 0);
 }
 
+/**
+ * Test-only direct accessors for the two private nsc wrappers.
+ * Tests use these to assert that both wrappers throw the typed error on
+ * non-zero exit without having to route through addBot's call graph.
+ */
+export function __nscForTests(args: string[]): string {
+  assertTestModeForSeam("__nscForTests");
+  return nsc(args);
+}
+
+export function __nscWithStderrForTests(args: string[]): string {
+  assertTestModeForSeam("__nscWithStderrForTests");
+  return nscWithStderr(args);
+}
+
 function assertTestModeForSeam(seamName: string): void {
   if (process.env.ARC_TEST_MODE !== "1" && process.env.NODE_ENV !== "test") {
     throw new Error(

--- a/src/commands/nats.ts
+++ b/src/commands/nats.ts
@@ -68,7 +68,13 @@ function nsc(args: string[]): string {
   const stdout = result.stdout.trim();
   const stderr = result.stderr.trim();
   if (result.exitCode !== 0) {
-    throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
+    // arc#169: throw a typed error so consumers of --json get the precise
+    // NSC_COMMAND_FAILED code instead of UNKNOWN (outside try blocks) or
+    // having the addBot catch-all reclassify as ROLLBACK_FAILED.
+    throw new ArcNatsCommandError(
+      "NSC_COMMAND_FAILED",
+      `nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`,
+    );
   }
   return stdout;
 }
@@ -78,7 +84,10 @@ function nscWithStderr(args: string[]): string {
   if (result.exitCode !== 0) {
     const stderr = result.stderr.trim();
     const stdout = result.stdout.trim();
-    throw new Error(`nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`);
+    throw new ArcNatsCommandError(
+      "NSC_COMMAND_FAILED",
+      `nsc ${args[0]} failed: ${stderr || stdout || "unknown error"}`,
+    );
   }
   return (result.stdout + result.stderr).trim();
 }

--- a/src/lib/json-response.ts
+++ b/src/lib/json-response.ts
@@ -24,6 +24,7 @@ export const ARC_NATS_SCHEMA = "arc.nats.v1" as const;
  */
 export type ArcNatsErrorCode =
   | "NSC_NOT_INSTALLED"     // `nsc` binary missing on PATH
+  | "NSC_COMMAND_FAILED"    // `nsc <subcommand>` exited non-zero (generic shell-out failure)
   | "USER_NOT_FOUND"        // bot user does not exist under the account
   | "ACCOUNT_NOT_FOUND"     // operator account cannot be detected/resolved
   | "ALREADY_EXISTS"        // user / creds file already exists (no --force)

--- a/test/commands/nats-json.test.ts
+++ b/test/commands/nats-json.test.ts
@@ -180,6 +180,66 @@ describe("addBot --json: error envelope", () => {
     expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
   });
 
+  // arc#169: nsc subcommands now throw ArcNatsCommandError("NSC_COMMAND_FAILED")
+  // instead of plain Error. Pre-fix: a failing `nsc add user` (which runs
+  // OUTSIDE the addBot try/catch) surfaced as code "UNKNOWN" at the CLI
+  // boundary because classifyError() falls back for non-typed errors.
+  test("arc#169: NSC_COMMAND_FAILED when `nsc add user` fails outside the rollback try", async () => {
+    const runner = buildRunner({
+      "describe user": () => fail("user not found"),
+      "add user": () => fail("signing key missing for account OP_TEST_JSON"),
+    });
+    __setNscRunnerForTests(runner);
+
+    let err: unknown;
+    try {
+      await addBot(TEST_BOT, { account: TEST_ACCOUNT, output: CUSTOM_OUT, json: true });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("NSC_COMMAND_FAILED");
+    expect((err as ArcNatsCommandError).message).toContain("nsc add failed");
+    expect((err as ArcNatsCommandError).message).toContain("signing key missing");
+  });
+
+  // Inside the rollback try, the catch-all preserves err.code (per validateSubject
+  // arc#136 fix), so NSC_COMMAND_FAILED flows through with the "rolled back" message
+  // wrapper. Operator gets both: precise code (nsc failed) AND the message
+  // making clear a rollback ran.
+  test("arc#169: NSC_COMMAND_FAILED preserved through rollback when `nsc edit user` fails", async () => {
+    const calls: string[] = [];
+    const handler = buildRunner({
+      "describe user": (a) => a.includes("-J") ? ok(FAKE_USER_JWT_JSON) : fail("user not found"),
+      "add user": () => ok("added"),
+      "edit user": () => fail("permission denied: signing key not unlocked"),
+      "delete user": () => ok("deleted"),
+      "generate creds": () => ok(FAKE_CREDS),
+    });
+    __setNscRunnerForTests((args) => {
+      calls.push(`${args[0]} ${args[1] ?? ""}`.trim());
+      return handler(args);
+    });
+
+    let err: unknown;
+    try {
+      await addBot(TEST_BOT, {
+        account: TEST_ACCOUNT,
+        output: CUSTOM_OUT,
+        json: true,
+        pub: "valid.subject",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("NSC_COMMAND_FAILED");
+    expect((err as ArcNatsCommandError).message).toContain("rolled back");
+    expect((err as ArcNatsCommandError).message).toContain("permission denied");
+    // Rollback actually ran: `nsc delete user` was invoked.
+    expect(calls).toContain("delete user");
+  });
+
   // arc#136: validateSubject used to throw a plain Error, which the addBot
   // catch-all rewrote as ROLLBACK_FAILED — the wrong code for an input
   // validation failure. The fix makes it throw VALIDATION_ERROR directly,

--- a/test/commands/nats-json.test.ts
+++ b/test/commands/nats-json.test.ts
@@ -23,6 +23,8 @@ import {
   setupOperator,
   __setNscRunnerForTests,
   __setNscInstallCheckForTests,
+  __nscForTests,
+  __nscWithStderrForTests,
   type NscResult,
   type NscRunner,
 } from "../../src/commands/nats.js";
@@ -178,6 +180,36 @@ describe("addBot --json: error envelope", () => {
     }
     expect(err).toBeInstanceOf(ArcNatsCommandError);
     expect((err as ArcNatsCommandError).code).toBe("VALIDATION_ERROR");
+  });
+
+  // arc#169 direct unit tests for the two private wrappers, so the typed-error
+  // contract is asserted independently of the addBot call graph.
+  test("arc#169: nsc() throws NSC_COMMAND_FAILED on non-zero exit", () => {
+    __setNscRunnerForTests(() => fail("signing key missing for account OP_X"));
+    let err: unknown;
+    try {
+      __nscForTests(["add", "user", "-a", "OP_X", "-n", "bot"]);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("NSC_COMMAND_FAILED");
+    expect((err as ArcNatsCommandError).message).toContain("nsc add failed");
+    expect((err as ArcNatsCommandError).message).toContain("signing key missing");
+  });
+
+  test("arc#169: nscWithStderr() throws NSC_COMMAND_FAILED on non-zero exit", () => {
+    __setNscRunnerForTests(() => fail("nsc env: account context not initialised"));
+    let err: unknown;
+    try {
+      __nscWithStderrForTests(["env"]);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ArcNatsCommandError);
+    expect((err as ArcNatsCommandError).code).toBe("NSC_COMMAND_FAILED");
+    expect((err as ArcNatsCommandError).message).toContain("nsc env failed");
+    expect((err as ArcNatsCommandError).message).toContain("account context not initialised");
   });
 
   // arc#169: nsc subcommands now throw ArcNatsCommandError("NSC_COMMAND_FAILED")


### PR DESCRIPTION
## Summary

Completes the plain-Error audit from arc#136 / PR #168 review:

- Add \`NSC_COMMAND_FAILED\` to the closed \`ArcNatsErrorCode\` set.
- Wrap the two plain-\`Error\` throw sites in nats.ts (\`nsc()\` line 71, \`nscWithStderr()\` line 81) to throw \`ArcNatsCommandError("NSC_COMMAND_FAILED", ...)\`.
- Document the new code in \`docs/integrations/cortex-creds.md\`.

## Why this matters for \`--json\` consumers

Before:
- \`nsc add user\` failure (outside the addBot try block) → \`classifyError\` falls back to \`UNKNOWN\`. Operator sees \"file an issue\" prompt for a recoverable nsc failure.
- \`nsc edit user\` failure (inside the try block) → addBot catch-all reclassifies the plain Error as \`ROLLBACK_FAILED\`. Operator can't distinguish \"the rollback step itself failed\" from \"nsc failed and we rolled back cleanly\".

After:
- Both paths now emit \`NSC_COMMAND_FAILED\`. The addBot catch-all preserves \`err.code\` for typed errors (existing behaviour, used by arc#136 \`VALIDATION_ERROR\`), so a failure inside the try still flows through with the wrapper message \"rolled back. Cause: …\".

## Files

- \`src/lib/json-response.ts\` — new code in the closed set
- \`src/commands/nats.ts\` — two throw sites typed
- \`test/commands/nats-json.test.ts\` — two regression tests (outside-try and inside-try-with-rollback)
- \`docs/integrations/cortex-creds.md\` — taxonomy entry

## Test plan

- [x] \`bun test test/commands/nats-json.test.ts\` — 21 pass
- [x] \`bun test\` (full suite) — 881 pass, 3 pre-existing skips, 0 fail
- [x] \`bun run tsc --noEmit\` — clean
- [x] Rollback path test asserts \`delete user\` actually ran during error handling (no regression of #136 hoist)

Closes #169
Refs #136, #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)