### PR TITLE
feat(nats): Thread B — JetStream stream + durable consumer provisioning

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.27.4
+version: 0.28.0
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.27.4",
+  "version": "0.28.0",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {
@@ -18,6 +18,8 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
     "@noble/ed25519": "^3.1.0",
     "commander": "^13.0.0",
     "yaml": "^2.7.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1411,6 +1411,43 @@ nats
     await setupOperator(account, botNames, { force: opts.force });
   });
 
+/**
+ * Shared dispatch helper for the JetStream provisioning verbs. The two
+ * verbs differ only in (a) the orchestrator they call and (b) how the
+ * success payload maps to the {@link ProvisionJson} envelope; everything
+ * else — the try/catch shape, the dual JSON / human output path, the
+ * `emitJson` + `process.exit` choreography — is identical. Extracted so
+ * the next change to exit-code mapping or `classifyError` handling
+ * applies to both verbs in one place (Sage cycle-1 Maintainability finding).
+ */
+async function runNatsProvisionCommand<R>(args: {
+  json: boolean | undefined;
+  run: () => Promise<R>;
+  toResources: (r: R) => { resources: ProvisionJson["resources"]; natsUrl: string };
+  printHuman: (r: R) => void;
+}): Promise<never> {
+  if (args.json) {
+    try {
+      const r = await args.run();
+      const { resources, natsUrl } = args.toResources(r);
+      emitJson({ schema: ARC_NATS_SCHEMA, ok: true, resources, natsUrl });
+      process.exit(0);
+    } catch (err) {
+      emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: classifyError(err) });
+      process.exit(1);
+    }
+  }
+  try {
+    const r = await args.run();
+    args.printHuman(r);
+    process.exit(0);
+  } catch (err) {
+    const classified = classifyError(err);
+    console.error(`Error: ${classified.message}`);
+    process.exit(1);
+  }
+}
+
 nats
   .command("provision-streams")
   .description("Idempotently create the CODE_REVIEW JetStream stream + optional per-agent consumer")
@@ -1434,36 +1471,19 @@ nats
       ...(opts.stream !== undefined && { streamName: opts.stream }),
       ...(opts.network && opts.agent && { consumer: { network: opts.network, agent: opts.agent } }),
     };
-    if (opts.json) {
-      try {
-        const r = await provisionStreams(callOpts);
-        const payload: ProvisionJson = {
-          schema: ARC_NATS_SCHEMA,
-          ok: true,
-          resources: r.resources,
-          natsUrl: r.natsUrl,
-        };
-        emitJson(payload);
-        process.exit(0);
-      } catch (err) {
-        emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: classifyError(err) });
-        process.exit(1);
-      }
-      return;
-    }
-    try {
-      const r = await provisionStreams(callOpts);
-      for (const res of r.resources) {
-        const tag = res.created ? "created" : "exists";
-        const where = res.stream ? ` (stream=${res.stream})` : "";
-        console.log(`  ${tag} ${res.kind} ${res.name}${where}`);
-      }
-      console.log(`Provisioning complete against ${r.natsUrl}.`);
-    } catch (err) {
-      const classified = classifyError(err);
-      console.error(`Error: ${classified.message}`);
-      process.exit(1);
-    }
+    await runNatsProvisionCommand({
+      json: opts.json,
+      run: () => provisionStreams(callOpts),
+      toResources: (r) => ({ resources: r.resources, natsUrl: r.natsUrl }),
+      printHuman: (r) => {
+        for (const res of r.resources) {
+          const tag = res.created ? "created" : "exists";
+          const where = res.stream ? ` (stream=${res.stream})` : "";
+          console.log(`  ${tag} ${res.kind} ${res.name}${where}`);
+        }
+        console.log(`Provisioning complete against ${r.natsUrl}.`);
+      },
+    });
   });
 
 nats
@@ -1487,33 +1507,16 @@ nats
       ...(opts.stream !== undefined && { stream: opts.stream }),
       ...(opts.filterSubject !== undefined && { filterSubject: opts.filterSubject }),
     };
-    if (opts.json) {
-      try {
-        const r = await provisionConsumer(callOpts);
-        const payload: ProvisionJson = {
-          schema: ARC_NATS_SCHEMA,
-          ok: true,
-          resources: [r.resource],
-          natsUrl: r.natsUrl,
-        };
-        emitJson(payload);
-        process.exit(0);
-      } catch (err) {
-        emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: classifyError(err) });
-        process.exit(1);
-      }
-      return;
-    }
-    try {
-      const r = await provisionConsumer(callOpts);
-      const tag = r.resource.created ? "created" : "exists";
-      console.log(`  ${tag} consumer ${r.resource.name} (stream=${r.resource.stream})`);
-      console.log(`Provisioning complete against ${r.natsUrl}.`);
-    } catch (err) {
-      const classified = classifyError(err);
-      console.error(`Error: ${classified.message}`);
-      process.exit(1);
-    }
+    await runNatsProvisionCommand({
+      json: opts.json,
+      run: () => provisionConsumer(callOpts),
+      toResources: (r) => ({ resources: [r.resource], natsUrl: r.natsUrl }),
+      printHuman: (r) => {
+        const tag = r.resource.created ? "created" : "exists";
+        console.log(`  ${tag} consumer ${r.resource.name} (stream=${r.resource.stream})`);
+        console.log(`Provisioning complete against ${r.natsUrl}.`);
+      },
+    });
   });
 
 // ── Identity management commands ──────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceTyp
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
 import { addBot, reissueBot, listBots, removeBot, setupOperator } from "./commands/nats.js";
