### PR TITLE
fix(upgrade): make registry-extracted packages upgradable (arc#187)

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -11,6 +11,11 @@ import { createSymlink } from "../lib/symlinks.js";
 import { findGitRoot } from "../lib/paths.js";
 import { loadSources } from "../lib/sources.js";
 import { findInAllSources } from "../lib/remote-registry.js";
+import {
+  parsePackageRef,
+  resolveFromRegistry,
+  fetchAndVerifyRegistryPackage,
+} from "../lib/registry-install.js";
 import { runScript } from "../lib/scripts.js";
 import { registerHooks, removeHooks, resolveHooksFromManifest } from "../lib/hooks.js";
 import { generateRules } from "../lib/rules.js";
@@ -75,10 +80,26 @@ export async function checkUpgrades(
       upgradable: false,
     };
 
-    // Check registry for advertised version
-    const found = await findInAllSources(sources, skill.name, arc.cachePath);
-    if (found?.entry.version) {
-      result.registryVersion = found.entry.version;
+    // Resolve the advertised version. Registry-extracted packages store a
+    // package ref (`@scope/name@version`) in repo_url and are published to the
+    // metafactory HTTP API, NOT the YAML registry index — so findInAllSources
+    // can never see them and --check would falsely report "up to date"
+    // (arc#187 bug 1). Resolve those through resolveFromRegistry instead.
+    // Git / YAML-registry packages keep the findInAllSources path unchanged.
+    const ref = parsePackageRef(skill.repo_url);
+    if (ref) {
+      const resolved = await resolveFromRegistry(
+        { scope: ref.scope, name: ref.name },
+        sources.sources,
+      );
+      if (resolved?.version) {
+        result.registryVersion = resolved.version;
+      }
+    } else {
+      const found = await findInAllSources(sources, skill.name, arc.cachePath);
+      if (found?.entry.version) {
+        result.registryVersion = found.entry.version;
+      }
     }
 
     // Check the actual cloned repo's manifest for current version
@@ -162,35 +183,100 @@ export async function upgradePackage(
     return { success: false, name, oldVersion: skill.version, error: `Install path not found: ${installPath}` };
   }
 
-  // For library artifacts, git pull must run at the repo root (not artifact subdir)
-  const gitCwd = findGitRoot(installPath) ?? installPath;
+  // Two upgrade substrates with different fetch + rollback mechanics (arc#187).
+  // Registry-extracted packages store a package ref in repo_url and have no
+  // `.git`, so `git pull` can never work for them (bug 2). Git-cloned packages
+  // pull. `rollback()` restores the prior on-disk state if a later gate fails;
+  // `commitSwap()` drops the registry backup once the upgrade has committed.
+  const ref = parsePackageRef(skill.repo_url);
+  const isRegistry = ref !== null;
 
-  // Capture the pre-pull HEAD so the broker-gate failure path below can
-  // roll the repo back to a consistent state — sage cycle-3 important
-  // finding. Without rollback, a broker-failed upgrade leaves the repo
-  // at the new commit while the DB still records the old version,
-  // creating a state-drift hazard for the next operation.
-  const preHeadProbe = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
-    cwd: gitCwd, stdout: "pipe", stderr: "pipe",
-  });
-  const preHeadSha = preHeadProbe.exitCode === 0 ? preHeadProbe.stdout.toString().trim() : null;
+  let rollback: () => string;
+  let commitSwap: () => void = () => undefined;
 
