### PR TITLE
fix(ci): green up main — Linux tar bundling + eslint gate

### DIFF
--- a/src/commands/jetstream.ts
+++ b/src/commands/jetstream.ts
@@ -191,10 +191,11 @@ async function provisionConsumerInternal(
   filterSubject?: string,
 ): Promise<ResourceOutcome> {
   const durable = reviewConsumerName(network, agent);
+  const ackPolicy: ConsumerAckPolicy = "explicit";
   const result = await ensureConsumer(jsm, stream, {
     durable_name: durable,
     ...(filterSubject !== undefined && { filter_subject: filterSubject }),
-    ack_policy: "explicit" as ConsumerAckPolicy,
+    ack_policy: ackPolicy,
   });
   if (!result.ok) {
     throw new ArcNatsCommandError(

--- a/src/lib/bundle.ts
+++ b/src/lib/bundle.ts
@@ -205,13 +205,31 @@ export async function createBundle(
 
   const excludeArgs = buildTarArgs(exclusions, includePatterns);
 
+  // Write the archive to a temp dir OUTSIDE packageDir, then move it into
+  // place. Writing the tarball directly into packageDir while archiving `.`
+  // makes the directory change as tar reads it: GNU tar (Linux CI) aborts
+  // with "file changed as we read it" (exit 1), while bsdtar (macOS) tolerates
+  // it — which is exactly why this passed locally but failed in CI. Staging
+  // outside the source tree keeps the read set stable on every platform.
+  const stageDir = await mkdtemp(join(tmpdir(), "arc-bundle-"));
+  const stagedTarball = join(stageDir, "bundle.tar.gz");
+
   const result = Bun.spawnSync(
-    ["tar", "czf", tarballName, ...excludeArgs, "."],
+    ["tar", "czf", stagedTarball, ...excludeArgs, "."],
     { cwd: packageDir, stdout: "pipe", stderr: "pipe" },
   );
 
   if (result.exitCode !== 0) {
+    await rm(stageDir, { recursive: true, force: true }).catch(() => undefined);
     return { success: false, tarballPath: tarballName, sha256: "", sizeBytes: 0, fileCount: 0, manifest, warnings, error: `tar failed: ${result.stderr.toString().trim()}` };
+  }
+
+  // Move the finished archive into its final location, then drop the temp dir.
+  // `mv` (not fs.rename) so a cross-filesystem tmpdir → packageDir move works.
+  const moveResult = Bun.spawnSync(["mv", stagedTarball, tarballName], { stdout: "pipe", stderr: "pipe" });
+  await rm(stageDir, { recursive: true, force: true }).catch(() => undefined);
+  if (moveResult.exitCode !== 0) {
+    return { success: false, tarballPath: tarballName, sha256: "", sizeBytes: 0, fileCount: 0, manifest, warnings, error: `failed to finalize bundle: ${moveResult.stderr.toString().trim()}` };
   }
 
   const { sha256, sizeBytes, fileCount } = await getBundleStats(tarballName);

--- a/src/lib/jetstream.ts
+++ b/src/lib/jetstream.ts
@@ -94,7 +94,7 @@ export async function connectJsm(url: string = DEFAULT_NATS_URL): Promise<
     nc = await Promise.race([
       connect({ servers: url, name: "arc-jetstream-provision", reconnect: false }),
       new Promise<never>((_, reject) => {
-        timeoutHandle = setTimeout(() => reject(new Error("NATS connect timeout (2s)")), 2000);
+        timeoutHandle = setTimeout(() => { reject(new Error("NATS connect timeout (2s)")); }, 2000);
       }),
     ]);
   } catch (err) {
@@ -144,7 +144,7 @@ export async function ensureStream(
       status: "already_exists",
       value: {
         name: existing.config.name,
-        subjects: existing.config.subjects ?? [],
+        subjects: existing.config.subjects,
       },
     };
   } catch (err) {
@@ -156,13 +156,13 @@ export async function ensureStream(
     }
   }
   try {
-    const created = await jsm.streams.add(config as StreamConfig);
+    const created = await jsm.streams.add(config);
     return {
       ok: true,
       status: "created",
       value: {
         name: created.config.name,
-        subjects: created.config.subjects ?? [],
+        subjects: created.config.subjects,
       },
     };
   } catch (err) {
@@ -211,7 +211,7 @@ export async function ensureConsumer(
     }
   }
   try {
-    const created = await jsm.consumers.add(stream, config as ConsumerConfig);
+    const created = await jsm.consumers.add(stream, config);
     return {
       ok: true,
       status: "created",

--- a/src/lib/json-response.ts
+++ b/src/lib/json-response.ts
@@ -126,14 +126,14 @@ export interface SetupOperatorJson extends JsonOkBase {
  */
 export interface ProvisionJson extends JsonOkBase {
   /** Each touched resource, in invocation order. */
-  resources: Array<{
+  resources: {
     kind: "stream" | "consumer";
     name: string;
     /** Parent stream for consumers; omitted for streams. */
     stream?: string;
     /** `true` iff this call created the resource; `false` for idempotent no-op. */
     created: boolean;
-  }>;
+  }[];
   /** NATS server URL the provisioning targeted. */
   natsUrl: string;
 }

--- a/src/lib/nats-broker.ts
+++ b/src/lib/nats-broker.ts
@@ -135,7 +135,7 @@ export function parseNatsUrl(url: string): { host: string; port: number } {
   // because WHATWG's URL parser rejects unknown schemes for hostname
   // extraction on some runtimes; `tcp://` is treated as a generic special
   // scheme and the hostname / port surface cleanly.
-  if (/^nats:\/\//.test(url)) {
+  if (url.startsWith("nats://")) {
     try {
       const parsed = new URL(url.replace(/^nats:/, "tcp:"));
       const host = stripIpv6(parsed.hostname);


### PR DESCRIPTION
Two **pre-existing** failures keep `main` CI red (Tests + Lint), independent of any feature branch. Fixing both so feature PRs (e.g. #188) can merge against a green base.

## 1. Tests — `createBundle` fails only on Linux
`tar czf <tarball> … .` wrote the archive **into** `packageDir` while archiving `.`, so the growing tarball perturbed the directory tar was reading. GNU tar (Linux CI) aborts with `file changed as we read it` (exit 1); bsdtar (macOS) tolerates it — which is why the suite passed locally but failed in CI (`createBundle`, `arc bundle`, `arc publish` all route through it).

**Fix:** stage the archive in a temp dir outside the source tree, then `mv` it into place (`mv`, not `fs.rename`, for cross-filesystem moves). Read set is now stable on every platform.

## 2. Lint — `eslint --quiet .` gate has 8 errors
Pre-existing across `commands/jetstream.ts`, `lib/jetstream.ts`, `json-response.ts`, `nats-broker.ts`:
- unnecessary type assertions (`as ConsumerAckPolicy`, `as StreamConfig`, `as ConsumerConfig`)
- unnecessary `?? []` on nats-lib `subjects` (typed non-nullable `string[]`)
- `Array<T>` → `T[]`
- regex `test` → `String#startsWith`
- void-expression arrow needing braces

All mechanical / behavior-preserving. `commands/jetstream.ts` keeps its `ConsumerAckPolicy` alias via annotation rather than assertion (preserves the documented "don't import the runtime enum" intent).

## Verification
- Full suite **955 pass / 3 skip / 0 fail**
- `bunx tsc --noEmit` clean
- `bun run lint:errors` (the CI gate) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)