+import { provisionStreams, provisionConsumer } from "./commands/jetstream.js";
 import {
   ARC_NATS_SCHEMA,
   emitJson,
@@ -47,6 +48,7 @@ import {
   type ReissueBotJson,
   type RemoveBotJson,
   type SetupOperatorJson,
+  type ProvisionJson,
 } from "./lib/json-response.js";
 import { generateIdentity, exportPrincipals, importPrincipals, listPrincipals } from "./commands/identity.js";
 import { bundle, formatBundle } from "./commands/bundle.js";
@@ -1407,6 +1409,111 @@ nats
       return;
     }
     await setupOperator(account, botNames, { force: opts.force });
+  });
+
+nats
+  .command("provision-streams")
+  .description("Idempotently create the CODE_REVIEW JetStream stream + optional per-agent consumer")
+  .option("--nats-url <url>", "NATS broker URL (defaults to $NATS_URL or nats://127.0.0.1:4222)")
+  .option("--stream <name>", "Stream name override (default: CODE_REVIEW)")
+  .option("--network <network>", "Network segment of the consumer name (with --agent)")
+  .option("--agent <agent>", "Agent segment of the consumer name (with --network)")
+  .option("--json", "Emit a single line of stable JSON (schema: arc.nats.v1)")
+  .action(async (opts: { natsUrl?: string; stream?: string; network?: string; agent?: string; json?: boolean }) => {
+    if ((opts.network && !opts.agent) || (!opts.network && opts.agent)) {
+      const msg = "--network and --agent must be supplied together";
+      if (opts.json) {
+        emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: { code: "VALIDATION_ERROR", message: msg } });
+        process.exit(1);
+      }
+      console.error(`Error: ${msg}`);
+      process.exit(1);
+    }
+    const callOpts = {
+      ...(opts.natsUrl !== undefined && { natsUrl: opts.natsUrl }),
+      ...(opts.stream !== undefined && { streamName: opts.stream }),
+      ...(opts.network && opts.agent && { consumer: { network: opts.network, agent: opts.agent } }),
+    };
+    if (opts.json) {
+      try {
+        const r = await provisionStreams(callOpts);
+        const payload: ProvisionJson = {
+          schema: ARC_NATS_SCHEMA,
+          ok: true,
+          resources: r.resources,
+          natsUrl: r.natsUrl,
+        };
+        emitJson(payload);
+        process.exit(0);
+      } catch (err) {
+        emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: classifyError(err) });
+        process.exit(1);
+      }
+      return;
+    }
+    try {
+      const r = await provisionStreams(callOpts);
+      for (const res of r.resources) {
+        const tag = res.created ? "created" : "exists";
+        const where = res.stream ? ` (stream=${res.stream})` : "";
+        console.log(`  ${tag} ${res.kind} ${res.name}${where}`);
+      }
+      console.log(`Provisioning complete against ${r.natsUrl}.`);
+    } catch (err) {
+      const classified = classifyError(err);
+      console.error(`Error: ${classified.message}`);
+      process.exit(1);
+    }
+  });
+
+nats
+  .command("provision-consumer")
+  .description("Idempotently create a per-(network, agent) durable consumer on the CODE_REVIEW stream")
+  .requiredOption("--network <network>", "Network segment of the consumer name")
+  .requiredOption("--agent <agent>", "Agent segment of the consumer name")
+  .option("--nats-url <url>", "NATS broker URL (defaults to $NATS_URL or nats://127.0.0.1:4222)")
+  .option("--stream <name>", "Stream name override (default: CODE_REVIEW)")
+  .option("--filter-subject <subject>", "Optional consumer filter subject")
+  .option("--json", "Emit a single line of stable JSON (schema: arc.nats.v1)")
+  .action(async (opts: {
+    network: string; agent: string;
+    natsUrl?: string; stream?: string; filterSubject?: string;
+    json?: boolean;
+  }) => {
+    const callOpts = {
+      network: opts.network,
+      agent: opts.agent,
+      ...(opts.natsUrl !== undefined && { natsUrl: opts.natsUrl }),
+      ...(opts.stream !== undefined && { stream: opts.stream }),
+      ...(opts.filterSubject !== undefined && { filterSubject: opts.filterSubject }),
+    };
+    if (opts.json) {
+      try {
+        const r = await provisionConsumer(callOpts);
+        const payload: ProvisionJson = {
+          schema: ARC_NATS_SCHEMA,
+          ok: true,
+          resources: [r.resource],
+          natsUrl: r.natsUrl,
+        };
+        emitJson(payload);
+        process.exit(0);
+      } catch (err) {
+        emitJson({ schema: ARC_NATS_SCHEMA, ok: false, error: classifyError(err) });
+        process.exit(1);
+      }
+      return;
+    }
+    try {
+      const r = await provisionConsumer(callOpts);
+      const tag = r.resource.created ? "created" : "exists";
+      console.log(`  ${tag} consumer ${r.resource.name} (stream=${r.resource.stream})`);
+      console.log(`Provisioning complete against ${r.natsUrl}.`);
+    } catch (err) {
+      const classified = classifyError(err);
+      console.error(`Error: ${classified.message}`);
+      process.exit(1);
+    }
   });
 
 // ── Identity management commands ──────────────────────────