-  // git pull in the cloned repo
-  const pullResult = Bun.spawnSync(["git", "pull", "--ff-only"], {
-    cwd: gitCwd,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  if (isRegistry) {
+    // Clean, fully-verified re-download (SHA-256 + registry signature +
+    // Sigstore — security parity with install) into a temp dir, then an
+    // atomic swap. Because the download+verify completes BEFORE the working
+    // install is touched, a failed/blocked fetch can never strand the user
+    // with no install — which is the remove+install hazard (bug 3).
+    const sources = await loadSources(arc.sourcesPath);
+    const tmpDirName = `${ref.scope}__${ref.name}.arc-upgrade-tmp`;
+    const fetched = await fetchAndVerifyRegistryPackage({
+      ref: { scope: ref.scope, name: ref.name },
+      sources: sources.sources,
+      reposDir: arc.reposDir,
+      targetDirName: tmpDirName,
+    });
+    if (!fetched.success || !fetched.extractedPath) {
+      return { success: false, name, oldVersion: skill.version, error: fetched.error ?? "registry re-download failed" };
+    }
 
-  if (pullResult.exitCode !== 0) {
-    const stderr = pullResult.stderr.toString().trim();
-    return { success: false, name, oldVersion: skill.version, error: `git pull failed: ${stderr}` };
+    const newPath = fetched.extractedPath;
+    const backupPath = `${installPath}.arc-upgrade-bak`;
+    Bun.spawnSync(["rm", "-rf", backupPath], { stdout: "pipe", stderr: "pipe" });
+    const aside = Bun.spawnSync(["mv", installPath, backupPath], { stdout: "pipe", stderr: "pipe" });
+    if (aside.exitCode !== 0) {
+      Bun.spawnSync(["rm", "-rf", newPath], { stdout: "pipe", stderr: "pipe" });
+      return { success: false, name, oldVersion: skill.version, error: `upgrade swap failed: ${aside.stderr.toString().trim()}` };
+    }
+    const intoPlace = Bun.spawnSync(["mv", newPath, installPath], { stdout: "pipe", stderr: "pipe" });
+    if (intoPlace.exitCode !== 0) {
+      // Restore the working install — never leave the user without one.
+      Bun.spawnSync(["mv", backupPath, installPath], { stdout: "pipe", stderr: "pipe" });
+      Bun.spawnSync(["rm", "-rf", newPath], { stdout: "pipe", stderr: "pipe" });
+      return { success: false, name, oldVersion: skill.version, error: `upgrade swap failed: ${intoPlace.stderr.toString().trim()}` };
+    }
+    rollback = () => {
+      Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
+      const r = Bun.spawnSync(["mv", backupPath, installPath], { stdout: "pipe", stderr: "pipe" });
+      return r.exitCode === 0 ? "" : ` Additionally, restore of the prior install failed: ${r.stderr.toString().trim()}`;
+    };
+    commitSwap = () => { Bun.spawnSync(["rm", "-rf", backupPath], { stdout: "pipe", stderr: "pipe" }); };
+  } else {
+    // For library artifacts, git pull must run at the repo root (not artifact subdir)
+    const gitCwd = findGitRoot(installPath) ?? installPath;
+
+    // Capture the pre-pull HEAD so the broker-gate failure path below can
+    // roll the repo back to a consistent state — sage cycle-3 important
+    // finding. Without rollback, a broker-failed upgrade leaves the repo
+    // at the new commit while the DB still records the old version,
+    // creating a state-drift hazard for the next operation.
+    const preHeadProbe = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+      cwd: gitCwd, stdout: "pipe", stderr: "pipe",
+    });
+    const preHeadSha = preHeadProbe.exitCode === 0 ? preHeadProbe.stdout.toString().trim() : null;
+
+    // git pull in the cloned repo
+    const pullResult = Bun.spawnSync(["git", "pull", "--ff-only"], {
+      cwd: gitCwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    if (pullResult.exitCode !== 0) {
+      const stderr = pullResult.stderr.toString().trim();
+      return { success: false, name, oldVersion: skill.version, error: `git pull failed: ${stderr}` };
+    }
+
+    rollback = () => {
+      if (preHeadSha !== null) {
+        const resetRes = Bun.spawnSync(["git", "reset", "--hard", preHeadSha], {
+          cwd: gitCwd, stdout: "pipe", stderr: "pipe",
+        });
+        return resetRes.exitCode === 0
+          ? ""
+          : ` Additionally, post-failure rollback to ${preHeadSha} failed: ${resetRes.stderr.toString().trim()}`;
+      }
+      return ` Pre-pull HEAD was not captured; on-disk repo may be ahead of recorded version.`;
+    };
   }
 
-  // Re-read manifest for new version
+  // Re-read manifest for new version (from the now-current install path).
   const manifest = await readManifest(installPath);
   if (!manifest) {
-    return { success: false, name, oldVersion: skill.version, error: "No arc-manifest.yaml (or pai-manifest.yaml) after pull" };
+    const note = rollback();
+    return { success: false, name, oldVersion: skill.version, error: "No arc-manifest.yaml (or pai-manifest.yaml) after upgrade" + note };
   }
 
   // Runtime broker check (arc#152) — re-verify the bus dependency. The
@@ -202,22 +288,10 @@ export async function upgradePackage(
     contextClause: " during upgrade",
   });
   if (!brokerGate.ok) {
-    // Roll the repo back to its pre-pull HEAD so the on-disk + DB state
-    // stay consistent. Best-effort: if reset itself fails we surface the
-    // broker error (the real cause) AND the rollback failure so the
-    // operator sees both. Without preHeadSha we can't safely reset, so
-    // we log the inconsistency clearly.
-    let rollbackNote = "";
-    if (preHeadSha !== null) {
-      const resetRes = Bun.spawnSync(["git", "reset", "--hard", preHeadSha], {
-        cwd: gitCwd, stdout: "pipe", stderr: "pipe",
-      });
-      if (resetRes.exitCode !== 0) {
-        rollbackNote = ` Additionally, post-failure rollback to ${preHeadSha} failed: ${resetRes.stderr.toString().trim()}`;
-      }
-    } else {
-      rollbackNote = ` Pre-pull HEAD was not captured; on-disk repo may be ahead of recorded version.`;
-    }
+    // Roll the on-disk state back so it stays consistent with the DB.
+    // Best-effort: surface the broker error (the real cause) AND any
+    // rollback failure so the operator sees both.
+    const rollbackNote = rollback();
     return {
       success: false,
       name,
@@ -238,6 +312,7 @@ export async function upgradePackage(
         await generateRules(installPath, manifest.provides.templates, dir);
       }
     }
+    commitSwap();
     return { success: true, name, oldVersion, newVersion: oldVersion };
   }
 
@@ -250,7 +325,8 @@ export async function upgradePackage(
       env: { PAI_OLD_VERSION: oldVersion, PAI_NEW_VERSION: newVersion },
     });
     if (!preResult.success && !preResult.skipped) {
-      return { success: false, name, oldVersion, error: `Preupgrade script failed (exit ${preResult.exitCode})` };
+      const note = rollback();
+      return { success: false, name, oldVersion, error: `Preupgrade script failed (exit ${preResult.exitCode})` + note };
     }
   }
 
