### PR TITLE
fix: preserve publish submissions on registration conflict

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -226,9 +226,12 @@ export function formatPublish(result: PublishCommandResult): string {
     ].join("\n");
   }
 
-  if (result.submissionStatus === "pending_review") {
+  if (result.submissionStatus) {
+    const headline = result.submissionStatus === "pending_review"
+      ? `Uploaded @${result.scope}/${result.name} v${result.version}; queued for review`
+      : `Uploaded @${result.scope}/${result.name} v${result.version}; submission ${result.submissionStatus}`;
     return [
-      `Uploaded @${result.scope}/${result.name} v${result.version}; queued for review`,
+      headline,
       `  SHA-256:      ${result.sha256}`,
       ...(result.submissionId ? [`  Submission:   ${result.submissionId}`] : []),
       `  Status:       ${result.submissionStatus}`,

--- a/src/lib/publish.ts
+++ b/src/lib/publish.ts
@@ -47,6 +47,41 @@ function buildPublishHeaders(source: RegistrySource): Record<string, string> {
   return { Authorization: `Bearer ${source.token}` };
 }
 
+interface SubmissionWire {
+  id?: string;
+  status?: string;
+  review_comment?: string | null;
+}
+
+type SubmissionBody = {
+  submission_id?: string;
+  submission_status?: string;
+  review_comment?: string | null;
+  submission?: SubmissionWire;
+  // The existing-submission probe returns flat { id, status } instead of
+  // wrapping the payload under `submission`, so accept both wire shapes.
+} & SubmissionWire;
+
+const VISIBLE_SUBMISSION_STATUSES = new Set([
+  "submitted",
+  "validating",
+  "audit",
+  "pending_review",
+  "rejected",
+]);
+
+function normalizeSubmission(body: SubmissionBody): RegisterResult["submission"] | undefined {
+  const nested = body.submission;
+  const status = nested?.status ?? body.submission_status ?? body.status;
+  if (!status || !VISIBLE_SUBMISSION_STATUSES.has(status)) return undefined;
+
+  return {
+    id: nested?.id ?? body.submission_id ?? body.id,
+    status,
+    reviewComment: nested?.review_comment ?? body.review_comment ?? null,
+  };
+}
+
 /**
  * Prefer the informative top-level `message` field over the generic `error`
  * field. Falls back to `formatServerError` so nested/object `error` payloads
@@ -382,6 +417,7 @@ export async function registerVersion(
   payload: RegisterPayload,
 ): Promise<RegisterResult> {
   const url = `${source.url}/api/v1/packages/${encodeURIComponent(`@${scope}`)}/${encodeURIComponent(name)}/versions`;
+  const submissionUrl = `${url}/${encodeURIComponent(payload.version)}/submission`;
   const headers = { ...buildPublishHeaders(source), "Content-Type": "application/json" };
 
   const serverPayload = {
@@ -397,64 +433,80 @@ export async function registerVersion(
   };
   debugLog(`registerVersion payload: ${JSON.stringify(serverPayload)}`);
 
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const resp = await fetch(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(serverPayload),
-        signal: AbortSignal.timeout(API_TIMEOUT_MS),
-      });
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(serverPayload),
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
 
-      if (resp.status === 201 || resp.status === 200) {
-        const body = (await resp.json()) as {
-          version_id?: string;
-          version?: { id?: string };
-          submission_id?: string;
-          submission?: { id?: string; status?: string; review_comment?: string | null };
-        };
+    if (resp.status === 201 || resp.status === 200) {
+      const body = (await resp.json()) as {
+        version_id?: string;
+        version?: { id?: string };
+      } & SubmissionBody;
+      const submission = normalizeSubmission(body);
+      return {
+        success: true,
+        versionId: body.version_id ?? body.version?.id,
+        submissionId: body.submission_id ?? body.submission?.id,
+        submission,
+        statusCode: resp.status,
+      };
+    }
+
+    const body = (await resp.json().catch(() => ({}))) as { error?: unknown; message?: unknown } & SubmissionBody;
+    const serverError = combineError(body);
+    const inlineSubmission = normalizeSubmission(body);
+
+    if (inlineSubmission) {
+      return {
+        success: true,
+        submissionId: inlineSubmission.id,
+        submission: inlineSubmission,
+        statusCode: resp.status,
+      };
+    }
+
+    if (resp.status === 409) {
+      const existingSubmission = await fetch(submissionUrl, {
+        headers: buildPublishHeaders(source),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      })
+        .then(async (submissionResp) => {
+          if (!submissionResp.ok) return undefined;
+          const submissionBody = (await submissionResp.json().catch(() => ({}))) as SubmissionBody;
+          return normalizeSubmission(submissionBody);
+        })
+        .catch(() => undefined);
+
+      if (existingSubmission) {
         return {
           success: true,
-          versionId: body.version_id ?? body.version?.id,
-          submissionId: body.submission_id ?? body.submission?.id,
-          submission: body.submission
-            ? {
-              id: body.submission.id,
-              status: body.submission.status,
-              reviewComment: body.submission.review_comment ?? null,
-            }
-            : undefined,
-          statusCode: resp.status,
+          submissionId: existingSubmission.id,
+          submission: existingSubmission,
+          statusCode: 409,
         };
       }
 
-      const body = (await resp.json().catch(() => ({}))) as { error?: unknown; message?: unknown };
-      const serverError = combineError(body);
-
-      if (resp.status === 409) {
-        return { success: false, error: `Version ${payload.version} already exists. Published versions are immutable — bump the version in arc-manifest.yaml.`, statusCode: 409 };
-      }
-
-      if (resp.status === 400) {
-        return { success: false, error: serverError ?? "Manifest validation failed on server.", statusCode: 400 };
-      }
-
-      if (resp.status === 403) {
-        return { success: false, error: `Namespace @${scope} not owned. Complete identity verification at meta-factory.ai.`, statusCode: 403 };
-      }
-
-      if (resp.status === 401) {
-        return { success: false, error: 'Not authenticated. Run "arc login" first.', statusCode: 401 };
-      }
-
-      if (resp.status >= 500 && attempt === 0) continue;
-
-      return { success: false, error: serverError ?? `Registration failed: HTTP ${resp.status}`, statusCode: resp.status };
-    } catch (err) {
-      if (attempt === 0) continue;
-      return { success: false, error: `Network error during version registration: ${(err as Error).message}` };
+      return { success: false, error: `Version ${payload.version} already exists. Published versions are immutable — bump the version in arc-manifest.yaml.`, statusCode: 409 };
     }
-  }
 
-  return { success: false, error: "Registration failed after retries." };
+    if (resp.status === 400) {
+      return { success: false, error: serverError ?? "Manifest validation failed on server.", statusCode: 400 };
+    }
+
+    if (resp.status === 403) {
+      return { success: false, error: `Namespace @${scope} not owned. Complete identity verification at meta-factory.ai.`, statusCode: 403 };
+    }
+
+    if (resp.status === 401) {
+      return { success: false, error: 'Not authenticated. Run "arc login" first.', statusCode: 401 };
+    }
+
+    return { success: false, error: serverError ?? `Registration failed: HTTP ${resp.status}`, statusCode: resp.status };
+  } catch (err) {
+    return { success: false, error: `Network error during version registration: ${(err as Error).message}` };
+  }
 }

--- a/test/commands/publish.test.ts
+++ b/test/commands/publish.test.ts
@@ -327,6 +327,90 @@ describe("arc publish command", () => {
     expect(output).not.toContain("Published @testns/my-skill");
   });
 
+  test("409 with existing validating submission succeeds and formats status", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "any-sha", r2_key: "packages/any-sha.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.endsWith("/versions")) {
+        return new Response(
+          JSON.stringify({ error: "Version 1.0.0 already exists" }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.endsWith("/versions/1.0.0/submission")) {
+        return new Response(
+          JSON.stringify({ id: "submission-existing", status: "validating" }),
+          { status: 200 },
+        );
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, allowUnsignedOfficial: true });
+    const output = formatPublish(result);
+
+    expect(result.success).toBe(true);
+    expect(result.submissionStatus).toBe("validating");
+    expect(result.submissionId).toBe("submission-existing");
+    expect(output).toContain("Uploaded @testns/my-skill v1.0.0");
+    expect(output).toContain("submission validating");
+    expect(output).toContain("submission-existing");
+    expect(output).not.toContain("Published @testns/my-skill");
+  });
+
+  test("409 remains immutable conflict when no visible submission exists", async () => {
+    await saveSources(env.arc.sourcesPath, metafactorySource());
+    const pkgDir = await createPackageDir(testDir, validManifest);
+
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes("/storage/upload")) {
+        return new Response(
+          JSON.stringify({ sha256: "x", r2_key: "packages/x.tar.gz", size_bytes: 100 }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.endsWith("/versions")) {
+        return new Response(
+          JSON.stringify({ error: "Version 1.0.0 already exists" }),
+          { status: 409 },
+        );
+      }
+
+      if (urlStr.endsWith("/versions/1.0.0/submission")) {
+        return new Response("Not found", { status: 404 });
+      }
+
+      if (urlStr.includes("/packages/")) {
+        return new Response(JSON.stringify({ namespace: "testns", name: "my-skill" }), { status: 200 });
+      }
+
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await publish({ paths: env.arc, packageDir: pkgDir, allowUnsignedOfficial: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("immutable");
+  });
+
   test("rejected publish submission fails with review comment", async () => {
     await saveSources(env.arc.sourcesPath, metafactorySource());
     const pkgDir = await createPackageDir(testDir, validManifest);

--- a/test/unit/publish.test.ts
+++ b/test/unit/publish.test.ts
@@ -346,7 +346,7 @@ describe("registerVersion", () => {
     expect(requestBody.signed_at).toBe(0);
   });
 
-  test("409 version exists", async () => {
+  test("409 version exists when no visible submission exists", async () => {
     mockFetch(async () => new Response(
       JSON.stringify({ error: "Already exists" }),
       { status: 409 },
@@ -356,6 +356,63 @@ describe("registerVersion", () => {
     expect(result.success).toBe(false);
     expect(result.statusCode).toBe(409);
     expect(result.error).toContain("immutable");
+  });
+
+  test("409 with visible pending submission succeeds instead of immutable conflict", async () => {
+    mockFetch(async (url: any) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith("/versions")) {
+        return new Response(
+          JSON.stringify({ error: "Version 1.0.0 already exists" }),
+          { status: 409 },
+        );
+      }
+      if (urlStr.endsWith("/versions/1.0.0/submission")) {
+        return new Response(
+          JSON.stringify({
+            id: "submission-visible",
+            status: "validating",
+            review_comment: null,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("Not found", { status: 404 });
+    });
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(409);
+    expect(result.submissionId).toBe("submission-visible");
+    expect(result.submission?.status).toBe("validating");
+  });
+
+  test("502 with created submission is not retried into a misleading 409", async () => {
+    let callCount = 0;
+    mockFetch(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(
+          JSON.stringify({
+            error: "validation_pipeline_error",
+            submission_id: "submission-502",
+            submission_status: "audit",
+          }),
+          { status: 502 },
+        );
+      }
+      return new Response(
+        JSON.stringify({ error: "Version 1.0.0 already exists" }),
+        { status: 409 },
+      );
+    });
+
+    const result = await registerVersion(makeSource(), "ns", "pkg", payload);
+    expect(callCount).toBe(1);
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(502);
+    expect(result.submissionId).toBe("submission-502");
+    expect(result.submission?.status).toBe("audit");
   });
 
   test("400 validation failed", async () => {
@@ -369,19 +426,17 @@ describe("registerVersion", () => {
     expect(result.statusCode).toBe(400);
   });
 
-  test("retries on 500 error", async () => {
+  test("does not retry state-changing 500 registration errors", async () => {
     let callCount = 0;
     mockFetch(async () => {
       callCount++;
-      if (callCount === 1) {
-        return new Response("Internal error", { status: 500 });
-      }
-      return new Response(JSON.stringify({ version_id: "uuid-retry" }), { status: 201 });
+      return new Response(JSON.stringify({ error: "Internal error" }), { status: 500 });
     });
 
     const result = await registerVersion(makeSource(), "ns", "pkg", payload);
-    expect(result.success).toBe(true);
-    expect(callCount).toBe(2);
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(500);
+    expect(callCount).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- stop retrying the state-changing version registration POST after server failures
- treat visible in-flight/review submissions as successful publish handoffs instead of immutable duplicate failures
- probe `/versions/:version/submission` on 409 before reporting a true duplicate-version conflict
- format non-public submission states like `validating` and `audit` as uploaded submissions in CI output

Fixes #199.

## Verification

- `rtk bun test test/unit/publish.test.ts`
- `rtk bun test test/commands/publish.test.ts`
- `rtk bunx tsc --noEmit`
- `rtk bun run lint`
- `rtk bun test`
