### PR TITLE
fix(publish): forward repository / homepage / keywords / category to registry

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.27.3
+version: 0.27.4
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -111,6 +111,15 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
   if (subprocess.length) serverCaps.subprocess = subprocess;
   if (environment.length) serverCaps.environment = environment;
 
+  // Optional discovery / provenance metadata forwarded as-is to the registry
+  // when the publisher set it in arc-manifest.yaml. Server-side validation
+  // (MetafactoryManifest in meta-factory/src/types/manifest.ts) enforces the
+  // accepted shapes; arc stays a thin pass-through so the source of truth
+  // remains on one side. The `repository` field opens the same-repo image
+  // rewrite for README rendering (the-metafactory/meta-factory#501 / #502 /
+  // #505) — without it, relative `<img src="docs/...">` paths in the
+  // published README cannot be resolved against the repo's raw content and
+  // surface as broken-image icons on the package landing page.
   return {
     schema: "metafactory/v1",
     name: `@${scope}/${manifest.name}`,
@@ -119,6 +128,12 @@ export function toServerManifest(manifest: ArcManifest, scope: string): Record<s
     author: { name: manifest.author?.name ?? scope },
     license: manifest.license ?? "MIT",
     ...(manifest.description ? { description: manifest.description } : {}),
+    ...(manifest.repository ? { repository: manifest.repository } : {}),
+    ...(manifest.homepage ? { homepage: manifest.homepage } : {}),
+    ...(manifest.keywords && manifest.keywords.length > 0
+      ? { keywords: manifest.keywords }
+      : {}),
+    ...(manifest.category ? { category: manifest.category } : {}),
     capabilities: serverCaps,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -345,6 +345,32 @@ export interface ArcManifest {
   description?: string;
   /** SPDX license identifier */
   license?: string;
+  /**
+   * Canonical source repository URL. Forwarded to the metafactory registry
+   * at publish time so the package landing page can resolve relative README
+   * image paths against the repo's raw content
+   * (the-metafactory/meta-factory#501).
+   *
+   * Common shapes accepted by the registry's `extractRepoSlug`:
+   *   - `https://github.com/owner/repo[.git]`
+   *   - `git+https://github.com/owner/repo.git`
+   *   - `git@github.com:owner/repo.git`
+   *   - `github:owner/repo`
+   *   - `owner/repo`
+   */
+  repository?: string;
+  /** Optional public homepage / docs URL. Forwarded as-is to the registry. */
+  homepage?: string;
+  /** Free-form search keywords. Forwarded to the registry for discovery. */
+  keywords?: string[];
+  /**
+   * Discovery category. The registry pins an enumeration —
+   * `text-processing | security | api-integration | data-ops | devtools |
+   * research | communication | infrastructure` — but arc forwards the raw
+   * string and lets the server validate, so the source of truth stays in
+   * one place.
+   */
+  category?: string;
 }
 
 /** Trust tier for installed packages */

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -363,3 +363,92 @@ describe("toServerManifest — network capability coercion", () => {
     expect((server.capabilities as any).network).toBeUndefined();
   });
 });
+
+// Forwards optional discovery / provenance metadata from arc-manifest.yaml
+// to the registry. Without this, `repository` (and friends) never reach
+// MetafactoryManifest, the registry treats every package as
+// repository-less, and the same-repo image rewrite for README rendering
+// stays closed (the-metafactory/meta-factory#501 / #502 / #505).
+describe("toServerManifest — optional metadata forwarding", () => {
+  test("forwards repository when set", () => {
+    const m = makeManifest({
+      repository: "https://github.com/the-metafactory/soma",
+    });
+    const server = toServerManifest(m, "metafactory");
+    expect(server.repository).toBe("https://github.com/the-metafactory/soma");
+  });
+
+  test("omits repository when absent (no empty-string poisoning)", () => {
+    const m = makeManifest();
+    const server = toServerManifest(m, "metafactory");
+    expect("repository" in server).toBe(false);
+  });
+
+  test("omits repository when empty string", () => {
+    const m = makeManifest({ repository: "" });
+    const server = toServerManifest(m, "metafactory");
+    expect("repository" in server).toBe(false);
+  });
+
+  test("forwards homepage when set", () => {
+    const m = makeManifest({ homepage: "https://soma.metafactory.ai" });
+    const server = toServerManifest(m, "metafactory");
+    expect(server.homepage).toBe("https://soma.metafactory.ai");
+  });
+
+  test("omits homepage when absent", () => {
+    const m = makeManifest();
+    const server = toServerManifest(m, "metafactory");
+    expect("homepage" in server).toBe(false);
+  });
+
+  test("forwards keywords array when non-empty", () => {
+    const m = makeManifest({ keywords: ["pai", "memory", "identity"] });
+    const server = toServerManifest(m, "metafactory");
+    expect(server.keywords).toEqual(["pai", "memory", "identity"]);
+  });
+
+  test("omits keywords when absent", () => {
+    const m = makeManifest();
+    const server = toServerManifest(m, "metafactory");
+    expect("keywords" in server).toBe(false);
+  });
+
+  test("omits keywords when empty array (no [] poisoning)", () => {
+    const m = makeManifest({ keywords: [] });
+    const server = toServerManifest(m, "metafactory");
+    expect("keywords" in server).toBe(false);
+  });
+
+  test("forwards category when set", () => {
+    const m = makeManifest({ category: "devtools" });
+    const server = toServerManifest(m, "metafactory");
+    expect(server.category).toBe("devtools");
+  });
+
+  test("omits category when absent", () => {
+    const m = makeManifest();
+    const server = toServerManifest(m, "metafactory");
+    expect("category" in server).toBe(false);
+  });
+
+  test("forwards every optional metadata field together", () => {
+    const m = makeManifest({
+      description: "Soma in one line",
+      repository: "https://github.com/the-metafactory/soma",
+      homepage: "https://meta-factory.ai/package/@metafactory/soma",
+      keywords: ["pai", "soma"],
+      category: "devtools",
+    });
+    const server = toServerManifest(m, "metafactory");
+    expect(server.description).toBe("Soma in one line");
+    expect(server.repository).toBe(
+      "https://github.com/the-metafactory/soma",
+    );
+    expect(server.homepage).toBe(
+      "https://meta-factory.ai/package/@metafactory/soma",
+    );
+    expect(server.keywords).toEqual(["pai", "soma"]);
+    expect(server.category).toBe("devtools");
+  });
+});