@@ -316,7 +392,8 @@ export async function upgradePackage(
       env: { PAI_OLD_VERSION: oldVersion, PAI_NEW_VERSION: newVersion },
     });
     if (!postResult.success && !postResult.skipped) {
-      return { success: false, name, oldVersion, error: `${postHookName} script failed (exit ${postResult.exitCode})` };
+      const note = rollback();
+      return { success: false, name, oldVersion, error: `${postHookName} script failed (exit ${postResult.exitCode})` + note };
     }
   }
 
@@ -350,6 +427,9 @@ export async function upgradePackage(
       for (const s of caps.secrets) insertCap.run(name, "secret", s, "");
     }
   }
+
+  // Upgrade committed — drop the registry backup (no-op for git packages).
+  commitSwap();
 
   return { success: true, name, oldVersion, newVersion };
 }

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -8,6 +8,8 @@ import type {
 } from "../types.js";
 import { getSourceType } from "./sources.js";
 import { fetchMetafactoryPackageDetail } from "./metafactory-api.js";
+import { verifyVersionSignature } from "./registry-signing.js";
+import { verifyPackageSigstore } from "./cosign-verify.js";
 
 // ---------------------------------------------------------------------------
 // Package reference parsing
@@ -495,4 +497,102 @@ export async function extractPackage(
   }
 
   return { success: true, extractedPath };
