### PR TITLE
fix: surface publish submission status

### DIFF
--- a/Plans/2026-06-03-arc-issues-196-183-184-sequential-plan.md
+++ b/Plans/2026-06-03-arc-issues-196-183-184-sequential-plan.md
@@ -1,0 +1,56 @@
+# Arc sequential fix plan: #196, #183, #184
+
+Date: 2026-06-03
+
+## Operating rules
+
+- Work issues in this exact order: #196, #183, #184.
+- Use a fresh branch from `origin/main` for each issue.
+- Keep scratch and body files inside this repo when needed; do not write temporary task artifacts under `/tmp`.
+- Use TDD: add a failing behavior test first, implement the smallest fix, then refactor if needed.
+- Verify each issue locally with focused tests, `rtk bunx tsc --noEmit`, `rtk bun run lint`, and `rtk bun test`.
+- Open a PR, wait for GitHub CI, run Sage review via `sage dispatch`, fix any blockers/majors, then merge.
+- Leave unrelated untracked files untouched.
+
+## Queue
+
+### 1. #196 - publish submission status
+
+Goal: `arc publish` must not report unconditional `Published` when MetaFactory returns a review submission status.
+
+Expected implementation:
+- Preserve `submission_id` and `submission.status` from version registration responses.
+- Surface pending review as uploaded/queued, including submission id.
+- Surface rejected submissions clearly, including review comment when present.
+- Keep approved/no-submission legacy responses as `Published`.
+
+Verification:
+- Unit tests for `registerVersion()` response parsing.
+- Command tests for formatted pending/rejected publish output.
+
+### 2. #183 - idempotent hook registration
+
+Goal: repeated install/upgrade must leave exactly one hook registration per package/event/matcher/command.
+
+Expected implementation:
+- Replace package-owned hook registrations rather than appending duplicates.
+- Reconcile old untagged duplicates matching the same event/matcher/command.
+- Preserve unrelated hook entries.
+
+Verification:
+- Install/upgrade hook tests showing repeated runs do not duplicate hooks.
+- Regression test for untagged duplicate cleanup.
+
+### 3. #184 - tarball upgrade and check
+
+Goal: registry/tarball installs upgrade without `git pull`, and `--check` reports available registry upgrades.
+
+Expected implementation:
+- Detect tarball-extracted installs and use registry download/replace path.
+- Keep git installs on the existing git path.
+- Ensure `--check` resolves scoped registry package versions correctly.
+
+Verification:
+- Tests for tarball upgrade from older installed version to newer registry version.
+- Tests for `arc upgrade <name> --check` reporting the available newer version.
+

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -33,6 +33,9 @@ export interface PublishCommandResult {
   scope?: string;
   sha256?: string;
   url?: string;
+  submissionId?: string;
+  submissionStatus?: string;
+  reviewComment?: string | null;
   dryRun?: boolean;
   error?: string;
 }
@@ -166,6 +169,23 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
       return { success: false, error: registerResult.error };
     }
 
+    if (registerResult.submission?.status === "rejected") {
+      const reviewSuffix = registerResult.submission.reviewComment
+        ? ` Review comment: ${registerResult.submission.reviewComment}`
+        : "";
+      return {
+        success: false,
+        name: manifest.name,
+        version: manifest.version,
+        scope,
+        sha256: uploadResult.sha256,
+        submissionId: registerResult.submissionId,
+        submissionStatus: registerResult.submission.status,
+        reviewComment: registerResult.submission.reviewComment,
+        error: `Publish submission rejected${registerResult.submissionId ? ` (${registerResult.submissionId})` : ""}.${reviewSuffix}`,
+      };
+    }
+
     return {
       success: true,
       name: manifest.name,
@@ -173,6 +193,9 @@ export async function publish(opts: PublishOptions): Promise<PublishCommandResul
       scope,
       sha256: uploadResult.sha256,
       url: `${source.url}/package/@${scope}/${manifest.name}`,
+      submissionId: registerResult.submissionId,
+      submissionStatus: registerResult.submission?.status,
+      reviewComment: registerResult.submission?.reviewComment,
     };
   } finally {
     // Clean up temp tarball
@@ -200,6 +223,16 @@ export function formatPublish(result: PublishCommandResult): string {
       `[DRY RUN] Would publish @${result.scope}/${result.name} v${result.version}`,
       `  SHA-256:  ${result.sha256}`,
       `  Source:   metafactory`,
+    ].join("\n");
+  }
+
+  if (result.submissionStatus === "pending_review") {
+    return [
+      `Uploaded @${result.scope}/${result.name} v${result.version}; queued for review`,
+      `  SHA-256:      ${result.sha256}`,
+      ...(result.submissionId ? [`  Submission:   ${result.submissionId}`] : []),
+      `  Status:       ${result.submissionStatus}`,
+      `  URL:          ${result.url}`,
     ].join("\n");
   }
 

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -407,8 +407,25 @@ export async function registerVersion(
       });
 
       if (resp.status === 201 || resp.status === 200) {
-        const body = (await resp.json()) as { version_id?: string };
-        return { success: true, versionId: body.version_id, statusCode: resp.status };
+        const body = (await resp.json()) as {
+          version_id?: string;
+          version?: { id?: string };
+          submission_id?: string;
+          submission?: { id?: string; status?: string; review_comment?: string | null };
+        };
+        return {
+          success: true,
+          versionId: body.version_id ?? body.version?.id,
+          submissionId: body.submission_id ?? body.submission?.id,
+          submission: body.submission
+            ? {
+              id: body.submission.id,
+              status: body.submission.status,
+              reviewComment: body.submission.review_comment ?? null,
+            }
+            : undefined,
+          statusCode: resp.status,
+        };
       }
 
       const body = (await resp.json().catch(() => ({}))) as { error?: unknown; message?: unknown };

