### PR TITLE
fix: make hook registration idempotent

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -28,6 +28,25 @@ interface Settings {
   [key: string]: unknown;
 }
 
+function matcherKey(matcher: string | undefined): string {
+  return matcher ?? "";
+}
+
+function hookGroupHasCommand(entry: SettingsHookGroup, command: string): boolean {
+  return entry.hooks.some((hook) => hook.command === command);
+}
+
+function shouldReplaceHookGroup(
+  packageName: string,
+  hook: { command: string; matcher?: string },
+  entry: SettingsHookGroup,
+): boolean {
+  if (matcherKey(entry.matcher) !== matcherKey(hook.matcher)) return false;
+  if (!hookGroupHasCommand(entry, hook.command)) return false;
+
+  return entry._pai_pkg === packageName || entry._pai_pkg === undefined;
+}
+
 /**
  * Read settings.json, returning empty object if it doesn't exist.
  */
@@ -217,16 +236,9 @@ export async function registerHooks(
       settings.hooks[hook.event] = [];
     }
 
-    const eventArray = settings.hooks[hook.event];
-
-    // Check for duplicate: same package + same command
-    const existing = eventArray.find(
-      (entry) =>
-        entry._pai_pkg === packageName &&
-        entry.hooks.some((h) => h.command === hook.command),
+    settings.hooks[hook.event] = settings.hooks[hook.event].filter(
+      (entry) => !shouldReplaceHookGroup(packageName, hook, entry),
     );
-
-    if (existing) continue; // Already registered, skip
 
     const group: SettingsHookGroup = {
       _pai_pkg: packageName,
@@ -234,7 +246,7 @@ export async function registerHooks(
       hooks: [{ type: "command", command: hook.command }],
     };
 
-    eventArray.push(group);
+    settings.hooks[hook.event].push(group);
   }
 
   await writeSettings(settingsPath, settings);

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -119,6 +119,61 @@ describe("registerHooks", () => {
     expect(settings.hooks.PostToolUse).toBeArrayOfSize(1);
   });
 
+  test("reconciles legacy untagged duplicate hook registrations", async () => {
+    const command = "${PAI_DIR}/hooks/CortexBashGuard.hook.ts";
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command }],
+          },
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command }],
+          },
+          {
+            _pai_pkg: "Cortex",
+            matcher: "Bash",
+            hooks: [{ type: "command", command }],
+          },
+          {
+            matcher: "Read",
+            hooks: [{ type: "command", command }],
+          },
+          {
+            _pai_pkg: "OtherPkg",
+            matcher: "Bash",
+            hooks: [{ type: "command", command }],
+          },
+        ],
+      },
+    };
+    await Bun.write(settingsPath, JSON.stringify(existing, null, 4));
+
+    await registerHooks(
+      "Cortex",
+      [{ event: "PreToolUse", matcher: "Bash", command }],
+      settingsPath,
+    );
+
+    const settings = JSON.parse(await Bun.file(settingsPath).text());
+    const bashCommandGroups = settings.hooks.PreToolUse.filter(
+      (entry: { _pai_pkg?: string; matcher?: string; hooks: { command: string }[] }) =>
+        entry.matcher === "Bash" &&
+        entry.hooks.some((hook) => hook.command === command),
+    );
+
+    expect(bashCommandGroups).toBeArrayOfSize(2);
+    expect(bashCommandGroups[0]._pai_pkg).toBe("OtherPkg");
+    expect(bashCommandGroups[1]._pai_pkg).toBe("Cortex");
+    expect(settings.hooks.PreToolUse).toBeArrayOfSize(3);
+    expect(settings.hooks.PreToolUse).toContainEqual({
+      matcher: "Read",
+      hooks: [{ type: "command", command }],
+    });
+  });
+
   test("includes matcher field for PreToolUse hooks", async () => {
     await registerHooks(
       "Grove",


### PR DESCRIPTION
## Summary

- make hook registration replace existing matching registrations instead of append-skipping
- reconcile legacy untagged duplicate hook entries with the same matcher and command
- add regression coverage for the duplicate PreToolUse Bash hook shape from #183

Fixes #183.

## Verification

- `rtk bun test test/unit/hooks.test.ts`
- `rtk bun test test/commands/remove-hooks-137.test.ts`
- `rtk bun test test/commands/install.test.ts`
- `rtk bunx tsc --noEmit`
- `rtk bun run lint`
- `rtk bun test`