+}
+
+// ---------------------------------------------------------------------------
+// Verified registry fetch (shared install + upgrade path) — arc#187
+// ---------------------------------------------------------------------------
+
+export interface VerifiedFetchResult {
+  success: boolean;
+  /** Path the verified tarball was extracted to (a temp dir name under reposDir). */
+  extractedPath?: string;
+  /** Resolved registry metadata (version, source, …). */
+  resolved?: ResolvedRegistryPackage;
+  error?: string;
+  quarantine?: QuarantineInfo;
+}
+
+/**
+ * Resolve, download, fully verify, and extract a registry package — arc#187.
+ *
+ * This is the secure registry pipeline factored out of the `arc install`
+ * inline flow (cli.ts) so `arc upgrade` can re-download a registry-extracted
+ * package with the SAME verification guarantees instead of a weaker check.
+ * It performs, in order:
+ *   1. resolveFromRegistry (metafactory API) → version + sha256 + signing block
+ *   2. downloadPackage (anonymous by default; bearer attached for auth'd storage)
+ *   3. SHA-256 checksum verification
+ *   4. Ed25519 registry-signature verification (A-504; fail-closed on `false`)
+ *   5. Sigstore bundle verification (A-503; fail-closed on `false`, `null` = proceed)
+ *   6. extract to `<reposDir>/<targetDirName>`
+ *
+ * The artifact is extracted to a caller-chosen dir name (typically a `.tmp`
+ * sibling of the real install path) so the caller can atomically swap it into
+ * place only after success — never destroying the working install first.
+ *
+ * Unsigned/legacy versions (`verified: null`) proceed, mirroring install-side
+ * graceful degradation. A genuine signature mismatch (`verified: false`)
+ * fails closed. Console output is the caller's responsibility — this function
+ * is silent so it can be used in non-interactive upgrade flows.
+ */
+export async function fetchAndVerifyRegistryPackage(opts: {
+  ref: PackageRef;
+  sources: RegistrySource[];
+  reposDir: string;
+  targetDirName: string;
+}): Promise<VerifiedFetchResult> {
+  const resolved = await resolveFromRegistry(opts.ref, opts.sources);
+  if (!resolved) {
+    return {
+      success: false,
+      error: `Package "${formatPackageRef(opts.ref)}" not found in any metafactory registry.`,
+    };
+  }
+
+  const download = await downloadPackage(resolved.downloadUrl, opts.reposDir, resolved.source);
+  if (!download.success || !download.tempPath) {
+    return { success: false, error: download.error, quarantine: download.quarantine };
+  }
+
+  const checksum = await verifyChecksum(download.tempPath, resolved.sha256);
+  if (!checksum.valid) {
+    await unlink(download.tempPath).catch(() => undefined);
+    return {
+      success: false,
+      error: `Checksum verification failed (expected ${checksum.expected}, got ${checksum.actual}).`,
+    };
+  }
+
+  const sigResult = await verifyVersionSignature(
+    resolved.source,
+    { registry_signature: resolved.registrySignature, registry_key_id: resolved.registryKeyId },
+    resolved.manifestCanonical,
+  );
+  if (sigResult.verified === false) {
+    await unlink(download.tempPath).catch(() => undefined);
+    return { success: false, error: `Registry signature verification failed: ${sigResult.reason}` };
+  }
+
+  const sigstoreResult = await verifyPackageSigstore({
+    source: resolved.source,
+    sha256: resolved.sha256,
+    signing: {
+      signature_bundle_key: resolved.signatureBundleKey,
+      signer_identity: resolved.signerIdentity,
+    },
+    artifactPath: download.tempPath,
+    tempDir: opts.reposDir,
+  });
+  if (sigstoreResult.verified === false) {
+    await unlink(download.tempPath).catch(() => undefined);
+    return { success: false, error: `Sigstore verification failed: ${sigstoreResult.reason}` };
+  }
+
+  const extract = await extractPackage(download.tempPath, opts.reposDir, opts.targetDirName);
+  if (!extract.success) {
+    return { success: false, error: extract.error };
+  }
+
+  return { success: true, extractedPath: extract.extractedPath, resolved };
 }

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -9,8 +9,9 @@ import {
   formatCheckResults,
   formatUpgradeResults,
 } from "../../src/commands/upgrade.js";
