### PR TITLE
publish: Sigstore-sign official package versions

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.30.0
+version: 0.30.1
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -934,7 +934,8 @@ program
   .option("--dry-run", "Validate and show what would be published without uploading")
   .option("-s, --source <name>", "Use a specific metafactory source")
   .option("--scope <namespace>", "Override publish scope/namespace")
-  .action(async (path: string | undefined, opts: { tarball?: string; dryRun?: boolean; source?: string; scope?: string }) => {
+  .option("--allow-unsigned-official", "Legacy rollout escape hatch: publish to an official source without Sigstore signing")
+  .action(async (path: string | undefined, opts: { tarball?: string; dryRun?: boolean; source?: string; scope?: string; allowUnsignedOfficial?: boolean }) => {
     const paths = createArcPaths();
     const result = await publish({
       paths,
@@ -943,6 +944,7 @@ program
       dryRun: opts.dryRun,
       sourceName: opts.source,
       scope: opts.scope,
+      allowUnsignedOfficial: opts.allowUnsignedOfficial,
     });
 
     console.log(formatPublish(result));

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,13 +1,16 @@
-import { resolve } from "path";
+import { join, resolve } from "path";
 import { rm } from "fs/promises";
+import { tmpdir } from "os";
 import { createBundle, computeChecksum } from "../lib/bundle.js";
 import {
   extractReadme,
   resolvePublishScope,
   uploadBundle,
+  uploadSigstoreBundle,
   ensurePackageExists,
   registerVersion,
 } from "../lib/publish.js";
+import { signSigstoreBundle, type SignSigstoreResult } from "../lib/cosign.js";
 import { loadSources, findMetafactorySource } from "../lib/sources.js";
 import { readManifest } from "../lib/manifest.js";
 import type { ArcPaths } from "../types.js";
@@ -19,6 +22,8 @@ export interface PublishOptions {
   dryRun?: boolean;
   sourceName?: string;
   scope?: string;
+  allowUnsignedOfficial?: boolean;
+  signer?: (artifactPath: string, bundlePath: string) => Promise<SignSigstoreResult>;
 }
 
 export interface PublishCommandResult {
@@ -96,11 +101,35 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
     };
   }
 
+  let sigstoreBundlePath: string | undefined;
+
   try {
     // 7. Upload tarball
     const uploadResult = await uploadBundle(tarballPath, source, sha256);
     if (!uploadResult.success) {
       return { success: false, error: uploadResult.error };
+    }
+
+    let signatureBundleKey: string | undefined;
+    let signerIdentity: string | undefined;
+    let signedAt: number | undefined;
+
+    if (source.tier === "official" && !opts.allowUnsignedOfficial) {
+      sigstoreBundlePath = join(tmpdir(), `arc-sigstore-${uploadResult.sha256}-${Date.now()}.bundle`);
+      const signer = opts.signer ?? signSigstoreBundle;
+      const signResult = await signer(tarballPath, sigstoreBundlePath);
+      if (!signResult.success || !signResult.bundlePath) {
+        return { success: false, error: `Sigstore signing failed: ${signResult.error ?? "bundle was not created"}` };
+      }
+
+      const bundleUpload = await uploadSigstoreBundle(signResult.bundlePath, source, uploadResult.sha256);
+      if (!bundleUpload.success || !bundleUpload.bundleKey) {
+        return { success: false, error: bundleUpload.error ?? "Sigstore bundle upload failed." };
+      }
+
+      signatureBundleKey = bundleUpload.bundleKey;
+      signerIdentity = signResult.signerIdentity;
+      signedAt = signResult.signedAt;
     }
 
     // 8. Ensure package exists
@@ -121,6 +150,9 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
       manifest,
       scope,
       readme: readme ?? undefined,
+      signature_bundle_key: signatureBundleKey,
+      signer_identity: signerIdentity,
+      signed_at: signedAt,
     });
 
     if (!registerResult.success) {
@@ -140,6 +172,11 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
     if (tempTarball) {
       await rm(tarballPath).catch(() => {
         // best-effort cleanup; tarball may already be gone
+      });
+    }
+    if (sigstoreBundlePath) {
+      await rm(sigstoreBundlePath).catch(() => {
+        // best-effort cleanup; bundle may already be gone
       });
     }
   }

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -153,6 +153,65 @@ export interface VerifySigstoreResult {
   output?: string;
 }
 
+export interface SignSigstoreResult {
+  success: boolean;
+  bundlePath?: string;
+  signerIdentity?: string;
+  signedAt?: number;
+  error?: string;
+  output?: string;
+}
+
+export function resolveSignerIdentity(env: Record<string, string | undefined> = process.env): string | undefined {
+  if (env.ARC_SIGSTORE_SIGNER_IDENTITY) return env.ARC_SIGSTORE_SIGNER_IDENTITY;
+  if (env.GITHUB_WORKFLOW_REF) return `https://github.com/${env.GITHUB_WORKFLOW_REF}`;
+  return undefined;
+}
+
+/**
+ * Sign an artifact with keyless cosign and write the Sigstore bundle to disk.
+ */
+export async function signSigstoreBundle(
+  artifactPath: string,
+  bundlePath: string,
+): Promise<SignSigstoreResult> {
+  const cosign = await ensureCosignBinary();
+  if (!cosign.path) {
+    return { success: false, error: cosign.error ?? "cosign binary unavailable" };
+  }
+
+  const signedAt = Math.floor(Date.now() / 1000);
+  const result = Bun.spawnSync(
+    [
+      cosign.path,
+      "sign-blob",
+      "--bundle", bundlePath,
+      "--yes",
+      artifactPath,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  const stdout = result.stdout.toString().trim();
+  const stderr = result.stderr.toString().trim();
+
+  if (result.exitCode === 0) {
+    return {
+      success: true,
+      bundlePath,
+      signerIdentity: resolveSignerIdentity(),
+      signedAt,
+      output: stdout || stderr,
+    };
+  }
+
+  return {
+    success: false,
+    error: stderr || stdout || `cosign exited with code ${result.exitCode}`,
+    output: stdout,
+  };
+}
+
 /**
  * Verify a Sigstore bundle for an artifact using cosign verify-blob.
  * Auto-fetches cosign if not already present.

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -310,6 +310,68 @@ export interface RegisterPayload {
   manifest: ArcManifest;
   scope: string;
   readme?: string;
+  signature_bundle_key?: string;
+  signer_identity?: string;
+  signed_at?: number;
+}
+
+export interface UploadSigstoreBundleResult {
+  success: boolean;
+  bundleKey?: string;
+  sizeBytes?: number;
+  error?: string;
+}
+
+/** Upload a cosign signature bundle for an already-uploaded tarball hash. */
+export async function uploadSigstoreBundle(
+  bundlePath: string,
+  source: RegistrySource,
+  sha256: string,
+): Promise<UploadSigstoreBundleResult> {
+  const file = Bun.file(bundlePath);
+  const bundleJson = await file.text();
+  const expectedBundleKey = `packages/${sha256}.bundle`;
+
+  try {
+    const resp = await fetch(`${source.url}/api/v1/storage/bundle/${sha256}`, {
+      method: "PUT",
+      headers: {
+        ...buildPublishHeaders(source),
+        "Content-Type": "application/json",
+      },
+      body: bundleJson,
+      signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+    });
+
+    if (resp.status === 401) {
+      return { success: false, error: 'Not authenticated. Run "arc login" first.' };
+    }
+
+    const body = (await resp.json().catch(() => ({}))) as { bundle_key?: string; size_bytes?: number; error?: unknown; message?: unknown };
+
+    if (resp.status === 409) {
+      return { success: true, bundleKey: body.bundle_key ?? expectedBundleKey, sizeBytes: body.size_bytes ?? Buffer.byteLength(bundleJson) };
+    }
+
+    if (!resp.ok) {
+      return { success: false, error: combineError(body) ?? `Sigstore bundle upload failed: HTTP ${resp.status}` };
+    }
+
+    if (!body.bundle_key) {
+      return { success: false, error: "Server response missing bundle_key field." };
+    }
+
+    if (body.bundle_key !== expectedBundleKey) {
+      return { success: false, error: `Sigstore bundle key mismatch: expected=${expectedBundleKey}, server=${body.bundle_key}` };
+    }
+
+    return { success: true, bundleKey: body.bundle_key, sizeBytes: body.size_bytes ?? Buffer.byteLength(bundleJson) };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return { success: false, error: "Sigstore bundle upload timed out (120s limit)." };
+    }
+    return { success: false, error: `Sigstore bundle upload failed: ${(err as Error).message}` };
+  }
 }
 
 /** Register a new version for an existing package */
@@ -329,6 +391,9 @@ export async function registerVersion(
     size_bytes: payload.size_bytes,
     manifest: toServerManifest(payload.manifest, payload.scope),
     readme: payload.readme,
+    ...(payload.signature_bundle_key !== undefined ? { signature_bundle_key: payload.signature_bundle_key } : {}),
+    ...(payload.signer_identity !== undefined ? { signer_identity: payload.signer_identity } : {}),
+    ...(payload.signed_at !== undefined ? { signed_at: payload.signed_at } : {}),
   };
   debugLog(`registerVersion payload: ${JSON.stringify(serverPayload)}`);
 

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, rm } from "fs/promises";
+import { mkdtemp, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { createTestEnv, createPackageDir, type TestEnv } from "../helpers/test-env.js";
@@ -105,10 +105,12 @@ describe("arc publish command", () => {
     const pkgDir = await createPackageDir(testDir, validManifest);
 
     let uploadCalled = false;
+    let bundleUploadCalled = false;
     let ensureCalled = false;
     let registerCalled = false;
+    let registerBody: any;
 
-    mockFetch(async (url: any) => {
+    mockFetch(async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
 
       if (urlStr.includes("/storage/upload")) {
@@ -119,8 +121,18 @@ describe("arc publish command", () => {
         );
       }
 
+      if (urlStr.includes("/storage/bundle/")) {
+        bundleUploadCalled = true;
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", bundle_key: "packages/any-sha.bundle", size_bytes: 321 }),
+          { status: 201 },
+        );
+      }
+
       if (urlStr.includes("/versions")) {
         registerCalled = true;
+        if (typeof init?.body !== "string") throw new Error("expected JSON string body");
+        registerBody = JSON.parse(init.body);
         return new Response(JSON.stringify({ version_id: "uuid-1" }), { status: 201 });
       }
 
@@ -132,13 +144,97 @@ describe("arc publish command", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const result = await publish({ paths: env.arc, packageDir: pkgDir });
+    const result = await publish({
+      paths: env.arc,
+      packageDir: pkgDir,
+      signer: async (_artifactPath, bundlePath) => {
+        await writeFile(bundlePath, JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle+json" }));
+        return {
+          success: true,
+          bundlePath,
+          signerIdentity: "https://github.com/the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main",
+          signedAt: 1_780_000_000,
+        };
+      },
+    });
     expect(result.success).toBe(true);
     expect(result.name).toBe("my-skill");
     expect(result.version).toBe("1.0.0");
     expect(uploadCalled).toBe(true);
+    expect(bundleUploadCalled).toBe(true);
     expect(ensureCalled).toBe(true);
     expect(registerCalled).toBe(true);
+    expect(registerBody.signature_bundle_key).toBe("packages/any-sha.bundle");
+    expect(registerBody.signer_identity).toContain("publish.yml");
+    expect(registerBody.signed_at).toBe(1_780_000_000);
+  });
+
+  test("official publish fails closed when signing is unavailable", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+      return new Response("Unexpected", { status: 500 });
+    });
+
+    const result = await publish({
+      paths: env.arc,
+      packageDir: pkgDir,
+      signer: async () => ({ success: false, error: "cosign binary unavailable" }),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Sigstore signing failed");
+  });
+
+  test("explicit unsigned official override keeps legacy payload unsigned", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+    let registerBody: any;
+
+    mockFetch(async (url: any, init?: RequestInit) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/versions")) {
+        if (typeof init?.body !== "string") throw new Error("expected JSON string body");
+        registerBody = JSON.parse(init.body);
+        return new Response(JSON.stringify({ version_id: "uuid-unsigned" }), { status: 201 });
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({
+      paths: env.arc,
+      packageDir: pkgDir,
+      allowUnsignedOfficial: true,
+      signer: async () => {
+        throw new Error("signer should not be called");
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(registerBody.signature_bundle_key).toBeUndefined();
+    expect(registerBody.signer_identity).toBeUndefined();
+    expect(registerBody.signed_at).toBeUndefined();
   });
 
   test("version exists error (409)", async () => {
@@ -169,7 +265,7 @@ describe("arc publish command", () => {
       return new Response("Not found", { status: 404 });
     });
 
-    const result = await publish({ paths: env.arc, packageDir: pkgDir });
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, allowUnsignedOfficial: true });
     expect(result.success).toBe(false);
     expect(result.error).toContain("immutable");
   });

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -3,6 +3,7 @@ import {
   detectPlatform,
   findCosignBinary,
   ensureCosignBinary,
+  resolveSignerIdentity,
   verifySigstoreBundle,
 } from "../../src/lib/cosign.js";
 
@@ -55,6 +56,21 @@ describe("ensureCosignBinary", () => {
       process.stderr.write = originalWrite;
     }
   }, 60_000);
+});
+
+describe("resolveSignerIdentity", () => {
+  test("uses explicit ARC_SIGSTORE_SIGNER_IDENTITY override", () => {
+    expect(resolveSignerIdentity({
+      ARC_SIGSTORE_SIGNER_IDENTITY: "https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main",
+      GITHUB_WORKFLOW_REF: "ignored/repo/.github/workflows/release.yml@refs/heads/main",
+    })).toBe("https://github.com/org/repo/.github/workflows/release.yml@refs/heads/main");
+  });
+
+  test("derives GitHub Actions identity from GITHUB_WORKFLOW_REF", () => {
+    expect(resolveSignerIdentity({
+      GITHUB_WORKFLOW_REF: "the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main",
+    })).toBe("https://github.com/the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main");
+  });
 });
 
 describe("verifySigstoreBundle", () => {

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -6,6 +6,7 @@ import {
   extractReadme,
   resolvePublishScope,
   uploadBundle,
+  uploadSigstoreBundle,
   ensurePackageExists,
   registerVersion,
   combineError,
@@ -177,6 +178,44 @@ describe("uploadBundle", () => {
   });
 });
 
+// ── uploadSigstoreBundle ────────────────────────────────────
+
+describe("uploadSigstoreBundle", () => {
+  test("successful upload returns bundle key", async () => {
+    const bundlePath = join(testDir, "test.bundle");
+    const sha = "a".repeat(64);
+    await writeFile(bundlePath, JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle+json" }));
+
+    mockFetch(async (url: any, init?: RequestInit) => {
+      expect(String(url)).toBe(`https://meta-factory.test/api/v1/storage/bundle/${sha}`);
+      expect(init?.method).toBe("PUT");
+      return new Response(
+        JSON.stringify({ sha256: sha, bundle_key: `packages/${sha}.bundle`, size_bytes: 123 }),
+        { status: 201 },
+      );
+    });
+
+    const result = await uploadSigstoreBundle(bundlePath, makeSource(), sha);
+    expect(result.success).toBe(true);
+    expect(result.bundleKey).toBe(`packages/${sha}.bundle`);
+  });
+
+  test("409 treated as idempotent success", async () => {
+    const bundlePath = join(testDir, "test.bundle");
+    const sha = "b".repeat(64);
+    await writeFile(bundlePath, "{}");
+
+    mockFetch(async () => new Response(
+      JSON.stringify({ error: "Conflict", message: "Bundle already exists" }),
+      { status: 409 },
+    ));
+
+    const result = await uploadSigstoreBundle(bundlePath, makeSource(), sha);
+    expect(result.success).toBe(true);
+    expect(result.bundleKey).toBe(`packages/${sha}.bundle`);
+  });
+});
+
 // ── ensurePackageExists ──────────────────────────────────────
 
 describe("ensurePackageExists", () => {
@@ -239,6 +278,50 @@ describe("registerVersion", () => {
     const result = await registerVersion(makeSource(), "ns", "pkg", payload);
     expect(result.success).toBe(true);
     expect(result.versionId).toBe("uuid-123");
+  });
+
+  test("includes Sigstore metadata in registration payload", async () => {
+    let requestBody: any;
+    mockFetch(async (_url: any, init?: RequestInit) => {
+      if (typeof init?.body !== "string") throw new Error("expected JSON string body");
+      requestBody = JSON.parse(init.body);
+      return new Response(
+        JSON.stringify({ version_id: "uuid-signed" }),
+        { status: 201 },
+      );
+    });
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", {
+      ...payload,
+      signature_bundle_key: "packages/abc123.bundle",
+      signer_identity: "https://github.com/the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main",
+      signed_at: 1_780_000_000,
+    });
+    expect(result.success).toBe(true);
+    expect(requestBody.signature_bundle_key).toBe("packages/abc123.bundle");
+    expect(requestBody.signer_identity).toContain("publish.yml");
+    expect(requestBody.signed_at).toBe(1_780_000_000);
+  });
+
+  test("preserves zero-valued signed_at in registration payload", async () => {
+    let requestBody: any;
+    mockFetch(async (_url: any, init?: RequestInit) => {
+      if (typeof init?.body !== "string") throw new Error("expected JSON string body");
+      requestBody = JSON.parse(init.body);
+      return new Response(
+        JSON.stringify({ version_id: "uuid-signed-zero" }),
+        { status: 201 },
+      );
+    });
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", {
+      ...payload,
+      signature_bundle_key: "packages/abc123.bundle",
+      signer_identity: "https://github.com/the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main",
+      signed_at: 0,
+    });
+    expect(result.success).toBe(true);
+    expect(requestBody.signed_at).toBe(0);
   });
 
   test("409 version exists", async () => {


### PR DESCRIPTION
## Summary
- sign official-source publish tarballs with cosign keyless signing
- upload Sigstore bundles to /api/v1/storage/bundle/:sha256 and register signing metadata
- fail closed unless --allow-unsigned-official is used for legacy rollout

Closes #191.

## Verification
- bunx tsc --noEmit
- bunx eslint --quiet src/lib/cosign.ts src/lib/publish.ts src/commands/publish.ts src/cli.ts test/unit/publish.test.ts test/commands/publish.test.ts test/unit/cosign.test.ts
- bun test: 962 pass, 3 skip, 0 fail