### PR TITLE
fix: fail fast for unsupported Sigstore publish auth

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -10,7 +10,7 @@ import {
   ensurePackageExists,
   registerVersion,
 } from "../lib/publish.js";
-import { signSigstoreBundle, type SignSigstoreResult } from "../lib/cosign.js";
+import { resolveSigningAuth, signSigstoreBundle, type SignSigstoreResult } from "../lib/cosign.js";
 import { loadSources, findMetafactorySource } from "../lib/sources.js";
 import { readManifest } from "../lib/manifest.js";
 import type { ArcPaths } from "../types.js";
@@ -104,6 +104,13 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
   let sigstoreBundlePath: string | undefined;
 
   try {
+    if (source.tier === "official" && !opts.allowUnsignedOfficial && !opts.signer) {
+      const signingAuth = resolveSigningAuth();
+      if (signingAuth.kind === "unsupported") {
+        return { success: false, error: `Sigstore signing failed: ${signingAuth.error}` };
+      }
+    }
+
     // 7. Upload tarball
     const uploadResult = await uploadBundle(tarballPath, source, sha256);
     if (!uploadResult.success) {

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -6,7 +6,8 @@
 
 import { join } from "path";
 import { existsSync } from "fs";
-import { writeFile, mkdir, chmod } from "fs/promises";
+import { writeFile, mkdir, chmod, rm } from "fs/promises";
+import { tmpdir } from "os";
 import { errorMessage } from "./errors.js";
 
 // ---------------------------------------------------------------------------
@@ -168,6 +169,42 @@ export function resolveSignerIdentity(env: Record<string, string | undefined> = 
   return undefined;
 }
 
+type SigningAuth =
+  | { kind: "github-actions"; signerIdentity?: string }
+  | { kind: "identity-token"; token: string; signerIdentity?: string }
+  | { kind: "identity-token-file"; tokenFile: string; signerIdentity?: string }
+  | { kind: "unsupported"; error: string };
+
+export function resolveSigningAuth(env: Record<string, string | undefined> = process.env): SigningAuth {
+  const signerIdentity = resolveSignerIdentity(env);
+  if (env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE) {
+    return { kind: "identity-token-file", tokenFile: env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE, signerIdentity };
+  }
+  if (env.ARC_SIGSTORE_IDENTITY_TOKEN) {
+    return { kind: "identity-token", token: env.ARC_SIGSTORE_IDENTITY_TOKEN, signerIdentity };
+  }
+
+  const hasGitHubActionsOidc =
+    env.GITHUB_ACTIONS === "true"
+    && Boolean(env.GITHUB_WORKFLOW_REF)
+    && Boolean(env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)
+    && Boolean(env.ACTIONS_ID_TOKEN_REQUEST_URL);
+
+  if (hasGitHubActionsOidc) {
+    return { kind: "github-actions", signerIdentity };
+  }
+
+  return {
+    kind: "unsupported",
+    error: [
+      "Sigstore signing requires GitHub Actions OIDC",
+      "(workflow permissions: id-token: write, contents: read)",
+      "or ARC_SIGSTORE_IDENTITY_TOKEN_FILE / ARC_SIGSTORE_IDENTITY_TOKEN.",
+      "Local cosign browser/device auth is disabled because phase 1 install verification trusts GitHub Actions OIDC.",
+    ].join(" "),
+  };
+}
+
 /**
  * Sign an artifact with keyless cosign and write the Sigstore bundle to disk.
  */
@@ -175,31 +212,58 @@ export async function signSigstoreBundle(
   artifactPath: string,
   bundlePath: string,
 ): Promise<SignSigstoreResult> {
+  const auth = resolveSigningAuth();
+  if (auth.kind === "unsupported") {
+    return { success: false, error: auth.error };
+  }
+
   const cosign = await ensureCosignBinary();
   if (!cosign.path) {
     return { success: false, error: cosign.error ?? "cosign binary unavailable" };
   }
 
   const signedAt = Math.floor(Date.now() / 1000);
-  const result = Bun.spawnSync(
-    [
+  let tempIdentityTokenPath: string | undefined;
+  const authArgs: string[] = [];
+
+  if (auth.kind === "github-actions") {
+    authArgs.push("--oidc-provider", "github-actions", "--fulcio-auth-flow", "token");
+  } else if (auth.kind === "identity-token-file") {
+    authArgs.push("--identity-token", auth.tokenFile);
+  } else {
+    tempIdentityTokenPath = join(tmpdir(), `arc-sigstore-token-${process.pid}-${Date.now()}.token`);
+    await writeFile(tempIdentityTokenPath, auth.token, { mode: 0o600 });
+    authArgs.push("--identity-token", tempIdentityTokenPath);
+  }
+
+  const args = [
       cosign.path,
       "sign-blob",
       "--bundle", bundlePath,
+      ...authArgs,
       "--yes",
       artifactPath,
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
+  ];
 
-  const stdout = result.stdout.toString().trim();
-  const stderr = result.stderr.toString().trim();
+  let result: ReturnType<typeof Bun.spawnSync>;
+  try {
+    result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });
+  } finally {
+    if (tempIdentityTokenPath) {
+      await rm(tempIdentityTokenPath, { force: true }).catch(() => {
+        // best-effort cleanup
+      });
+    }
+  }
+
+  const stdout = result.stdout?.toString().trim() ?? "";
+  const stderr = result.stderr?.toString().trim() ?? "";
 
   if (result.exitCode === 0) {
     return {
       success: true,
       bundlePath,
-      signerIdentity: resolveSignerIdentity(),
+      signerIdentity: auth.signerIdentity,
       signedAt,
       output: stdout || stderr,
     };

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -194,6 +194,53 @@ describe("arc publish command", () => {
     expect(result.error).toContain("Sigstore signing failed");
   });
 
+  test("official publish fails before uploading when ambient signing would be interactive", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+    let fetchCalled = false;
+    const saved = {
+      ARC_SIGSTORE_IDENTITY_TOKEN: process.env.ARC_SIGSTORE_IDENTITY_TOKEN,
+      ARC_SIGSTORE_IDENTITY_TOKEN_FILE: process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN,
+      ACTIONS_ID_TOKEN_REQUEST_URL: process.env.ACTIONS_ID_TOKEN_REQUEST_URL,
+      GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+      GITHUB_WORKFLOW_REF: process.env.GITHUB_WORKFLOW_REF,
+    };
+
+    mockFetch(async () => {
+      fetchCalled = true;
+      return new Response("Unexpected", { status: 500 });
+    });
+
+    try {
+      delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN;
+      delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_WORKFLOW_REF;
+
+      const result = await publish({ paths: env.arc, packageDir: pkgDir });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("GitHub Actions OIDC");
+      expect(fetchCalled).toBe(false);
+    } finally {
+      if (saved.ARC_SIGSTORE_IDENTITY_TOKEN === undefined) delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN;
+      else process.env.ARC_SIGSTORE_IDENTITY_TOKEN = saved.ARC_SIGSTORE_IDENTITY_TOKEN;
+      if (saved.ARC_SIGSTORE_IDENTITY_TOKEN_FILE === undefined) delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      else process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE = saved.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      if (saved.ACTIONS_ID_TOKEN_REQUEST_TOKEN === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      else process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = saved.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      if (saved.ACTIONS_ID_TOKEN_REQUEST_URL === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+      else process.env.ACTIONS_ID_TOKEN_REQUEST_URL = saved.ACTIONS_ID_TOKEN_REQUEST_URL;
+      if (saved.GITHUB_ACTIONS === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = saved.GITHUB_ACTIONS;
+      if (saved.GITHUB_WORKFLOW_REF === undefined) delete process.env.GITHUB_WORKFLOW_REF;
+      else process.env.GITHUB_WORKFLOW_REF = saved.GITHUB_WORKFLOW_REF;
+    }
+  });
+
   test("explicit unsigned official override keeps legacy payload unsigned", async () => {
     await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -4,6 +4,7 @@ import {
   findCosignBinary,
   ensureCosignBinary,
   resolveSignerIdentity,
+  signSigstoreBundle,
   verifySigstoreBundle,
 } from "../../src/lib/cosign.js";
 
@@ -70,6 +71,50 @@ describe("resolveSignerIdentity", () => {
     expect(resolveSignerIdentity({
       GITHUB_WORKFLOW_REF: "the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main",
     })).toBe("https://github.com/the-metafactory/arc/.github/workflows/publish.yml@refs/heads/main");
+  });
+});
+
+describe("signSigstoreBundle", () => {
+  test("fails fast outside supported non-interactive signing environments", async () => {
+    const saved = {
+      ARC_SIGSTORE_IDENTITY_TOKEN: process.env.ARC_SIGSTORE_IDENTITY_TOKEN,
+      ARC_SIGSTORE_IDENTITY_TOKEN_FILE: process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN,
+      ACTIONS_ID_TOKEN_REQUEST_URL: process.env.ACTIONS_ID_TOKEN_REQUEST_URL,
+      GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+      GITHUB_WORKFLOW_REF: process.env.GITHUB_WORKFLOW_REF,
+    };
+
+    try {
+      delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN;
+      delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+      delete process.env.GITHUB_ACTIONS;
+      delete process.env.GITHUB_WORKFLOW_REF;
+
+      const result = await signSigstoreBundle(
+        "/nonexistent/artifact.tar.gz",
+        "/nonexistent/artifact.bundle",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("GitHub Actions OIDC");
+      expect(result.error).toContain("id-token: write");
+    } finally {
+      if (saved.ARC_SIGSTORE_IDENTITY_TOKEN === undefined) delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN;
+      else process.env.ARC_SIGSTORE_IDENTITY_TOKEN = saved.ARC_SIGSTORE_IDENTITY_TOKEN;
+      if (saved.ARC_SIGSTORE_IDENTITY_TOKEN_FILE === undefined) delete process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      else process.env.ARC_SIGSTORE_IDENTITY_TOKEN_FILE = saved.ARC_SIGSTORE_IDENTITY_TOKEN_FILE;
+      if (saved.ACTIONS_ID_TOKEN_REQUEST_TOKEN === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      else process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = saved.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+      if (saved.ACTIONS_ID_TOKEN_REQUEST_URL === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+      else process.env.ACTIONS_ID_TOKEN_REQUEST_URL = saved.ACTIONS_ID_TOKEN_REQUEST_URL;
+      if (saved.GITHUB_ACTIONS === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = saved.GITHUB_ACTIONS;
+      if (saved.GITHUB_WORKFLOW_REF === undefined) delete process.env.GITHUB_WORKFLOW_REF;
+      else process.env.GITHUB_WORKFLOW_REF = saved.GITHUB_WORKFLOW_REF;
+    }
   });
 });
 


### PR DESCRIPTION
Closes #193.\n\nChanges:\n- Reject official Sigstore publishes before upload when the environment would fall back to local cosign device/browser auth.\n- Allow only GitHub Actions OIDC or explicit ARC_SIGSTORE_IDENTITY_TOKEN_FILE / ARC_SIGSTORE_IDENTITY_TOKEN for non-interactive signing.\n- Restrict cosign to the GitHub Actions OIDC provider in CI and keep token values out of process args by writing inline tokens to a temp file.\n\nValidation:\n- rtk bun test test/commands/publish.test.ts test/unit/cosign.test.ts\n- rtk bunx tsc --noEmit\n- rtk bun run lint\n- rtk bun test