### PR DESCRIPTION
## Summary

\`toServerManifest\` was dropping four optional metadata fields when translating arc-manifest.yaml → metafactory/v1 for publish. The forcing function: soma's README was rendering relative \`<img src=\"docs/...\">\` paths as broken-image icons on \`meta-factory.ai\`, even though every soma version (0.1.3 → 0.3.1) carries \`repository:\` in its arc-manifest.yaml.

Inspection of the registry's stored manifest (D1 \`package_versions.manifest\`):

\`\`\`json
{\"schema\":\"metafactory/v1\",\"name\":\"@metafactory/soma\",\"version\":\"0.3.1\",
 \"type\":\"tool\",\"author\":{\"name\":\"metafactory\"},\"license\":\"MIT\",
 \"description\":\"...\",\"capabilities\":{...}}
\`\`\`

No \`repository\`. No \`homepage\`. No \`keywords\`. No \`category\`. arc was dropping all four.

## Background

- the-metafactory/meta-factory#501 — soma's README image regression report
- the-metafactory/meta-factory#502 — registry-side allowlist + plumbed \`repoSlug\` from \`manifest.repository\`
- the-metafactory/meta-factory#505 — relative-path → \`raw.githubusercontent.com/{slug}/HEAD\` rewrite (closes the visual gap)

#502 / #505 derive the slug at publish time via \`extractRepoSlug(manifest.repository)\`. arc never forwarded the field, so the same-repo image rewrite stayed closed for **every** package published via arc.

## What changed

| File | Change |
| --- | --- |
| \`src/types.ts\` | \`ArcManifest\` gains \`repository?: string\`, \`homepage?: string\`, \`keywords?: string[]\`, \`category?: string\`. All four are already part of \`MetafactoryManifest\` server-side. |
| \`src/lib/publish.ts\` | \`toServerManifest\` forwards each field as-is when set. Empty strings / empty arrays are treated as \"absent\" so they do not poison the payload with empty values. |
| \`test/unit/publish.test.ts\` | 10 new unit tests under a \`toServerManifest — optional metadata forwarding\` describe block. |
| \`arc-manifest.yaml\`, \`package.json\` | Version bump 0.27.3 → 0.27.4. |

arc stays a thin pass-through: server-side validation (\`validateManifest\` on the registry) remains the source of truth for accepted shapes and the category enum.

## Test results

\`\`\`
bun test — 60 test files, 904 pass / 3 skip / 0 fail (was 894).
\`\`\`

New tests under \`toServerManifest — optional metadata forwarding\`:

- forwards repository when set
- omits repository when absent (no empty-string poisoning)
- omits repository when empty string
- forwards homepage when set / omits when absent
- forwards keywords array when non-empty / omits when absent / omits when empty array
- forwards category when set / omits when absent
- forwards every optional metadata field together (end-to-end)

## Verification plan

- [x] \`bun test\` passes
- [ ] After release, republish a metafactory package (e.g. \`@metafactory/soma\` 0.3.2) with arc 0.27.4 and confirm \`json_extract(pv.manifest, '\$.repository')\` returns the URL on the registry D1.
- [ ] Confirm \`meta-factory.ai/package/@metafactory/soma\` renders the relative-path \`<img>\` as \`https://raw.githubusercontent.com/the-metafactory/soma/HEAD/docs/...\`.

## Out of scope

- Author's \`github\` / \`verified\` fields — \`MetafactoryManifest\` has a more constrained author shape (\`ManifestAuthor\`); a sibling PR could reconcile.
- Dependency forwarding — separate concern, lives in arc's resolver path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)