-import { loadSources, saveSources } from "../../src/lib/sources.js";
+import { saveSources } from "../../src/lib/sources.js";
 import { writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
 import { join } from "path";
 import YAML from "yaml";
 import type { RegistryConfig, SourcesConfig } from "../../src/types.js";
@@ -274,6 +275,184 @@ describe("upgradeAll", () => {
     expect(forceResults).toHaveLength(1);
     expect(forceResults[0].name).toBe("ForceAll");
     expect(forceResults[0].success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// arc#187 — registry-extracted package upgrade path
+// ---------------------------------------------------------------------------
+
+function mockFetch(handler: (input: any, init?: any) => Promise<Response>): typeof fetch {
+  const fn = handler as typeof fetch;
+  (fn as any).preconnect = () => {};
+  return fn;
+}
+
+/**
+ * Build a real gzipped package tarball (single top-level dir containing
+ * arc-manifest.yaml) and return its bytes + sha256 so a mocked metafactory
+ * registry can advertise and serve it. extractPackage strips one path
+ * component, so the manifest must live one level deep.
+ */
+async function buildRegistryFixture(
+  baseDir: string,
+  name: string,
+  version: string,
+): Promise<{ bytes: Uint8Array; sha256: string }> {
+  const stageRoot = join(baseDir, `__fixture-${name}-${version}`);
+  const topDir = join(stageRoot, "pkg");
+  await mkdir(join(topDir, "skill"), { recursive: true });
+  await writeFile(join(topDir, "skill", "SKILL.md"), `---\nname: ${name}\ndescription: fixture\n---\n\n# ${name}\n`);
+  await writeFile(
+    join(topDir, "arc-manifest.yaml"),
+    YAML.stringify({
+      name,
+      version,
+      type: "skill",
+      tier: "custom",
+      author: { name: "t", github: "t" },
+      provides: { skill: [{ trigger: name.toLowerCase() }] },
+      depends_on: { tools: [{ name: "bun", version: ">=1.0.0" }] },
+      capabilities: {
+        filesystem: { read: [], write: [] },
+        network: [],
+        bash: { allowed: false },
+        secrets: [],
+      },
+    }),
+  );
+  const tarPath = join(baseDir, `__fixture-${name}-${version}.tar.gz`);
+  Bun.spawnSync(["tar", "czf", tarPath, "-C", stageRoot, "pkg"], { stdout: "pipe", stderr: "pipe" });
+  const buf = await Bun.file(tarPath).arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buf);
+  return { bytes: new Uint8Array(buf), sha256: hasher.digest("hex") };
+}
+
+function metafactoryRegistryHandler(opts: {
+  scope: string;
+  name: string;
+  latestVersion: string;
+  sha256: string;
+  tarball?: Uint8Array;
+}) {
+  return async (input: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.includes("/storage/download/")) {
+      return new Response((opts.tarball ?? new Uint8Array()) as unknown as BodyInit, { status: 200 });
+    }
+    // version detail: /packages/<scope>/<name>@<version>
+    if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
+      return new Response(JSON.stringify({
+        version: opts.latestVersion,
+        sha256: opts.sha256,
+        manifest_canonical: `{"name":"@${opts.scope}/${opts.name}","version":"${opts.latestVersion}"}`,
+        signing: { registry_signature: null, registry_key_id: null },
+      }), { status: 200 });
+    }
+    // package detail
+    return new Response(JSON.stringify({
+      namespace: `@${opts.scope}`, name: opts.name,
+      display_name: null, description: "", type: "skill", license: "MIT",
+      latest_version: opts.latestVersion, versions: [opts.latestVersion],
+      publisher: { display_name: "T", tier: "official", mfa_enabled: true, github_username: null },
+      sponsor: null, created_at: 0, updated_at: 0,
+    }), { status: 200 });
+  };
+}
+
+async function addMetafactorySource(env: TestEnv): Promise<void> {
+  await saveSources(env.arc.sourcesPath, {
+    sources: [
+      { name: "mf", url: "https://meta-factory.test", tier: "official", enabled: true, type: "metafactory" },
+    ],
+  });
+}
+
+describe("checkUpgrades — registry-extracted package (arc#187)", () => {
+  test("resolves newer version via metafactory API, not the YAML index", async () => {
+    const repo = await createMockSkillRepo(env.root, { name: "soma", version: "0.6.4" });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
+    // Simulate a registry-extracted install: repo_url is a package ref.
+    env.db.prepare("UPDATE skills SET repo_url = ? WHERE name = ?").run("@metafactory/soma@0.6.4", "soma");
+    await addMetafactorySource(env);
+
+    const fixture = await buildRegistryFixture(env.root, "soma", "0.7.1");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(metafactoryRegistryHandler({ scope: "metafactory", name: "soma", latestVersion: "0.7.1", sha256: fixture.sha256 }));
+    try {
+      const results = await checkUpgrades(env.db, env.arc, env.host);
+      const soma = results.find((r) => r.name === "soma")!;
+      expect(soma.installedVersion).toBe("0.6.4");
+      expect(soma.registryVersion).toBe("0.7.1");
+      expect(soma.upgradable).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("upgradePackage — registry-extracted package (arc#187)", () => {
+  test("force-upgrades via clean re-download — no git pull error, DB updated", async () => {
+    const repo = await createMockSkillRepo(env.root, { name: "soma", version: "0.6.4" });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
+    env.db.prepare("UPDATE skills SET repo_url = ? WHERE name = ?").run("@metafactory/soma@0.6.4", "soma");
+    await addMetafactorySource(env);
+
+    const fixture = await buildRegistryFixture(env.root, "soma", "0.7.1");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch(metafactoryRegistryHandler({
+      scope: "metafactory", name: "soma", latestVersion: "0.7.1", sha256: fixture.sha256, tarball: fixture.bytes,
+    }));
+    try {
+      const result = await upgradePackage(env.db, env.arc, env.host, "soma", { force: true });
+      expect(result.success).toBe(true);
+      expect(result.oldVersion).toBe("0.6.4");
+      expect(result.newVersion).toBe("0.7.1");
+      // The defining symptom of bug 2 must be gone.
+      expect(result.error ?? "").not.toContain("git pull failed");
+      expect(result.error ?? "").not.toContain("not a git repository");
+
+      const row = env.db.prepare("SELECT version FROM skills WHERE name = ?").get("soma") as { version: string };
+      expect(row.version).toBe("0.7.1");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("never strands the user: a failed download leaves the prior install intact", async () => {
+    const repo = await createMockSkillRepo(env.root, { name: "soma", version: "0.6.4" });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true });
+    const installPath = (env.db.prepare("SELECT install_path FROM skills WHERE name = ?").get("soma") as { install_path: string }).install_path;
+    env.db.prepare("UPDATE skills SET repo_url = ? WHERE name = ?").run("@metafactory/soma@0.6.4", "soma");
+    await addMetafactorySource(env);
+
+    const originalFetch = globalThis.fetch;
+    // Storage download returns 401 (stale token) — the exact remove+install hazard.
+    globalThis.fetch = mockFetch(async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/storage/download/")) return new Response("denied", { status: 401 });
+      if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
+        return new Response(JSON.stringify({ version: "0.7.1", sha256: "deadbeef", manifest_canonical: "{}", signing: { registry_signature: null, registry_key_id: null } }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        namespace: "@metafactory", name: "soma", display_name: null, description: "", type: "skill", license: "MIT",
+        latest_version: "0.7.1", versions: ["0.7.1"],
+        publisher: { display_name: "T", tier: "official", mfa_enabled: true, github_username: null }, sponsor: null, created_at: 0, updated_at: 0,
+      }), { status: 200 });
+    });
+    try {
+      const result = await upgradePackage(env.db, env.arc, env.host, "soma", { force: true });
+      expect(result.success).toBe(false);
+      // The working install is still on disk — not removed.
+      expect(existsSync(installPath)).toBe(true);
+      expect(existsSync(join(installPath, "arc-manifest.yaml"))).toBe(true);
+      // DB still records the old version (no drift).
+      const row = env.db.prepare("SELECT version FROM skills WHERE name = ?").get("soma") as { version: string };
+      expect(row.version).toBe("0.6.4");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #187.

Registry-extracted packages (installed via `@scope/name`, e.g. `@metafactory/soma`) could not be upgraded, breaking the documented SOMA upgrade experience three ways. Root cause for all three: the upgrade path assumed every package is a git clone resolved through the YAML registry index.

## Bug 1 — `arc upgrade <pkg> --check` falsely reports "up to date"
`checkUpgrades` resolved the advertised version via `findInAllSources` (the YAML registry index), but registry packages are published to the metafactory HTTP API. Lookup returned null → fell back to the on-disk manifest version (== installed) → never upgradable.

**Fix:** parse `repo_url`; if it's a package ref, resolve the latest version through `resolveFromRegistry` (metafactory API). Git / YAML-registry packages keep the `findInAllSources` path unchanged.

## Bug 2 — `arc upgrade <pkg> --force` errors `git pull failed: not a git repository`
The pipeline always ran `git pull` in the install dir, but a registry-extracted tarball has no `.git`.

**Fix:** `upgradePackage` now detects registry packages and upgrades them by clean re-download + atomic swap instead of `git pull`. New `fetchAndVerifyRegistryPackage` helper performs the **same verification as install** — SHA-256 + Ed25519 registry signature + Sigstore bundle (reusing the existing verify functions). Git packages keep the `git pull` + pre-pull-HEAD rollback path.

## Bug 3 — remove+install can strand the user
The documented fallback (`arc remove` + `arc install`) can leave the package fully uninstalled when the reinstall fails on a stale token.

**Fix:** bugs 1+2 remove the need for the destructive fallback. Additionally the registry upgrade downloads+verifies **before** touching the working install and restores the prior install on any failure — so an upgrade can never strand the user.

## Verification
- Full suite **958 pass / 3 skip / 0 fail**; `tsc --noEmit` and `eslint` clean.
- New tests: registry `--check` detection, registry `--force` clean re-download (asserts the `git pull` error is gone + DB updated), and a "never strands the user" case (storage 401 mid-upgrade leaves install dir + manifest + DB version intact).

Files: `src/commands/upgrade.ts`, `src/lib/registry-install.ts`, `test/commands/upgrade.test.ts` (+404 / −45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)