--- a/src/commands/jetstream.ts
+++ b/src/commands/jetstream.ts
@@ -1,0 +1,219 @@
+/**
+ * arc nats provision-streams / provision-consumer — JetStream resource
+ * provisioning commands.
+ *
+ * Companion to `arc nats add-bot` (NSC user provisioning, arc#108) and the
+ * broker-bootstrap gate in `install.ts` (arc#152 / PR #153). Together
+ * those three layers make a fresh-operator install reach a state where
+ * `pilot request-review` round-trips to sage without any manual NATS
+ * admin work.
+ *
+ * Use cases:
+ *   - First-install: run after broker comes up to create CODE_REVIEW + per-agent durables
+ *   - Re-run / diagnosis: idempotent — safe to invoke on a healthy host
+ *   - CI: stand up a test broker, provision, run integration tests, tear down
+ */
+
+import {
+  connectJsm,
+  ensureStream,
+  ensureConsumer,
+  reviewConsumerName,
+  CODE_REVIEW_STREAM,
+  CODE_REVIEW_STREAM_SUBJECTS,
+  DEFAULT_NATS_URL,
+} from "../lib/jetstream.js";
+import type { JetStreamManager } from "@nats-io/jetstream";
+import { ArcNatsCommandError, type ArcNatsErrorCode } from "../lib/json-response.js";
+
+/**
+ * Map a JetStream `ProvisionResult` failure reason to the public
+ * `ArcNatsErrorCode` taxonomy. Keep this isolated so the CLI layer's
+ * `classifyError` doesn't depend on JetStream-internal types.
+ */
+function reasonToCode(
+  reason: "broker_unreachable" | "stream_op_failed" | "consumer_op_failed",
+): ArcNatsErrorCode {
+  switch (reason) {
+    case "broker_unreachable": return "BROKER_UNREACHABLE";
+    case "stream_op_failed":   return "STREAM_OP_FAILED";
+    case "consumer_op_failed": return "CONSUMER_OP_FAILED";
+  }
+}
+
+/**
+ * Touched-resource entry surfaced in both human-readable stderr and the
+ * `--json` envelope. `created: false` is a successful idempotent no-op.
+ */
+export interface ResourceOutcome {
+  kind: "stream" | "consumer";
+  name: string;
+  stream?: string;
+  created: boolean;
+}
+
+export interface ProvisionStreamsOpts {
+  /** NATS broker URL. Defaults to {@link DEFAULT_NATS_URL}. */
+  natsUrl?: string;
+  /** Override the stream name. Defaults to {@link CODE_REVIEW_STREAM}. */
+  streamName?: string;
+  /** Override the subject pattern list. Defaults to {@link CODE_REVIEW_STREAM_SUBJECTS}. */
+  subjects?: readonly string[];
+  /** When true, `addPerNetworkConsumer` is also invoked for the given (network, agent) pair. */
+  consumer?: { network: string; agent: string };
+  /** Test seam — injectable JSM connector. */
+  _connectJsm?: typeof connectJsm;
+}
+
+/**
+ * Provision the CODE_REVIEW stream and optionally a per-(network, agent)
+ * durable consumer in one call.
+ *
+ * Throws `ArcNatsCommandError` on any failure so the CLI layer's existing
+ * `try/catch` → `classifyError` path applies uniformly to nats subcommands.
+ */
+export async function provisionStreams(opts: ProvisionStreamsOpts = {}): Promise<{
+  resources: ResourceOutcome[];
+  natsUrl: string;
+}> {
+  const natsUrl = opts.natsUrl ?? DEFAULT_NATS_URL;
+  const streamName = opts.streamName ?? CODE_REVIEW_STREAM;
+  const subjects = [...(opts.subjects ?? CODE_REVIEW_STREAM_SUBJECTS)];
+  const doConnect = opts._connectJsm ?? connectJsm;
+
+  const connection = await doConnect(natsUrl);
+  if (!connection.ok) {
+    throw new ArcNatsCommandError(
+      reasonToCode(connection.reason),
+      `JetStream provisioning failed: broker at ${natsUrl} unreachable (${connection.cause}). ` +
+        `If you haven't started the broker yet, see arc#152 / PR#153. ` +
+        `If the broker is up, check $NATS_URL and the JetStream account permissions.`,
+    );
+  }
+
+  const { nc, jsm } = connection;
+  const resources: ResourceOutcome[] = [];
+
+  try {
+    const streamResult = await ensureStream(jsm, { name: streamName, subjects });
+    if (!streamResult.ok) {
+      throw new ArcNatsCommandError(
+        reasonToCode(streamResult.reason),
+        `Stream "${streamName}" provisioning failed: ${streamResult.cause}`,
+      );
+    }
+    resources.push({
+      kind: "stream",
+      name: streamResult.value.name,
+      created: streamResult.status === "created",
+    });
+
+    if (opts.consumer) {
+      const consumerOutcome = await provisionConsumerInternal(
+        jsm,
+        streamName,
+        opts.consumer.network,
+        opts.consumer.agent,
+      );
+      resources.push(consumerOutcome);
+    }
+  } finally {
+    await nc.close().catch(() => {
+      /* close failure is secondary to provisioning result */
+    });
+  }
+
+  return { resources, natsUrl };
+}
+
+export interface ProvisionConsumerOpts {
+  /** NATS broker URL. */
+  natsUrl?: string;
+  /** Stream the durable consumer attaches to. Defaults to CODE_REVIEW. */
+  stream?: string;
+  /** Network segment of the consumer name (`cortex-review-consumer-<network>-<agent>`). */
+  network: string;
+  /** Agent segment of the consumer name. */
+  agent: string;
+  /** Optional filter subject override. */
+  filterSubject?: string;
+  /** Test seam — injectable JSM connector. */
+  _connectJsm?: typeof connectJsm;
+}
+
+/**
+ * Provision a single per-(network, agent) durable consumer on an existing
+ * stream. Errors if the stream does not exist (call `provisionStreams` first).
+ */
+export async function provisionConsumer(opts: ProvisionConsumerOpts): Promise<{
+  resource: ResourceOutcome;
+  natsUrl: string;
+}> {
+  const natsUrl = opts.natsUrl ?? DEFAULT_NATS_URL;
+  const stream = opts.stream ?? CODE_REVIEW_STREAM;
+  const doConnect = opts._connectJsm ?? connectJsm;
+
+  const connection = await doConnect(natsUrl);
+  if (!connection.ok) {
+    throw new ArcNatsCommandError(
+      reasonToCode(connection.reason),
+      `Consumer provisioning failed: broker at ${natsUrl} unreachable (${connection.cause}).`,
+    );
+  }
+
+  const { nc, jsm } = connection;
+  try {
+    const outcome = await provisionConsumerInternal(
+      jsm,
+      stream,
+      opts.network,
+      opts.agent,
+      opts.filterSubject,
+    );
+    return { resource: outcome, natsUrl };
+  } finally {
+    await nc.close().catch(() => {
+      /* close failure is secondary */
+    });
+  }
+}
+
+/**
+ * Internal helper — shared by `provisionStreams({consumer})` and standalone
+ * `provisionConsumer`. Centralises the durable-name derivation + the
+ * `ensureConsumer` → typed-error mapping.
+ */
+async function provisionConsumerInternal(
+  jsm: JetStreamManager,
+  stream: string,
+  network: string,
+  agent: string,
+  filterSubject?: string,
+): Promise<ResourceOutcome> {
+  const durable = reviewConsumerName(network, agent);
+  const result = await ensureConsumer(jsm, stream, {
+    durable_name: durable,
+    ...(filterSubject !== undefined && { filter_subject: filterSubject }),
+    ack_policy: "explicit" as ConsumerAckPolicy,
+  });
+  if (!result.ok) {
+    throw new ArcNatsCommandError(
+      reasonToCode(result.reason),
+      `Consumer "${durable}" on stream "${stream}" provisioning failed: ${result.cause}`,
+    );
+  }
+  return {
+    kind: "consumer",
+    name: result.value.durable,
+    stream: result.value.stream,
+    created: result.status === "created",
+  };
+}
+
+/**
+ * Re-export of JetStream's `AckPolicy` enum value as a string literal so
+ * the orchestrator stays one import-of-the-lib lighter. The wire format is
+ * the bare string ("explicit") — using the runtime enum would force every
+ * caller to import the same dependency.
+ */
+type ConsumerAckPolicy = "explicit";

