### PR TITLE
fix(upgrade): #203 — regenerate templates for governance-overlay packages (not just type:rules)

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -304,9 +304,13 @@ export async function upgradePackage(
   const newVersion = manifest.version;
 
   if (compareSemver(oldVersion, newVersion) >= 0 && !opts?.force) {
-    // Version matches — but for rules packages, still regenerate templates
-    // (template content may have changed even if version was already bumped)
-    if (manifest.type === "rules" && manifest.provides?.templates?.length) {
+    // Version matches — but if this package provides templates, still
+    // regenerate them (template content may have changed even if the version
+    // was already bumped). Keyed off `provides.templates`, NOT `type`: any
+    // package that declares templates (e.g. type:rules OR
+    // type:governance-overlay like compass) regenerates them in its consumers
+    // (arc#203).
+    if (manifest.provides?.templates?.length) {
       const consumerDirs = findConsumerRepos(manifest.provides.templates);
       for (const dir of consumerDirs) {
         await generateRules(installPath, manifest.provides.templates, dir);
@@ -364,9 +368,12 @@ export async function upgradePackage(
     await registerHooks(name, resolvedHooks, settingsPath);
   }
 
-  // Re-generate rules templates if this is a rules package
-  // Scan all repos with matching config files, not just cwd
-  if (manifest.type === "rules" && manifest.provides?.templates?.length) {
+  // Re-generate templates for any package that provides them.
+  // Scan all repos with matching config files, not just cwd. Keyed off
+  // `provides.templates`, NOT `type`: type:rules AND type:governance-overlay
+  // (compass) both regenerate the templates they declare into consumers
+  // (arc#203).
+  if (manifest.provides?.templates?.length) {
     const consumerDirs = findConsumerRepos(manifest.provides.templates);
     for (const dir of consumerDirs) {
       await generateRules(installPath, manifest.provides.templates, dir);

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -10,8 +10,8 @@ import {
   formatUpgradeResults,
 } from "../../src/commands/upgrade.js";
 import { saveSources } from "../../src/lib/sources.js";
-import { writeFile, mkdir } from "fs/promises";
-import { existsSync } from "fs";
+import { writeFile, mkdir, rm } from "fs/promises";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import YAML from "yaml";
 import type { RegistryConfig, SourcesConfig } from "../../src/types.js";
@@ -517,6 +517,184 @@ describe("arc#184 — extracted-tarball upgrade and check", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// arc#203 — template regen is keyed off provides.templates, NOT type:rules.
+// A governance-overlay package (compass) that declares provides.templates must
+// regenerate its consumers' CLAUDE.md on upgrade, exactly like a type:rules
+// package would.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build + git-commit a package repo that declares `provides.templates` under
+ * the given `type`. Ships a CLAUDE.md.template under templates/ + a
+ * capabilities block, mirroring compass.
+ */
+async function createMockTemplateRepo(
+  root: string,
+  opts: { name: string; version: string; type: string; templateBody: string },
+): Promise<{ path: string; url: string }> {
+  const repoDir = join(root, `mock-${opts.name}`);
+  await mkdir(join(repoDir, "templates"), { recursive: true });
+  await writeFile(join(repoDir, "templates", "CLAUDE.md.template"), opts.templateBody);
+
+  const manifest = {
+    name: opts.name,
+    version: opts.version,
+    type: opts.type,
+    tier: "custom",
+    author: { name: "tester", github: "tester" },
+    provides: {
+      templates: [
+        { source: "templates/CLAUDE.md.template", target: "CLAUDE.md", config: "agents-md.yaml" },
+      ],
+    },
+    depends_on: { tools: [{ name: "bun", version: ">=1.0.0" }] },
+    capabilities: {
+      filesystem: { read: [], write: [] },
+      network: [],
+      bash: { allowed: false },
+      secrets: [],
+    },
+  };
+  await writeFile(join(repoDir, "arc-manifest.yaml"), YAML.stringify(manifest));
+
+  Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "Initial commit"],
+    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+  );
+  return { path: repoDir, url: repoDir };
+}
+
+/**
+ * Flip the on-disk manifest `type` to `governance-overlay` and commit, mirroring
+ * the LIVE compass scenario: compass was installed while it was `type: rules`
+ * (the DB still records artifact_type:rules), then its manifest later changed to
+ * `type: governance-overlay`. upgradePackage re-reads the manifest from disk, so
+ * the regen guard sees `governance-overlay`. This is the exact condition arc#203
+ * fixes — the installer's own type dispatch (which doesn't yet accept
+ * governance-overlay) is a separate concern outside this regen path.
+ */
+function flipManifestTypeToGovernanceOverlay(repoPath: string): void {
+  const manifestPath = join(repoPath, "arc-manifest.yaml");
+  const raw = readFileSync(manifestPath, "utf-8");
+  const parsed = YAML.parse(raw);
+  parsed.type = "governance-overlay";
+  writeFileSync(manifestPath, YAML.stringify(parsed));
+  Bun.spawnSync(["git", "add", "."], { cwd: repoPath, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "flip to governance-overlay"],
+    { cwd: repoPath, stdout: "pipe", stderr: "pipe" },
+  );
+}
+
+/**
+ * Run `fn` with findConsumerRepos pinned to a sandbox so it can NEVER touch a
+ * real repo. findConsumerRepos resolves consumers from two sources: the
+ * BLUEPRINT_DEV_ROOT scan AND an always-on `process.cwd()` inclusion. A test
+ * that ignored either would regenerate the running repo's own CLAUDE.md (the
+ * worktree carries agents-md.yaml) — destructive and a cross-test race. So we
+ * pin BOTH: dev-root scan → `devRoot`, cwd → `consumerDir`. Both globals are
+ * restored in finally even if `fn` throws.
+ */
+async function withConsumerSandbox<T>(
+  devRoot: string,
+  consumerDir: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prevDevRoot = process.env.BLUEPRINT_DEV_ROOT;
+  const prevCwd = process.cwd();
+  process.env.BLUEPRINT_DEV_ROOT = devRoot;
+  process.chdir(consumerDir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prevCwd);
+    if (prevDevRoot === undefined) delete process.env.BLUEPRINT_DEV_ROOT;
+    else process.env.BLUEPRINT_DEV_ROOT = prevDevRoot;
+  }
+}
+
+describe("upgradePackage — template regen for governance-overlay (arc#203)", () => {
+  test("a governance-overlay package with provides.templates regenerates a consumer's CLAUDE.md on force-upgrade", async () => {
+    // A consumer repo (sibling under the dev root) that opts into the template
+    // via agents-md.yaml. withConsumerSandbox pins findConsumerRepos to this dir.
+    const devRoot = join(env.root, "dev-root");
+    const consumerDir = join(devRoot, "consumer-repo");
+    await mkdir(consumerDir, { recursive: true });
+    await writeFile(
+      join(consumerDir, "agents-md.yaml"),
+      YAML.stringify({ project_name: "Consumer" }),
+    );
+
+    // Install while the package is type:rules (compass's original DB state),
+    // then flip the live manifest to type:governance-overlay before upgrade —
+    // reproducing the exact live drift behind arc#203.
+    const repo = await createMockTemplateRepo(env.root, {
+      name: "OverlayPkg",
+      version: "1.0.0",
+      type: "rules",
+      templateBody: "# {PROJECT_NAME}\n\nSENTINEL-ROW: a freshly-added SOP line.\n",
+    });
+    // Pass consumerDir so the install-time rules render targets the sandbox
+    // consumer (default would be process.cwd() = the running repo).
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true, consumerDir });
+    flipManifestTypeToGovernanceOverlay(repo.path);
+
+    // Prove the upgrade — not the install — is what regenerates: clear the
+    // install-time render, then assert the upgrade rebuilds it.
+    await rm(join(consumerDir, "CLAUDE.md"), { force: true });
+    expect(existsSync(join(consumerDir, "CLAUDE.md"))).toBe(false);
+
+    await withConsumerSandbox(devRoot, consumerDir, async () => {
+      // force-upgrade re-runs the pipeline; the regen must fire despite the
+      // package being governance-overlay (not type:rules) — this is the arc#203 fix.
+      const result = await upgradePackage(env.db, env.arc, env.host, "OverlayPkg", { force: true });
+      expect(result.success).toBe(true);
+    });
+
+    // The consumer's CLAUDE.md was generated from the overlay's template.
+    const generated = join(consumerDir, "CLAUDE.md");
+    expect(existsSync(generated)).toBe(true);
+    const body = await Bun.file(generated).text();
+    expect(body).toContain("SENTINEL-ROW: a freshly-added SOP line.");
+    expect(body).toContain("# Consumer"); // placeholder substitution ran
+  });
+
+  test("same-version (non-force) upgrade still regenerates templates for a governance-overlay package", async () => {
+    const devRoot = join(env.root, "dev-root-2");
+    const consumerDir = join(devRoot, "consumer-repo");
+    await mkdir(consumerDir, { recursive: true });
+    await writeFile(
+      join(consumerDir, "agents-md.yaml"),
+      YAML.stringify({ project_name: "Consumer2" }),
+    );
+
+    const repo = await createMockTemplateRepo(env.root, {
+      name: "OverlayPkg2",
+      version: "1.0.0",
+      type: "rules",
+      templateBody: "# {PROJECT_NAME}\n\nSAME-VERSION-ROW: regen on matching version.\n",
+    });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: repo.url, yes: true, consumerDir });
+    flipManifestTypeToGovernanceOverlay(repo.path);
+    await rm(join(consumerDir, "CLAUDE.md"), { force: true });
+
+    await withConsumerSandbox(devRoot, consumerDir, async () => {
+      // No force, no newer version: hits the same-version short-circuit branch
+      // (upgrade.ts ~L309), which must now regenerate for governance-overlay too.
+      const result = await upgradePackage(env.db, env.arc, env.host, "OverlayPkg2");
+      expect(result.success).toBe(true);
+    });
+
+    const generated = join(consumerDir, "CLAUDE.md");
+    expect(existsSync(generated)).toBe(true);
+    const body = await Bun.file(generated).text();
+    expect(body).toContain("SAME-VERSION-ROW: regen on matching version.");
   });
 });
 


### PR DESCRIPTION
Closes #203

## Problem

`arc upgrade compass` (even `--force`) never regenerated downstream `CLAUDE.md` files. A template/SOP change merged into compass did not reach any consumer repo.

## Root cause

`src/commands/upgrade.ts` gated the rules-template regen on `manifest.type === "rules"` at **two** sites:

- same-version short-circuit path (`~L309`)
- full-upgrade path (`~L369`)

compass is **`type: governance-overlay`** and DOES declare `provides.templates`. Both branches skipped it, so the template it provides was never rendered into consumers. Confirmed live via the DB: compass was installed as `artifact_type: rules` back in April, the manifest later changed to `governance-overlay`, and `upgradePackage` re-reads the on-disk manifest — so the live guard sees `governance-overlay` and skips.

## Fix

Re-key both guards off `provides.templates` alone (drop the `type === "rules"` requirement):

```diff
-  if (manifest.type === "rules" && manifest.provides?.templates?.length) {
+  if (manifest.provides?.templates?.length) {
```

"Declares templates ⇒ regenerates them in consumers" is the real signal. `findConsumerRepos` and `generateRules` are already type-agnostic (they key off `provides.templates` + `config`), so behavior for `type: rules` packages is unchanged — they already declare templates. The component/library install branches are untouched (separate concern).

## Tests

Two regression tests in `test/commands/upgrade.test.ts` reproduce the exact live compass drift: install while `type: rules` (compass's original DB state), flip the on-disk manifest to `type: governance-overlay`, then upgrade. Both the **force-upgrade** path and the **same-version short-circuit** path now regenerate a sandboxed consumer's `CLAUDE.md`. Both tests fail on the old guard and pass on the new one. Consumer resolution is pinned to a temp sandbox (`consumerDir` passed to install + `BLUEPRINT_DEV_ROOT`/cwd pinned for upgrade) so the suite never touches the running repo's own `CLAUDE.md`.

## Verification

- `bunx tsc --noEmit` → 0 errors
- `bun run lint` (eslint) → clean
- `bun test` → 987 pass, 0 fail (full suite, 5x stress; CLAUDE.md untouched every run)
- New tests confirmed to fail on the unfixed guard

## Follow-up (out of scope)

After this merges + arc is reinstalled, `arc upgrade compass --force` will regen `CLAUDE.md` across consumer repos (including the new Federation Wire Protocol SOP entry). Note the installer's own type dispatch (`createArtifactSymlinks`) does not yet accept `governance-overlay` for fresh installs — existing installs predate the type change and carry `artifact_type: rules` in the DB; this PR only fixes the regen path. The incidental pre-existing CLAUDE.md drift across 6 repos (noted in #203) is a separate sweep-and-commit task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)