### PR TITLE
fix: degrade identityless signed bundles to warn + ARC_SIGSTORE_EXPECTED_IDENTITY escape hatch

### DIFF
--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -27,7 +27,7 @@ export interface VersionSigstoreSigning {
 }
 
 export interface SigstoreVerifyResult {
-  /** true = verified; false = verified-and-rejected; null = not-applicable (unsigned). */
+  /** true = verified; false = verified-and-rejected; null = unverifiable (unsigned, or signed but registry served no identity). */
   verified: boolean | null;
   reason: string;
 }

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -93,10 +93,26 @@ export async function verifyPackageSigstore(
     return { verified: null, reason: "version is not sigstore-signed (legacy or unsigned publish)" };
   }
 
-  if (!signing.signer_identity) {
+  // soma#303: a bundle without a registry-served signer_identity is a
+  // registry DATA gap (the bundle exists; only the expected-identity record
+  // is missing), not evidence of tampering. Hard-failing here bricked every
+  // signed install when the registry never populated the field (the
+  // meta-factory#523 extraction bug). Two recovery paths:
+  //   1. ARC_SIGSTORE_EXPECTED_IDENTITY — operator supplies the identity;
+  //      full cosign verification runs against it.
+  //   2. Otherwise degrade to verified=null: callers treat it like the
+  //      unsigned case (prominent warning on official tier, and
+  //      --strict-signing still turns it into a refusal).
+  const operatorIdentity = process.env.ARC_SIGSTORE_EXPECTED_IDENTITY;
+  const expectedIdentity = signing.signer_identity ?? operatorIdentity ?? null;
+  const identitySource = signing.signer_identity ? "registry" : "operator-supplied";
+
+  if (!expectedIdentity) {
     return {
-      verified: false,
-      reason: "signer_identity missing — cannot verify Sigstore bundle without expected identity",
+      verified: null,
+      reason:
+        "bundle present but registry served no signer_identity — cannot verify; " +
+        "set ARC_SIGSTORE_EXPECTED_IDENTITY=<workflow identity> to verify against a known identity",
     };
   }
 
@@ -107,9 +123,12 @@ export async function verifyPackageSigstore(
   }
 
   try {
-    const result = await verifier(artifactPath, dl.path, signing.signer_identity, TRUSTED_OIDC_ISSUER);
+    const result = await verifier(artifactPath, dl.path, expectedIdentity, TRUSTED_OIDC_ISSUER);
     if (result.valid) {
-      return { verified: true, reason: `Sigstore bundle verified for ${signing.signer_identity}` };
+      return {
+        verified: true,
+        reason: `Sigstore bundle verified for ${expectedIdentity} (${identitySource} identity)`,
+      };
     }
     return { verified: false, reason: result.error ?? "cosign verification failed" };
   } finally {

--- a/test/unit/cosign-verify.test.ts
+++ b/test/unit/cosign-verify.test.ts
@@ -92,8 +92,14 @@ describe("verifyPackageSigstore", () => {
     expect(result.reason).toMatch(/not sigstore-signed/i);
   });
 
-  test("verified=false when signature_bundle_key present but signer_identity missing", async () => {
+  // soma#303: a signed bundle whose registry record lacks signer_identity is
+  // a registry DATA gap, not a tampered artifact. Hard-failing bricked every
+  // signed install when the registry never populated the field. Degrade to
+  // verified=null (warn path; --strict-signing still refuses on official
+  // tier) and offer ARC_SIGSTORE_EXPECTED_IDENTITY to verify anyway.
+  test("verified=null (degraded) when signature_bundle_key present but signer_identity missing", async () => {
     env = await createTestEnv();
+    delete process.env.ARC_SIGSTORE_EXPECTED_IDENTITY;
     const result = await verifyPackageSigstore({
       source: source(),
       sha256: "abc",
@@ -101,8 +107,56 @@ describe("verifyPackageSigstore", () => {
       artifactPath: "/tmp/fake.tgz",
       tempDir: env.arc.reposDir,
     });
-    expect(result.verified).toBe(false);
+    expect(result.verified).toBeNull();
     expect(result.reason).toMatch(/signer_identity/i);
+    expect(result.reason).toMatch(/ARC_SIGSTORE_EXPECTED_IDENTITY/);
+  });
+
+  test("ARC_SIGSTORE_EXPECTED_IDENTITY enables full verification when registry omits identity", async () => {
+    env = await createTestEnv();
+    const expected =
+      "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main";
+    process.env.ARC_SIGSTORE_EXPECTED_IDENTITY = expected;
+    try {
+      globalThis.fetch = mockFetch(async () => new Response("{}", { status: 200 }));
+      let seenIdentity: string | undefined;
+      const result = await verifyPackageSigstore({
+        source: source(),
+        sha256: "abc",
+        signing: { signature_bundle_key: "packages/abc.bundle", signer_identity: null },
+        artifactPath: "/tmp/fake.tgz",
+        tempDir: env.arc.reposDir,
+        verifier: async (_artifact, _bundle, identity) => {
+          seenIdentity = identity;
+          return { valid: true };
+        },
+      });
+      expect(seenIdentity).toBe(expected);
+      expect(result.verified).toBe(true);
+      expect(result.reason).toMatch(/operator-supplied/i);
+    } finally {
+      delete process.env.ARC_SIGSTORE_EXPECTED_IDENTITY;
+    }
+  });
+
+  test("ARC_SIGSTORE_EXPECTED_IDENTITY mismatch still fails verification", async () => {
+    env = await createTestEnv();
+    process.env.ARC_SIGSTORE_EXPECTED_IDENTITY =
+      "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main";
+    try {
+      globalThis.fetch = mockFetch(async () => new Response("{}", { status: 200 }));
+      const result = await verifyPackageSigstore({
+        source: source(),
+        sha256: "abc",
+        signing: { signature_bundle_key: "packages/abc.bundle", signer_identity: null },
+        artifactPath: "/tmp/fake.tgz",
+        tempDir: env.arc.reposDir,
+        verifier: async () => ({ valid: false, error: "no matching signatures" }),
+      });
+      expect(result.verified).toBe(false);
+    } finally {
+      delete process.env.ARC_SIGSTORE_EXPECTED_IDENTITY;
+    }
   });
 
   test("verified=false when bundle download fails", async () => {


### PR DESCRIPTION
## Context

the-metafactory/soma#303: arc 0.30.1 hard-failed `signer_identity missing — cannot verify Sigstore bundle without expected identity` for **every** signed release, because the registry never populated `signer_identity` (root cause: meta-factory#523, now fixed + backfilled). There was no client-side recovery path — a user who `arc remove`'d first was stranded.

## Change

In `verifyPackageSigstore` when `signature_bundle_key` is present but `signer_identity` is null:

1. **`ARC_SIGSTORE_EXPECTED_IDENTITY` set** → full cosign verification against the operator-supplied identity (verified true/false as normal)
2. **Otherwise** → `verified: null` (degraded) with the escape hatch named in the reason

`verified: null` is the existing warn path: the install command already prints the prominent official-tier warning and `--strict-signing` already turns it into a refusal — so strict installs keep their guarantee while default installs degrade gracefully instead of bricking.

Success reason now names the identity source (`registry` vs `operator-supplied`).

## Tests

- Degraded null + escape hatch named in reason
- Env override → verifier receives operator identity, verified=true
- Env override + cosign mismatch → still verified=false
- Full suite 983 pass / 0 fail, tsc clean

Fixes the-metafactory/soma#303

🤖 Generated with [Claude Code](https://claude.com/claude-code)