--- a/src/types.ts
+++ b/src/types.ts
@@ -795,6 +795,12 @@ export interface UploadResult {
 export interface RegisterResult {
   success: boolean;
   versionId?: string;
+  submissionId?: string;
+  submission?: {
+    id?: string;
+    status?: string;
+    reviewComment?: string | null;
+  };
   error?: string;
   statusCode?: number;
 }

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -284,6 +284,94 @@ describe("arc publish command", () => {
     expect(registerBody.signed_at).toBeUndefined();
   });
 
+  test("reports queued review status instead of unconditional published", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/versions")) {
+        return new Response(
+          JSON.stringify({
+            version: { id: "version-queued" },
+            submission_id: "submission-queued",
+            submission: { id: "submission-queued", status: "pending_review" },
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, allowUnsignedOfficial: true });
+    const output = formatPublish(result);
+
+    expect(result.success).toBe(true);
+    expect(result.submissionStatus).toBe("pending_review");
+    expect(result.submissionId).toBe("submission-queued");
+    expect(output).toContain("queued for review");
+    expect(output).toContain("submission-queued");
+    expect(output).not.toContain("Published @testns/my-skill");
+  });
+
+  test("rejected publish submission fails with review comment", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.includes("/versions")) {
+        return new Response(
+          JSON.stringify({
+            version: { id: "version-rejected" },
+            submission_id: "submission-rejected",
+            submission: {
+              id: "submission-rejected",
+              status: "rejected",
+              review_comment: "Capability declaration is incomplete",
+            },
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, allowUnsignedOfficial: true });
+    const output = formatPublish(result);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("rejected");
+    expect(result.error).toContain("Capability declaration is incomplete");
+    expect(output).toContain("Error:");
+  });
+
   test("version exists error (409)", async () => {
     await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -280,6 +280,28 @@ describe("registerVersion", () => {
     expect(result.versionId).toBe("uuid-123");
   });
 
+  test("successful registration preserves submission review status", async () => {
+    mockFetch(async () => new Response(
+      JSON.stringify({
+        version: { id: "version-123" },
+        submission_id: "submission-123",
+        submission: {
+          id: "submission-123",
+          status: "pending_review",
+          review_comment: "Awaiting sponsor approval",
+        },
+      }),
+      { status: 201 },
+    ));
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(true);
+    expect(result.versionId).toBe("version-123");
+    expect(result.submissionId).toBe("submission-123");
+    expect(result.submission?.status).toBe("pending_review");
+    expect(result.submission?.reviewComment).toBe("Awaiting sponsor approval");
+  });
+
   test("includes Sigstore metadata in registration payload", async () => {
     let requestBody: any;
     mockFetch(async (_url: any, init?: RequestInit) => {


### PR DESCRIPTION
Closes #196.

Plan artifact:
- Adds `Plans/2026-06-03-arc-issues-196-183-184-sequential-plan.md` for the requested #196 -> #183 -> #184 queue.

Changes:
- Preserve `submission_id` and `submission.status` from MetaFactory version registration responses.
- Preserve `version.id` for the current server response shape when `version_id` is absent.
- Show pending review publishes as uploaded and queued for review instead of `Published`.
- Treat rejected publish submissions as failures and include the review comment.

Validation:
- `rtk bun test test/unit/publish.test.ts`
- `rtk bun test test/commands/publish.test.ts`
- `rtk bunx tsc --noEmit`
- `rtk bun run lint`
- `rtk bun test` (971 pass, 3 skip, 0 fail)