--- a/src/lib/jetstream.ts
+++ b/src/lib/jetstream.ts
@@ -85,19 +85,38 @@ export async function connectJsm(url: string = DEFAULT_NATS_URL): Promise<
   | { ok: false; reason: "broker_unreachable"; cause: string }
 > {
   let nc: NatsConnection;
+  // Hold the timeout handle so the success path clears it. Without
+  // clearTimeout, non-JSON CLI invocations (which don't call process.exit
+  // on success) keep the event loop alive for the full 2s window after the
+  // command logically completes — Sage cycle-1 Performance finding.
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
     nc = await Promise.race([
       connect({ servers: url, name: "arc-jetstream-provision", reconnect: false }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("NATS connect timeout (2s)")), 2000),
-      ),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error("NATS connect timeout (2s)")), 2000);
+      }),
     ]);
   } catch (err) {
     const cause = err instanceof Error ? err.message : String(err);
     return { ok: false, reason: "broker_unreachable", cause };
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
-  const jsm = await jetstreamManager(nc);
-  return { ok: true, nc, jsm };
+  // JetStream manager init can fail with a connected broker — most often
+  // when JetStream is disabled on the broker or the account lacks JS
+  // permissions. Surface as `broker_unreachable` (broker is technically
+  // reachable but the JS subsystem behaves as if it isn't) with the real
+  // cause string, and close `nc` so the caller doesn't leak the socket
+  // — Sage cycle-1 CodeQuality finding.
+  try {
+    const jsm = await jetstreamManager(nc);
+    return { ok: true, nc, jsm };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    await nc.close().catch(() => { /* secondary to the JSM init failure */ });
+    return { ok: false, reason: "broker_unreachable", cause: `JetStream manager init failed: ${cause}` };
+  }
 }
 
 /**

--- a/src/lib/jetstream.ts
+++ b/src/lib/jetstream.ts
@@ -1,0 +1,229 @@
+/**
+ * JetStream resource helpers — idempotently provision streams + durable
+ * consumers required by metafactory bus packages.
+ *
+ * Companion to `src/lib/nats.ts` (NSC user provisioning, arc#108) and the
+ * broker-bootstrap gate in `src/commands/install.ts` (arc#152 / PR #153).
+ * Those two ensure (a) the broker is running and (b) NATS users exist.
+ * This module ensures (c) the JetStream stream + durable consumers exist
+ * so subscribers can actually consume from the broker.
+ *
+ * Closes the gap Andreas diagnosed in the P-VERIFY handover: first-install
+ * provisioning of CODE_REVIEW stream + `cortex-review-consumer-<network>-<agent>`
+ * durable was operator-manual. New operators hit silent timeouts because
+ * the consumer didn't exist; the publish landed on a subject no JetStream
+ * subscription was watching.
+ *
+ * Idempotent semantics:
+ *   - `ensureStream` — if stream exists with same config → no-op; missing → create
+ *   - `ensureConsumer` — if consumer exists on stream → no-op; missing → create
+ * Re-running is always safe.
+ */
+
+import { connect } from "@nats-io/transport-node";
+import { jetstreamManager } from "@nats-io/jetstream";
+import type { NatsConnection } from "@nats-io/transport-node";
+import type {
+  JetStreamManager,
+  StreamConfig,
+  ConsumerConfig,
+} from "@nats-io/jetstream";
+
+/**
+ * Default NATS URL used when no `NATS_URL` override is set. Matches pilot
+ * and cortex defaults (`nats://127.0.0.1:4222`).
+ */
+export const DEFAULT_NATS_URL = process.env.NATS_URL ?? "nats://127.0.0.1:4222";
+
+/**
+ * Canonical stream name for code-review tasks. Subjects follow the IoAW
+ * Broadcast grammar `local.{org}.{stack?}.tasks.code-review.{flavor}` so
+ * the sage subscription `local.{org}.{stack}.tasks.code-review.>` lands
+ * inside the stream filter.
+ */
+export const CODE_REVIEW_STREAM = "CODE_REVIEW";
+
+/**
+ * Default subjects covered by the CODE_REVIEW stream. The wildcards
+ * span every operator-id, every stack, and every code-review flavor so
+ * a single stream serves all multi-tenant deployments on the broker.
+ *
+ * `>` at the trailing position requires ≥1 segment, matching sage's
+ * subscribe-side filter (see pilot `tests/bus/publish-review-request.test.ts`
+ * for the corresponding subject derivation).
+ */
+export const CODE_REVIEW_STREAM_SUBJECTS: readonly string[] = [
+  "local.*.tasks.code-review.>",
+  "local.*.*.tasks.code-review.>",
+];
+
+/**
+ * Discriminated result of a provisioning call. Mirrors the typed-failure
+ * pattern in `src/lib/json-response.ts` so callers (CLI + tests) branch
+ * on `reason` rather than parsing stderr.
+ *
+ * `created` vs `already_exists` distinguishes first-install from re-run;
+ * operator logs surface the difference for "did I actually fix it" diagnosis.
+ */
+export type ProvisionResult<T> =
+  | { ok: true; status: "created" | "already_exists"; value: T }
+  | { ok: false; reason: "broker_unreachable"; cause: string }
+  | { ok: false; reason: "stream_op_failed"; stream: string; cause: string }
+  | { ok: false; reason: "consumer_op_failed"; stream: string; consumer: string; cause: string };
+
+/**
+ * Open a JetStream-enabled NATS connection. Surfaces the `broker_unreachable`
+ * reason as a typed result rather than a thrown exception so callers can
+ * decide between graceful-skip (install-time warning) and hard-fail (CLI
+ * verb invoked deliberately by the operator).
+ *
+ * The connection MUST be `.close()`-d by the caller — this helper does not
+ * own the lifecycle. Mirrors the pattern in pilot's `publishReviewRequested`.
+ */
+export async function connectJsm(url: string = DEFAULT_NATS_URL): Promise<
+  | { ok: true; nc: NatsConnection; jsm: JetStreamManager }
+  | { ok: false; reason: "broker_unreachable"; cause: string }
+> {
+  let nc: NatsConnection;
+  try {
+    nc = await Promise.race([
+      connect({ servers: url, name: "arc-jetstream-provision", reconnect: false }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("NATS connect timeout (2s)")), 2000),
+      ),
+    ]);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "broker_unreachable", cause };
+  }
+  const jsm = await jetstreamManager(nc);
+  return { ok: true, nc, jsm };
+}
+
+/**
+ * Idempotently ensure a JetStream stream exists with the requested config.
+ *
+ * Resolution:
+ *   1. `streams.info(name)` — exists? → status: "already_exists"
+ *   2. Not found → `streams.add(config)` → status: "created"
+ *   3. Anything else (RPC error, schema rejection) → typed failure
+ *
+ * Why not `update-or-add`. JetStream's `streams.update` requires posting the
+ * full config and validates against the existing one. Subject-list narrowing
+ * (rare but possible) is rejected by the broker as a destructive change.
+ * We default to leave-existing-alone — the operator changes config via
+ * `nats stream edit` deliberately, not via re-running provisioning.
+ */
+export async function ensureStream(
+  jsm: JetStreamManager,
+  config: Partial<StreamConfig> & { name: string; subjects: string[] },
+): Promise<ProvisionResult<{ name: string; subjects: string[] }>> {
+  try {
+    const existing = await jsm.streams.info(config.name);
+    return {
+      ok: true,
+      status: "already_exists",
+      value: {
+        name: existing.config.name,
+        subjects: existing.config.subjects ?? [],
+      },
+    };
+  } catch (err) {
+    // JetStream's `info` throws on 404 with `code: 404` on the error.
+    // Anything else (transport failure, auth) is a real error — surface it.
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/not found|404/i.test(message)) {
+      return { ok: false, reason: "stream_op_failed", stream: config.name, cause: message };
+    }
+  }
+  try {
+    const created = await jsm.streams.add(config as StreamConfig);
+    return {
+      ok: true,
+      status: "created",
+      value: {
+        name: created.config.name,
+        subjects: created.config.subjects ?? [],
+      },
+    };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: "stream_op_failed", stream: config.name, cause };
+  }
+}
+
+/**
+ * Idempotently ensure a durable consumer exists on the named stream.
+ *
+ * Durable-consumer name convention (cortex / sage): the consumer name
+ * embeds the deployment context so multiple consumers on the same stream
+ * don't collide. The handover documents
+ * `cortex-review-consumer-<network>-<agent>` — pilot operators picking
+ * sage/echo per-network land on distinct durables.
+ *
+ * Same resolution shape as {@link ensureStream}: info → exists, otherwise add.
+ */
+export async function ensureConsumer(
+  jsm: JetStreamManager,
+  stream: string,
+  config: Partial<ConsumerConfig> & { durable_name: string },
+): Promise<ProvisionResult<{ stream: string; durable: string; filter?: string }>> {
+  try {
+    const existing = await jsm.consumers.info(stream, config.durable_name);
+    return {
+      ok: true,
+      status: "already_exists",
+      value: {
+        stream,
+        durable: existing.name,
+        filter: existing.config.filter_subject,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/not found|404/i.test(message)) {
+      return {
+        ok: false,
+        reason: "consumer_op_failed",
+        stream,
+        consumer: config.durable_name,
+        cause: message,
+      };
+    }
+  }
+  try {
+    const created = await jsm.consumers.add(stream, config as ConsumerConfig);
+    return {
+      ok: true,
+      status: "created",
+      value: {
+        stream,
+        durable: created.name,
+        filter: created.config.filter_subject,
+      },
+    };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      reason: "consumer_op_failed",
+      stream,
+      consumer: config.durable_name,
+      cause,
+    };
+  }
+}
+
+/**
+ * Derive the canonical cortex review-consumer durable name from network +
+ * agent. Centralises the format so pilot's reference to
+ * `cortex-review-consumer-metafactory-echo` in the P-VERIFY handover and
+ * arc's provisioning landing on the same string by construction.
+ *
+ * Format: `cortex-review-consumer-<network>-<agent>`. Both segments must
+ * satisfy the NATS subject-segment grammar (lowercase alphanumeric +
+ * hyphen) to prevent broker-side rejections.
+ */
+export function reviewConsumerName(network: string, agent: string): string {
+  return `cortex-review-consumer-${network}-${agent}`;
+}

