### PR TITLE
fix(rules): regenerate templates for any package providing them, not just type:rules

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -230,9 +230,13 @@ export async function upgradePackage(
   const newVersion = manifest.version;
 
   if (compareSemver(oldVersion, newVersion) >= 0 && !opts?.force) {
-    // Version matches — but for rules packages, still regenerate templates
-    // (template content may have changed even if version was already bumped)
-    if (manifest.type === "rules" && manifest.provides?.templates?.length) {
+    // Version matches — but if the package provides templates, still
+    // regenerate them: template/section content may have changed even
+    // when the package version was already bumped. Gated on the presence
+    // of provides.templates[] rather than manifest.type, because a
+    // package can legitimately ship templates alongside other artefacts
+    // (e.g. a governance-overlay that also owns CLAUDE.md generation).
+    if (manifest.provides?.templates?.length) {
       const consumerDirs = findConsumerRepos(manifest.provides.templates);
       for (const dir of consumerDirs) {
         await generateRules(installPath, manifest.provides.templates, dir);
@@ -288,9 +292,12 @@ export async function upgradePackage(
     await registerHooks(name, resolvedHooks, settingsPath);
   }
 
-  // Re-generate rules templates if this is a rules package
-  // Scan all repos with matching config files, not just cwd
-  if (manifest.type === "rules" && manifest.provides?.templates?.length) {
+  // Re-generate rule files for any package that provides templates.
+  // Scan all repos with matching config files, not just cwd. Gated on
+  // provides.templates[] rather than manifest.type — the presence of the
+  // declaration is itself the signal that this package owns rules-file
+  // generation, regardless of its primary type.
+  if (manifest.provides?.templates?.length) {
     const consumerDirs = findConsumerRepos(manifest.provides.templates);
     for (const dir of consumerDirs) {
       await generateRules(installPath, manifest.provides.templates, dir);

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -123,21 +123,10 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "rules": {
-      // Rules packages: run template generation in the consumer repo
-      const templates = manifest.provides?.templates ?? [];
-      if (templates.length) {
-        const consumerDir = opts.consumerDir ?? process.cwd();
-        const results = await generateRules(installDir, templates, consumerDir);
-        if (!quiet) {
-          for (const r of results) {
-            if (r.success && r.target) {
-              console.log(`  Generated ${r.target}`);
-            } else if (!r.success) {
-              console.log(`  \u26A0 ${r.target}: ${r.error}`);
-            }
-          }
-        }
-      }
+      // Rules packages have no per-type primary layout. Template generation
+      // is handled by the type-agnostic provides.templates pass below (a-181)
+      // so that a package shipping templates under a different primary type
+      // (e.g. a governance-overlay) regenerates too.
       break;
     }
 
@@ -278,6 +267,29 @@ export async function createArtifactSymlinks(opts: {
     await mkdir(dirname(targetPath), { recursive: true });
     await linkTracked(sourcePath, targetPath);
     filesCreated.push({ source: sourcePath, target: targetPath });
+  }
+
+  // Type-agnostic provides.templates pass (a-181).
+  // Every artifact type that declares provides.templates[] gets rule-file
+  // generation run in the consumer repo. Previously only `type: rules`
+  // honored this, which silently broke packages that ship templates
+  // alongside other artefacts — compass is a governance-overlay that owns
+  // CLAUDE.md generation. The presence of provides.templates[] is itself
+  // the signal; the primary `type` does not gate it. Mirrors the
+  // provides.files pass above (issue #84).
+  const declaredTemplates = manifest.provides?.templates ?? [];
+  if (declaredTemplates.length) {
+    const consumerDir = opts.consumerDir ?? process.cwd();
+    const results = await generateRules(installDir, declaredTemplates, consumerDir);
+    if (!quiet) {
+      for (const r of results) {
+        if (r.success && r.target) {
+          console.log(`  Generated ${r.target}`);
+        } else if (!r.success) {
+          console.log(`  ⚠ ${r.target}: ${r.error}`);
+        }
+      }
+    }
   }
 
   return { filesCreated, filesMissingSource: [], record };

--- a/test/commands/rules.test.ts
+++ b/test/commands/rules.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "path";
 import { readFile, mkdir } from "fs/promises";
-import { createTestEnv, createMockSkillRepo, type TestEnv, type MockSkillRepo } from "../helpers/test-env.js";
+import { createTestEnv, type TestEnv, type MockSkillRepo } from "../helpers/test-env.js";
 import { install } from "../../src/commands/install.js";
 import { upgradePackage } from "../../src/commands/upgrade.js";
 
@@ -21,8 +21,16 @@ afterEach(async () => {
 
 /**
  * Create a mock rules package repo with templates.
+ *
+ * `opts.type` defaults to "rules" but can be overridden to model a package
+ * that ships templates alongside other artefacts (e.g. "governance-overlay"
+ * — the compass case from a-181). The upgrade pipeline should regenerate
+ * templates for any package declaring provides.templates[], regardless of type.
  */
-async function createMockRulesRepo(root: string, opts?: { version?: string }): Promise<MockSkillRepo> {
+async function createMockRulesRepo(
+  root: string,
+  opts?: { version?: string; type?: string },
+): Promise<MockSkillRepo> {
   const repoDir = join(root, "mock-rules-pkg");
 
   // Create templates
@@ -61,7 +69,7 @@ async function createMockRulesRepo(root: string, opts?: { version?: string }): P
     `schema: arc/v1
 name: compass-standards
 version: ${opts?.version ?? "0.3.0"}
-type: rules
+type: ${opts?.type ?? "rules"}
 tier: official
 author:
   name: metafactory
@@ -163,6 +171,66 @@ extra_labels:
   expect(output).toContain("| `network` |");
   // Injection markers should be cleaned up
   expect(output).not.toContain("<!-- inject:");
+});
+
+test("upgrade --force regenerates templates for a non-rules package that provides templates", async () => {
+  // a-181: a package can declare provides.templates[] while having a primary
+  // type other than "rules" (compass ships templates but resolves to a
+  // non-rules artifact type). Both the install pass and the upgrade pipeline
+  // must regenerate the consumer's CLAUDE.md regardless of primary type.
+  const overlayRepo = await createMockRulesRepo(env.root, { type: "component" });
+
+  await Bun.write(
+    join(consumerDir, "agents-md.yaml"),
+    `template: compass-standards
+repo_name: halden
+repo_description: "Overlay consumer"
+sections:
+  - position: "after:description"
+    file: docs/agents-md/architecture.md
+`,
+  );
+  await Bun.write(
+    join(consumerDir, "docs", "agents-md", "architecture.md"),
+    "## Architecture\n\nFirst version.",
+  );
+
+  await install({
+    arc: env.arc, host: env.host,
+    db: env.db,
+    repoUrl: overlayRepo.url,
+    yes: true,
+    consumerDir,
+  });
+
+  // Install-time generation picked up v1.
+  let output = await readFile(join(consumerDir, "CLAUDE.md"), "utf-8");
+  expect(output).toContain("First version.");
+
+  // Section content drifts with no package version bump — the exact case
+  // `arc upgrade compass --force` must handle.
+  await Bun.write(
+    join(consumerDir, "docs", "agents-md", "architecture.md"),
+    "## Architecture\n\nSecond version.",
+  );
+
+  // findConsumerRepos scans BLUEPRINT_DEV_ROOT — point it at the test root
+  // so the consumer dir is discovered.
+  const priorDevRoot = process.env.BLUEPRINT_DEV_ROOT;
+  process.env.BLUEPRINT_DEV_ROOT = env.root;
+  try {
+    const result = await upgradePackage(env.db, env.arc, env.host, "compass-standards", { force: true });
+    expect(result.success).toBe(true);
+  } finally {
+    if (priorDevRoot === undefined) delete process.env.BLUEPRINT_DEV_ROOT;
+    else process.env.BLUEPRINT_DEV_ROOT = priorDevRoot;
+  }
+
+  // Pre-fix: the upgrade gate required type === "rules", so this was a
+  // no-op and CLAUDE.md still said "First version." Post-fix: regenerated.
+  output = await readFile(join(consumerDir, "CLAUDE.md"), "utf-8");
+  expect(output).toContain("Second version.");
+  expect(output).not.toContain("First version.");
 });
 
 test("rules package recorded as rules artifact type in DB", async () => {


### PR DESCRIPTION
## Summary

`arc install` and `arc upgrade` only ran template generation (`generateRules`) when the package's primary `type` was `"rules"`. A package that legitimately ships templates alongside other artefacts — **compass is a `governance-overlay` that owns `CLAUDE.md` generation** — never had its templates regenerated. `arc upgrade compass --force` was a silent no-op for every consumer repo (cortex, halden, …).

Surfaced while dogfooding compass-CLAUDE.md adoption on [`mellanon/halden#95`](https://github.com/mellanon/halden/pull/95).

## Root cause

Two gate sites, both keyed on `manifest.type === "rules"`:

- `src/lib/artifact-installer.ts` — template generation lived **inside** the `case "rules":` branch of the artifact-type `switch`, so no other type reached it.
- `src/commands/upgrade.ts` — both regeneration sites (the version-match-no-force branch and the full upgrade pipeline) were `&&`-gated on `type === "rules"`.

## Fix

Mirrors the **type-agnostic `provides.files` pass** added for #84 — the presence of `provides.templates[]` is itself the signal that a package owns rules-file generation; the primary `type` does not gate it.

- **`artifact-installer.ts`** — hoisted template generation out of `case "rules":` into a type-agnostic `provides.templates` pass that runs for every artifact type after the `switch` (right beside the `provides.files` pass). `case "rules":` becomes a documented `break`.
- **`upgrade.ts`** — dropped the `manifest.type === "rules"` condition from both gate sites; they now fire on `manifest.provides?.templates?.length` alone.

## Test

`test/commands/rules.test.ts` — new case: `upgrade --force regenerates templates for a non-rules package that provides templates`. Installs a `type: component` package that declares `provides.templates[]`, drifts a section file with no version bump, runs `upgradePackage(..., { force: true })`, asserts the consumer's `CLAUDE.md` regenerated. Pre-fix this test fails (stale output); post-fix it passes. `createMockRulesRepo` gains a `type` option.

## Risk

Low. Packages without `provides.templates` are unaffected — the inner `if (templates.length)` guard is unchanged. Packages with `provides.templates` but a non-rules type were already declaring the contract; this honours it. No public signature changes.

## Validation

- Full suite: **956 pass / 0 fail / 3 skip** (959 across 63 files)
- `bunx tsc --noEmit` clean

## Test plan

- [x] `bun test` full suite green
- [x] `bunx tsc --noEmit` clean
- [ ] Post-merge: `arc upgrade compass --force` from a consumer repo with `agents-md.yaml` regenerates `CLAUDE.md` (verifies the real compass case end-to-end)
- [ ] Then update `compass/sops/claude-md-adoption.md` §Known issues per compass#64 acceptance criteria

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)