### PR TITLE
fix(#207): attach source token to Sigstore bundle download

### DIFF
--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -7,7 +7,8 @@
  * binary wrapper) along with the expected signer identity and OIDC issuer.
  *
  * Scope (OQ-14): GitHub Actions OIDC only — other issuers are out of scope
- * for phase 1. Anonymous bundle fetch (DD-80): no Authorization header.
+ * for phase 1. Bundle fetch carries the source's bearer token when present
+ * (#207 — the registry route is requireAuth()'d like the tarball download).
  */
 
 import { writeFile, unlink } from "fs/promises";

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -44,18 +44,36 @@ export type SigstoreVerifier = (
 // ---------------------------------------------------------------------------
 
 /**
- * Download a Sigstore bundle to a temp file. Anonymous (no Authorization
- * header) per DD-80 — bundles are public, the registry route is unauth'd.
+ * Download a Sigstore bundle to a temp file.
+ *
+ * arc#207: the registry's `GET /storage/bundle/:sha256` is `requireAuth()`'d
+ * ("same access level as tarball download" — meta-factory routes/storage.ts),
+ * so a metafactory source's bearer token is attached exactly like
+ * `downloadPackage` does for the tarball. The old anonymous-per-DD-80
+ * behavior 401'd every signed install once the identity gap (#303) was
+ * fixed and this download became reachable. Sources without a token stay
+ * anonymous so public installs keep working if the route ever opens up.
+ *
  * Never throws; returns `{error}` on any failure.
  */
 export async function downloadSigstoreBundle(
   url: string,
   tempDir: string,
+  source?: RegistrySource,
 ): Promise<{ path?: string; error?: string }> {
   try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (source?.token) {
+      headers.Authorization = `Bearer ${source.token}`;
+    }
     const resp = await fetch(url, {
-      headers: { Accept: "application/json" },
+      headers,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // The bundle route serves same-origin from the registry worker; no
+      // redirect to third-party storage exists today. `manual` fail-closes
+      // if that ever changes, instead of silently forwarding the bearer
+      // cross-origin (same concern downloadPackage handles for tarballs).
+      redirect: "manual",
     });
     if (!resp.ok) {
       return { error: `bundle not found or unreachable (HTTP ${resp.status})` };
@@ -117,7 +135,7 @@ export async function verifyPackageSigstore(
   }
 
   const bundleUrl = `${source.url}/api/v1/storage/bundle/${sha256}`;
-  const dl = await downloadSigstoreBundle(bundleUrl, tempDir);
+  const dl = await downloadSigstoreBundle(bundleUrl, tempDir, source);
   if (!dl.path) {
     return { verified: false, reason: `bundle ${dl.error ?? "download failed"}` };
   }

--- a/test/unit/cosign-verify.test.ts
+++ b/test/unit/cosign-verify.test.ts
@@ -62,7 +62,25 @@ describe("downloadSigstoreBundle", () => {
     expect(result.path).toBeUndefined();
   });
 
-  test("does not send Authorization header (anonymous per DD-80)", async () => {
+  // arc#207: the registry's GET /storage/bundle/:sha256 is requireAuth()'d
+  // ("same access level as tarball download") — the old anonymous-per-DD-80
+  // behavior 401'd every signed install once the identity gap (#303) was
+  // fixed and the download line became reachable.
+  test("sends Authorization when the metafactory source has a token (#207)", async () => {
+    env = await createTestEnv();
+    let authSeen: string | null | undefined;
+    globalThis.fetch = mockFetch(async (_input: any, init?: any) => {
+      authSeen = new Headers(init?.headers).get("Authorization");
+      return new Response("{}", { status: 200 });
+    });
+    await downloadSigstoreBundle("https://reg.test/bundle", env.arc.reposDir, {
+      ...source(),
+      token: "test-token",
+    });
+    expect(authSeen).toBe("Bearer test-token");
+  });
+
+  test("stays anonymous when no source is provided", async () => {
     env = await createTestEnv();
     let authSeen: string | null | undefined;
     globalThis.fetch = mockFetch(async (_input: any, init?: any) => {


### PR DESCRIPTION
## Symptom

First fully-verifiable signed install (soma 0.8.5, post meta-factory#523 + arc#205):

```
SHA-256 verified
Registry signature verified (verified with mf-reg-2026-04)
Sigstore verification failed: bundle bundle not found or unreachable (HTTP 401)
```

## Root cause

Registry `GET /storage/bundle/:sha256` = `requireAuth()` ('same access level as tarball download'). arc fetched it anonymously per a stale DD-80 comment. Dead code path until the #303 identity hard-fail was removed — nobody had ever reached the bundle fetch with real data.

## Fix

- `downloadSigstoreBundle(url, tempDir, source?)`: `Authorization: Bearer` when the source carries a token (same contract as `downloadPackage`); anonymous otherwise
- `redirect: 'manual'` so a future cross-origin redirect fail-closes instead of forwarding the bearer (mirrors `downloadPackage`'s stripping concern — the bundle route is same-origin today, no redirect handling needed)
- orchestrator passes its existing `source` through

## Tests

Token-attached + anonymous cases; old anonymous-enforcement test replaced with rationale. Suite 988/988, tsc clean.

## Verification after merge

`arc install @metafactory/soma` → Sigstore bundle verified for the GH-Actions identity → install completes. Will post output on #207.

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)