--- a/src/lib/json-response.ts
+++ b/src/lib/json-response.ts
@@ -33,6 +33,9 @@ export type ArcNatsErrorCode =
   | "VALIDATION_ERROR"      // bot name, subject, flags failed validation
   | "INVALID_USER_KEY"      // `nsc describe user -J` returned malformed data
   | "ROLLBACK_FAILED"       // create/reissue failed mid-way; manual recovery
+  | "BROKER_UNREACHABLE"    // JetStream provisioning: NATS broker not reachable
+  | "STREAM_OP_FAILED"      // JetStream provisioning: stream info/add/update failed
+  | "CONSUMER_OP_FAILED"    // JetStream provisioning: consumer info/add failed
   | "UNKNOWN";              // catch-all for un-mapped failures
 
 export interface ArcNatsError {
@@ -115,6 +118,27 @@ export interface SetupOperatorJson extends JsonOkBase {
 }
 
 /**
+ * `arc nats provision-streams` / `arc nats provision-consumer` result.
+ *
+ * `created` distinguishes first-install from re-run idempotent no-op.
+ * Multiple resources may be touched in a single call (one stream + N
+ * consumers), so `resources` is a list rather than a single field.
+ */
+export interface ProvisionJson extends JsonOkBase {
+  /** Each touched resource, in invocation order. */
+  resources: Array<{
+    kind: "stream" | "consumer";
+    name: string;
+    /** Parent stream for consumers; omitted for streams. */
+    stream?: string;
+    /** `true` iff this call created the resource; `false` for idempotent no-op. */
+    created: boolean;
+  }>;
+  /** NATS server URL the provisioning targeted. */
+  natsUrl: string;
+}
+
+/**
  * Emit a single line of JSON to stdout and return. Caller is responsible for
  * setting the process exit code (0 for ok, 1 for !ok).
  *
@@ -122,7 +146,7 @@ export interface SetupOperatorJson extends JsonOkBase {
  * compile error, not a silent contract violation.
  */
 export function emitJson(
-  payload: AddBotJson | ReissueBotJson | RemoveBotJson | SetupOperatorJson | JsonError,
+  payload: AddBotJson | ReissueBotJson | RemoveBotJson | SetupOperatorJson | ProvisionJson | JsonError,
 ): void {
   process.stdout.write(JSON.stringify(payload) + "\n");
 }

--- a/test/unit/jetstream.test.ts
+++ b/test/unit/jetstream.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for JetStream resource provisioning helpers.
+ *
+ * Uses a hand-rolled `JetStreamManager` mock — no real broker, no
+ * `@nats-io/transport-node` connection. The helpers' idempotent-by-info-first
+ * pattern means the test surface is just: stub `info` to throw 404 / return
+ * existing, stub `add` to return created config. No network in CI.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { JetStreamManager } from "@nats-io/jetstream";
+import {
+  ensureStream,
+  ensureConsumer,
+  reviewConsumerName,
+  CODE_REVIEW_STREAM,
+  CODE_REVIEW_STREAM_SUBJECTS,
+} from "../../src/lib/jetstream.js";
+import {
+  provisionStreams,
+  provisionConsumer,
+} from "../../src/commands/jetstream.js";
+
+/**
+ * Hand-rolled JSM mock. The functions we touch are tiny — pinning the shape
+ * here keeps the test file independent of `@nats-io/jetstream` minor-version
+ * drift in unrelated method signatures.
+ */
+function mockJsm(opts: {
+  streamsInfo?: (name: string) => Promise<{ config: { name: string; subjects?: string[] } }>;
+  streamsAdd?: (config: { name: string; subjects: string[] }) => Promise<{ config: { name: string; subjects?: string[] } }>;
+  consumersInfo?: (stream: string, durable: string) => Promise<{ name: string; config: { filter_subject?: string } }>;
+  consumersAdd?: (stream: string, config: { durable_name: string; filter_subject?: string }) => Promise<{ name: string; config: { filter_subject?: string } }>;
+}): JetStreamManager {
+  const notFound = () => { throw new Error("stream not found (404)"); };
+  return {
+    streams: {
+      info: opts.streamsInfo ?? notFound,
+      add: opts.streamsAdd ?? (async (cfg) => ({ config: { name: cfg.name, subjects: cfg.subjects } })),
+    },
+    consumers: {
+      info: opts.consumersInfo ?? notFound,
+      add: opts.consumersAdd ?? (async (_stream, cfg) => ({ name: cfg.durable_name, config: { filter_subject: cfg.filter_subject } })),
+    },
+  } as unknown as JetStreamManager;
+}
+
+describe("reviewConsumerName", () => {
+  test("composes the canonical cortex-review-consumer-<network>-<agent> format", () => {
+    expect(reviewConsumerName("metafactory", "echo")).toBe("cortex-review-consumer-metafactory-echo");
+    expect(reviewConsumerName("local", "sage")).toBe("cortex-review-consumer-local-sage");
+  });
+});
+
+describe("ensureStream", () => {
+  test("returns already_exists when stream is already present (idempotent re-run)", async () => {
+    const jsm = mockJsm({
+      streamsInfo: async (name) => ({ config: { name, subjects: ["local.*.tasks.code-review.>"] } }),
+    });
+    const result = await ensureStream(jsm, {
+      name: "CODE_REVIEW",
+      subjects: ["local.*.tasks.code-review.>"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status).toBe("already_exists");
+      expect(result.value.name).toBe("CODE_REVIEW");
+    }
+  });
+
+  test("creates stream when info returns 404", async () => {
+    let added = false;
+    const jsm = mockJsm({
+      streamsAdd: async (cfg) => {
+        added = true;
+        return { config: { name: cfg.name, subjects: cfg.subjects } };
+      },
+    });
+    const result = await ensureStream(jsm, {
+      name: "CODE_REVIEW",
+      subjects: ["local.*.tasks.code-review.>"],
+    });
+    expect(added).toBe(true);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.status).toBe("created");
+  });
+
+  test("returns stream_op_failed on non-404 info error", async () => {
+    const jsm = mockJsm({
+      streamsInfo: async () => { throw new Error("auth: insufficient permissions"); },
+    });
+    const result = await ensureStream(jsm, { name: "X", subjects: ["a.>"] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("stream_op_failed");
+  });
+
+  test("returns stream_op_failed on add error", async () => {
+    const jsm = mockJsm({
+      streamsAdd: async () => { throw new Error("subject overlap with existing stream X"); },
+    });
+    const result = await ensureStream(jsm, { name: "Y", subjects: ["a.>"] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("stream_op_failed");
+      expect(result.cause).toContain("subject overlap");
+    }
+  });
+});
+
+describe("ensureConsumer", () => {
+  test("returns already_exists when durable is present", async () => {
+    const jsm = mockJsm({
+      consumersInfo: async (_stream, durable) => ({ name: durable, config: { filter_subject: "x.>" } }),
+    });
+    const result = await ensureConsumer(jsm, "CODE_REVIEW", { durable_name: "cortex-review-consumer-net-echo" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.status).toBe("already_exists");
+      expect(result.value.durable).toBe("cortex-review-consumer-net-echo");
+    }
+  });
+
+  test("creates durable when info returns 404", async () => {
+    let added = false;
+    const jsm = mockJsm({
+      consumersAdd: async (_stream, cfg) => {
+        added = true;
+        return { name: cfg.durable_name, config: {} };
+      },
+    });
+    const result = await ensureConsumer(jsm, "CODE_REVIEW", { durable_name: "cortex-review-consumer-net-echo" });
+    expect(added).toBe(true);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.status).toBe("created");
+  });
+
+  test("returns consumer_op_failed on non-404 info error", async () => {
+    const jsm = mockJsm({
+      consumersInfo: async () => { throw new Error("transport: broken pipe"); },
+    });
+    const result = await ensureConsumer(jsm, "S", { durable_name: "d" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("consumer_op_failed");
+  });
+});
+
+describe("provisionStreams orchestrator", () => {
+  test("happy path: stream + per-(network, agent) consumer both created", async () => {
+    const jsm = mockJsm({});
+    const fakeNc = { close: async () => undefined };
+    const r = await provisionStreams({
+      consumer: { network: "metafactory", agent: "echo" },
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    });
+    expect(r.resources).toHaveLength(2);
+    expect(r.resources[0]).toMatchObject({ kind: "stream", name: CODE_REVIEW_STREAM, created: true });
+    expect(r.resources[1]).toMatchObject({
+      kind: "consumer",
+      name: "cortex-review-consumer-metafactory-echo",
+      stream: CODE_REVIEW_STREAM,
+      created: true,
+    });
+  });
+
+  test("idempotent re-run: both resources surface created=false", async () => {
+    const jsm = mockJsm({
+      streamsInfo: async (name) => ({ config: { name, subjects: [...CODE_REVIEW_STREAM_SUBJECTS] } }),
+      consumersInfo: async (_s, d) => ({ name: d, config: {} }),
+    });
+    const fakeNc = { close: async () => undefined };
+    const r = await provisionStreams({
+      consumer: { network: "metafactory", agent: "echo" },
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    });
+    for (const res of r.resources) expect(res.created).toBe(false);
+  });
+
+  test("no consumer when caller omits the {network, agent} pair", async () => {
+    const jsm = mockJsm({});
+    const fakeNc = { close: async () => undefined };
+    const r = await provisionStreams({
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    });
+    expect(r.resources).toHaveLength(1);
+    expect(r.resources[0]?.kind).toBe("stream");
+  });
+
+  test("broker_unreachable surfaces as ArcNatsCommandError", async () => {
+    await expect(provisionStreams({
+      _connectJsm: async () => ({ ok: false as const, reason: "broker_unreachable", cause: "ECONNREFUSED" }),
+    })).rejects.toThrow(/broker.*unreachable.*ECONNREFUSED/);
+  });
+
+  test("stream_op_failed surfaces as ArcNatsCommandError with stream name in message", async () => {
+    const jsm = mockJsm({
+      streamsInfo: async () => { throw new Error("auth: insufficient permissions"); },
+    });
+    const fakeNc = { close: async () => undefined };
+    await expect(provisionStreams({
+      streamName: "BROKEN",
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    })).rejects.toThrow(/BROKEN.*provisioning failed.*insufficient permissions/);
+  });
+
+  test("closes the NATS connection even when provisioning fails", async () => {
+    let closed = false;
+    const fakeNc = { close: async () => { closed = true; } };
+    const jsm = mockJsm({
+      streamsInfo: async () => { throw new Error("auth: forbidden"); },
+    });
+    await expect(provisionStreams({
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    })).rejects.toThrow(/forbidden/);
+    expect(closed).toBe(true);
+  });
+});
+
+describe("provisionConsumer orchestrator", () => {
+  test("derives the canonical durable name from (network, agent)", async () => {
+    let capturedDurable = "";
+    const jsm = mockJsm({
+      consumersAdd: async (_s, cfg) => {
+        capturedDurable = cfg.durable_name;
+        return { name: cfg.durable_name, config: {} };
+      },
+    });
+    const fakeNc = { close: async () => undefined };
+    const r = await provisionConsumer({
+      network: "metafactory",
+      agent: "echo",
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    });
+    expect(capturedDurable).toBe("cortex-review-consumer-metafactory-echo");
+    expect(r.resource.name).toBe("cortex-review-consumer-metafactory-echo");
+    expect(r.resource.stream).toBe(CODE_REVIEW_STREAM);
+  });
+
+  test("optional filter-subject flows through to consumer config", async () => {
+    let captured: { durable_name: string; filter_subject?: string } | null = null;
+    const jsm = mockJsm({
+      consumersAdd: async (_s, cfg) => {
+        captured = cfg;
+        return { name: cfg.durable_name, config: { filter_subject: cfg.filter_subject } };
+      },
+    });
+    const fakeNc = { close: async () => undefined };
+    await provisionConsumer({
+      network: "net-a",
+      agent: "echo",
+      filterSubject: "local.*.tasks.code-review.typescript",
+      _connectJsm: async () => ({ ok: true as const, nc: fakeNc as any, jsm }),
+    });
+    expect(captured!.filter_subject).toBe("local.*.tasks.code-review.typescript");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap Andreas diagnosed in the P-VERIFY handover: first-install
provisioning of \`CODE_REVIEW\` stream + \`cortex-review-consumer-<network>-<agent>\`
durable was operator-manual. New operators hit silent timeouts because the
consumer didn't exist; pilot's publish landed on a subject no JetStream
subscription was watching.

This PR is the **third layer of the bus-bootstrap stack**:

| Layer | Owner | Status |
|---|---|---|
| NSC user provisioning | \`arc nats add-bot\` (arc#108) | shipped |
| Broker lifecycle | \`arc install requires.nats=true\` (PR #153) | open |
| **JetStream stream + consumer provisioning** | **this PR** | new |

After all three exist on a host, a fresh \`arc install\` + \`arc nats provision-streams\` reaches a state where \`pilot request-review\` round-trips to sage without any manual NATS admin work.

## New CLI verbs

\`\`\`bash
# Create stream + per-agent consumer in one shot
arc nats provision-streams --network metafactory --agent echo [--json]

# Create just a consumer on an existing stream
arc nats provision-consumer --network metafactory --agent echo [--json]
\`\`\`

Both verbs are **idempotent** — info-first; if the resource exists, return \`created: false\`. Safe to re-run on healthy hosts.

## Architecture

- \`src/lib/jetstream.ts\` — JSM helpers (\`connectJsm\`, \`ensureStream\`, \`ensureConsumer\`, \`reviewConsumerName\`). Typed \`ProvisionResult\` discriminated union for failure reasons.
- \`src/commands/jetstream.ts\` — orchestrators (\`provisionStreams\`, \`provisionConsumer\`). Open JSM → ensure → close (even on failure). Map reasons to \`ArcNatsErrorCode\`.
- \`src/lib/json-response.ts\` — 3 new error codes (\`BROKER_UNREACHABLE\`, \`STREAM_OP_FAILED\`, \`CONSUMER_OP_FAILED\`) + \`ProvisionJson\` envelope.
- \`src/cli.ts\` — two commander subcommands wired to the \`nats\` group, matching the existing add-bot/remove-bot \`--json\` pattern.

## Subjects pinned to sage's subscription

CODE_REVIEW stream subjects default to **two patterns** so a single stream serves both pre-stack and post-myelin#113 pilot publishers:

\`\`\`
local.*.tasks.code-review.>        (4-segment form)
local.*.*.tasks.code-review.>      (5-segment form, post-stack)
\`\`\`

Sage's \`local.{org}.{?stack?}.tasks.code-review.>\` subscription always lands inside the stream filter regardless of which pilot path published.

Durable consumer name: \`cortex-review-consumer-<network>-<agent>\` per Andreas's handover spec.

## Test plan

- [x] \`bun test test/unit/jetstream.test.ts\` — 16 pass (mock JSM, no broker)
- [x] \`bun test\` full suite — **920 pass / 3 skip / 0 fail** (zero regression)
- [x] \`bunx tsc --noEmit\` — clean
- [x] Live smoke against running broker: connection + JSM API path verified end-to-end. Local broker has JetStream enabled but no storage quota → \`STREAM_OP_FAILED: insufficient storage resources available\` — exactly the actionable error a first-install operator needs (not a code defect).
- [ ] Live integration on a host with JetStream account-storage configured (next post-merge step during P-VERIFY round-trip re-test on Andreas's box).

## Refs

- P-VERIFY handover from Andreas (2026-05-17, JC-EU handoff)
- arc#152 / PR #153 — broker lifecycle (sibling layer)
- arc#108 — NSC credential helper (sibling layer)
- pilot Thread A (the-metafactory/pilot#133, merged) — publish-side symmetry fix that pairs with this PR for end-to-end round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)