### PR TITLE
fix: improve install shim path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Requires [Bun](https://bun.sh/) (v1.0+) and Git. Optional: [GitHub CLI](https://
 
 ```bash
 arc install <name-or-url>     # Install from registry or git URL
+arc install <name> --bin-dir <path> # Override where command shims are installed
 arc list                      # List installed packages
 arc info <name>               # Show details, capabilities, and release notes
 arc audit                     # Audit capability surface (summary + cross-tier warnings)
@@ -103,6 +104,14 @@ arc source list               # Show configured registry sources
 arc source add <n> <url>      # Add a source (--tier official|community|custom)
 arc source update             # Refresh indexes from all sources (like apt update)
 arc source remove <name>      # Remove a source
+```
+
+### Local Configuration
+
+```bash
+arc config get bin-dir        # Show where command shims are installed
+arc config set bin-dir ~/.local/bin
+arc doctor path               # Check whether the shim directory is on PATH
 ```
 
 ### Catalog

--- a/docs/agents-md/cli-reference.md
+++ b/docs/agents-md/cli-reference.md
@@ -4,6 +4,7 @@
 
 ```bash
 arc install <name-or-url>     # Install from registry or direct git URL
+arc install <name> --bin-dir <path> # Override where command shims are installed
 arc list                      # List installed packages
 arc list --json               # Output as JSON
 arc list --type <type>        # Filter by artifact type (skill, tool, agent, prompt, component, pipeline)
@@ -44,6 +45,14 @@ arc source list               # Show configured registry sources
 arc source add <name> <url>   # Add a source (--tier official|community|custom)
 arc source update             # Refresh indexes from all sources (like apt update)
 arc source remove <name>      # Remove a source
+```
+
+### Local Configuration
+
+```bash
+arc config get bin-dir        # Show where command shims are installed
+arc config set bin-dir ~/.local/bin
+arc doctor path               # Check whether the shim directory is on PATH
 ```
 
 ### Catalog

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { Command } from "commander";
 import { createArcPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
 import { openDatabase, getSkill } from "./lib/db.js";
-import { SymlinkConflictError } from "./lib/symlinks.js";
+import { extractAllCliInfo, SymlinkConflictError } from "./lib/symlinks.js";
 import { install, parseNameVersion } from "./commands/install.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
 import { info, formatInfo, formatInfoJson } from "./commands/info.js";
@@ -35,7 +35,7 @@ import {
   formatCatalogList,
   formatCatalogSearch,
 } from "./commands/catalog.js";
-import type { CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
+import type { ArcManifest, CatalogEntry, ArtifactType, PackageTier, RegistrySource, SourceType } from "./types.js";
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
 import { addBot, reissueBot, listBots, removeBot, setupOperator } from "./commands/nats.js";
@@ -92,6 +92,7 @@ import {
   formatSourceList,
   validateSource,
 } from "./lib/sources.js";
+import { loadUserConfig, normalizeUserPath, saveUserConfig } from "./lib/config.js";
 import {
   findInAllSources,
   updateAllSources,
@@ -104,6 +105,54 @@ import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
 
+function createInstallPaths(opts: { binDir?: string }): ReturnType<typeof createArcPaths> {
+  return createArcPaths(
+    opts.binDir
+      ? { shimDir: normalizeUserPath(opts.binDir) }
+      : undefined,
+  );
+}
+
+function shimDirIsOnPath(shimDir: string, pathEnv = process.env.PATH ?? ""): boolean {
+  const entries = pathEnv.split(":").filter(Boolean).map((entry) => normalizeUserPath(entry));
+  return entries.includes(normalizeUserPath(shimDir));
+}
+
+function quoteForSingleQuotedShell(value: string): string {
+  return value.replace(/'/g, "'\\''");
+}
+
+function formatPathRepairCommand(shimDir: string, shell = process.env.SHELL ?? ""): string {
+  if (shell.endsWith("/fish")) {
+    return `fish_add_path ${shimDir}`;
+  }
+
+  const exportLine = `export PATH="${shimDir}:$PATH"`;
+  if (shell.endsWith("/bash")) {
+    return `echo '${quoteForSingleQuotedShell(exportLine)}' >> ~/.bashrc`;
+  }
+  if (shell.endsWith("/zsh") || shell === "") {
+    return `echo '${quoteForSingleQuotedShell(exportLine)}' >> ~/.zshrc`;
+  }
+  return exportLine;
+}
+
+function installResultProvidesCli(result: Awaited<ReturnType<typeof install>>): boolean {
+  const manifests = [
+    result.manifest,
+    ...(result.artifacts?.map((artifact) => artifact.manifest) ?? []),
+  ].filter((manifest): manifest is ArcManifest => Boolean(manifest));
+
+  return manifests.some((manifest) => extractAllCliInfo(manifest).length > 0);
+}
+
+function printShimPathNotice(paths: ReturnType<typeof createArcPaths>, result: Awaited<ReturnType<typeof install>>): void {
+  if (!installResultProvidesCli(result) || shimDirIsOnPath(paths.shimDir)) return;
+
+  console.log(`\nCommand shims were installed in ${paths.shimDir}, but that directory is not on PATH.`);
+  console.log(`Add it with: ${formatPathRepairCommand(paths.shimDir)}`);
+}
+
 program
   .name("arc")
   .description("Agentic component package manager")
@@ -114,8 +163,9 @@ program
   .description("Install a skill from git URL, or by name from the registry")
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--pin <version>", "Pin to a specific version (git tag)")
+  .option("--bin-dir <path>", "Directory for PATH-accessible command shims")
   .option("--strict-signing", "Refuse to install if Sigstore signature is missing on an official-tier package")
-  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; strictSigning?: boolean }) => {
+  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; binDir?: string; strictSigning?: boolean }) => {
     // Non-TTY guard: fail loud rather than silently half-installing
     if (!opts.yes && !process.stdin.isTTY) {
       console.error("Error: arc install requires an interactive terminal for capability confirmation.");
@@ -123,7 +173,7 @@ program
       process.exit(1);
     }
 
-    const paths = createArcPaths();
+    const paths = createInstallPaths(opts);
     const host = getDefaultHost();
     await ensureDirectories(paths, host);
     const db = openDatabase(paths.dbPath);
@@ -340,6 +390,7 @@ program
           ? "(verified)"
           : "(SHA-256 + registry signature verified; Sigstore signature MISSING)";
         console.log(`Installed ${result.name} v${result.version} ${verifyLabel}`);
+        printShimPathNotice(paths, result);
       } else {
         console.error(`${result.error}`);
         process.exit(1);
@@ -353,6 +404,7 @@ program
         } else {
           console.log(`\n✅ Installed ${result.name} v${result.version}`);
         }
+        printShimPathNotice(paths, result);
       } else {
         console.error(`\n❌ ${result.error}`);
         process.exit(1);
@@ -389,6 +441,7 @@ program
         } else {
           console.log(`✅ Installed ${result.name} v${result.version}`);
         }
+        printShimPathNotice(paths, result);
       } else {
         console.error(`${result.error}`);
         process.exit(1);
@@ -539,6 +592,60 @@ program
     const result = await verify(db, paths, host, name);
     console.log(formatVerify(result));
     db.close();
+  });
+
+// ── Config / doctor commands ─────────────────────────────────
+
+const config = program
+  .command("config")
+  .description("Manage Arc configuration");
+
+config
+  .command("get <key>")
+  .description("Read a configuration value")
+  .action(async (key: string) => {
+    if (key !== "bin-dir") {
+      console.error(`Unknown config key "${key}". Supported keys: bin-dir`);
+      process.exit(1);
+    }
+
+    const paths = createArcPaths();
+    const userConfig = await loadUserConfig(paths.configRoot);
+    console.log(userConfig.binDir ?? paths.shimDir);
+  });
+
+config
+  .command("set <key> <value>")
+  .description("Set a configuration value")
+  .action(async (key: string, value: string) => {
+    if (key !== "bin-dir") {
+      console.error(`Unknown config key "${key}". Supported keys: bin-dir`);
+      process.exit(1);
+    }
+
+    const paths = createArcPaths();
+    const userConfig = await loadUserConfig(paths.configRoot);
+    const binDir = normalizeUserPath(value);
+    await saveUserConfig(paths.configRoot, { ...userConfig, binDir });
+    console.log(`bin-dir = ${binDir}`);
+  });
+
+const doctor = program
+  .command("doctor")
+  .description("Check local Arc setup");
+
+doctor
+  .command("path")
+  .description("Check whether Arc command shims are on PATH")
+  .action(() => {
+    const paths = createArcPaths();
+    if (shimDirIsOnPath(paths.shimDir)) {
+      console.log(`OK: ${paths.shimDir} is on PATH`);
+      return;
+    }
+
+    console.log(`Arc command shims are installed in ${paths.shimDir}, but that directory is not on PATH.`);
+    console.log(`Add it with: ${formatPathRepairCommand(paths.shimDir)}`);
   });
 
 program

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from "fs";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { homedir } from "os";
+import YAML from "yaml";
+
+export interface ArcUserConfig {
+  binDir?: string;
+}
+
+interface RawArcUserConfig {
+  bin_dir?: unknown;
+  binDir?: unknown;
+}
+
+export function expandHomePath(path: string, home = homedir()): string {
+  if (path === "~") return home;
+  return path.replace(/^~(?=\/)/, home);
+}
+
+export function normalizeUserPath(path: string, home = homedir()): string {
+  const expanded = expandHomePath(path, home);
+  return expanded === "/" ? expanded : expanded.replace(/\/+$/, "");
+}
+
+export function userConfigPath(configRoot: string): string {
+  return join(configRoot, "config.yaml");
+}
+
+function normalizeConfig(raw: RawArcUserConfig | null | undefined, home = homedir()): ArcUserConfig {
+  const rawBinDir = raw?.bin_dir ?? raw?.binDir;
+  return {
+    ...(typeof rawBinDir === "string" && rawBinDir.trim()
+      ? { binDir: normalizeUserPath(rawBinDir.trim(), home) }
+      : {}),
+  };
+}
+
+export function loadUserConfigSync(configRoot: string, home = homedir()): ArcUserConfig {
+  const path = userConfigPath(configRoot);
+  if (!existsSync(path)) return {};
+
+  try {
+    const parsed = YAML.parse(readFileSync(path, "utf-8")) as RawArcUserConfig | null;
+    return normalizeConfig(parsed, home);
+  } catch {
+    return {};
+  }
+}
+
+export async function loadUserConfig(configRoot: string, home = homedir()): Promise<ArcUserConfig> {
+  const path = userConfigPath(configRoot);
+  if (!existsSync(path)) return {};
+
+  try {
+    const parsed = YAML.parse(await readFile(path, "utf-8")) as RawArcUserConfig | null;
+    return normalizeConfig(parsed, home);
+  } catch {
+    return {};
+  }
+}
+
+export async function saveUserConfig(configRoot: string, config: ArcUserConfig): Promise<void> {
+  const path = userConfigPath(configRoot);
+  const content = YAML.stringify(
+    {
+      ...(config.binDir ? { bin_dir: normalizeUserPath(config.binDir) } : {}),
+    },
+    { indent: 2 },
+  );
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf-8");
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -4,6 +4,7 @@ import { existsSync, renameSync } from "fs";
 import { mkdir } from "fs/promises";
 import type { ArcPaths, HostAdapter } from "../types.js";
 import { createClaudeCodeHost } from "./hosts/claude-code.js";
+import { loadUserConfigSync, normalizeUserPath } from "./config.js";
 
 // TODO: Remove migration logic after 2026-Q3. Only 2 users (founders) on arc currently,
 // so this migration path can be dropped once both have upgraded.
@@ -52,6 +53,34 @@ function resolveConfigRoot(override?: string): string {
   return configRoot;
 }
 
+export function resolveDefaultShimDir(opts?: {
+  home?: string;
+  pathEnv?: string;
+  configuredBinDir?: string;
+}): string {
+  const home = opts?.home ?? homedir();
+  const configured = opts?.configuredBinDir?.trim();
+  if (configured) return normalizeUserPath(configured, home);
+
+  const pathEntries = new Set(
+    (opts?.pathEnv ?? process.env.PATH ?? "")
+      .split(":")
+      .filter(Boolean)
+      .map((entry) => normalizeUserPath(entry, home)),
+  );
+
+  const preferred = [
+    join(home, ".local", "bin"),
+    join(home, "bin"),
+  ];
+
+  for (const candidate of preferred) {
+    if (pathEntries.has(candidate)) return candidate;
+  }
+
+  return join(home, ".local", "bin");
+}
+
 /**
  * Create ArcPaths — arc's host-independent state directories. Override any
  * field for testing.
@@ -59,6 +88,11 @@ function resolveConfigRoot(override?: string): string {
 export function createArcPaths(overrides?: Partial<ArcPaths>): ArcPaths {
   const home = homedir();
   const configRoot = resolveConfigRoot(overrides?.configRoot);
+  const userConfig = loadUserConfigSync(configRoot, home);
+  const configuredShimDir =
+    process.env.ARC_BIN_DIR ??
+    process.env.ARC_SHIM_DIR ??
+    userConfig.binDir;
 
   return {
     configRoot,
@@ -70,7 +104,11 @@ export function createArcPaths(overrides?: Partial<ArcPaths>): ArcPaths {
     runtimeDir: overrides?.runtimeDir ?? join(configRoot, "skills"),
     pipelinesDir: overrides?.pipelinesDir ?? join(configRoot, "pipelines"),
     actionsDir: overrides?.actionsDir ?? join(configRoot, "actions"),
-    shimDir: overrides?.shimDir ?? join(home, "bin"),
+    shimDir: overrides?.shimDir ?? resolveDefaultShimDir({
+      home,
+      pathEnv: process.env.PATH,
+      configuredBinDir: configuredShimDir,
+    }),
     catalogPath:
       overrides?.catalogPath ?? join(import.meta.dir, "..", "..", "catalog.yaml"),
     registryPath:

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -1,5 +1,6 @@
-import { readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
+import { dirname } from "path";
 import YAML from "yaml";
 import type { SourcesConfig, RegistrySource, SourceType } from "../types.js";
 
@@ -54,6 +55,7 @@ export async function saveSources(
   config: SourcesConfig
 ): Promise<void> {
   const content = YAML.stringify(config, { indent: 2 });
+  await mkdir(dirname(sourcesPath), { recursive: true });
   await writeFile(sourcesPath, content, "utf-8");
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -638,7 +638,7 @@ export interface ArcPaths {
   pipelinesDir: string;
   /** Actions directory (~/.config/metafactory/actions/) */
   actionsDir: string;
-  /** PATH-accessible shim directory (~/bin/) — shared across hosts */
+  /** PATH-accessible shim directory (~/.local/bin by default) — shared across hosts */
   shimDir: string;
   /** Catalog file path (repo-root/catalog.yaml) */
   catalogPath: string;

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  loadUserConfig,
+  normalizeUserPath,
+  saveUserConfig,
+} from "../../src/lib/config.js";
+
+describe("user config", () => {
+  test("saveUserConfig and loadUserConfig round-trip binDir", async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), "arc-user-config-"));
+
+    await saveUserConfig(configRoot, { binDir: `${configRoot}/bin/` });
+    const config = await loadUserConfig(configRoot);
+
+    expect(config.binDir).toBe(`${configRoot}/bin`);
+  });
+
+  test("normalizeUserPath expands home and strips trailing slashes", () => {
+    expect(normalizeUserPath("~/.local/bin///", "/Users/tester")).toBe(
+      "/Users/tester/.local/bin",
+    );
+  });
+});

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -3,6 +3,7 @@ import {
   createArcPaths,
   getDefaultHost,
   migrateConfigIfNeeded,
+  resolveDefaultShimDir,
 } from "../../src/lib/paths.js";
 import { homedir } from "os";
 import { join } from "path";
@@ -38,15 +39,23 @@ describe("createArcPaths env-var handling", () => {
 });
 
 describe("createArcPaths", () => {
-  test("returns host-independent state paths from homedir", () => {
-    const paths = createArcPaths();
-    const home = homedir();
+  test("returns host-independent state paths from config root", () => {
+    const originalPath = process.env.PATH;
+    try {
+      process.env.PATH = "";
+      const configRoot = join(mkdtempSync(join(tmpdir(), "arc-paths-config-")), "metafactory");
+      const paths = createArcPaths({ configRoot });
+      const home = homedir();
 
-    expect(paths.configRoot).toBe(join(home, ".config", "metafactory"));
-    expect(paths.dbPath).toBe(join(home, ".config", "metafactory", "packages.db"));
-    expect(paths.reposDir).toBe(join(home, ".config", "metafactory", "pkg", "repos"));
-    expect(paths.cachePath).toBe(join(home, ".config", "metafactory", "pkg", "cache"));
-    expect(paths.shimDir).toBe(join(home, "bin"));
+      expect(paths.configRoot).toBe(configRoot);
+      expect(paths.dbPath).toBe(join(configRoot, "packages.db"));
+      expect(paths.reposDir).toBe(join(configRoot, "pkg", "repos"));
+      expect(paths.cachePath).toBe(join(configRoot, "pkg", "cache"));
+      expect(paths.shimDir).toBe(join(home, ".local", "bin"));
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
   });
 
   test("does not expose host-specific paths", () => {
@@ -75,6 +84,60 @@ describe("createArcPaths", () => {
     expect(paths.dbPath).toBe("/custom/packages.db");
     // reposDir still derived from configRoot
     expect(paths.reposDir).toBe("/tmp/test/.config/mf/pkg/repos");
+  });
+
+  test("uses remembered bin-dir from config.yaml", () => {
+    const base = mkdtempSync(join(tmpdir(), "arc-bin-config-"));
+    const configRoot = join(base, "metafactory");
+    mkdirSync(configRoot, { recursive: true });
+    writeFileSync(join(configRoot, "config.yaml"), "bin_dir: ~/.arc/bin\n");
+
+    const paths = createArcPaths({ configRoot });
+
+    expect(paths.shimDir).toBe(join(homedir(), ".arc", "bin"));
+  });
+});
+
+describe("resolveDefaultShimDir", () => {
+  test("prefers ~/.local/bin when it is already on PATH", () => {
+    const home = "/Users/tester";
+    const dir = resolveDefaultShimDir({
+      home,
+      pathEnv: `${home}/bin:${home}/.local/bin:/usr/bin`,
+    });
+
+    expect(dir).toBe(`${home}/.local/bin`);
+  });
+
+  test("matches PATH entries with trailing slashes", () => {
+    const home = "/Users/tester";
+    const dir = resolveDefaultShimDir({
+      home,
+      pathEnv: `${home}/.local/bin/:/usr/bin`,
+    });
+
+    expect(dir).toBe(`${home}/.local/bin`);
+  });
+
+  test("falls back to ~/.local/bin instead of creating ~/bin", () => {
+    const home = "/Users/tester";
+    const dir = resolveDefaultShimDir({
+      home,
+      pathEnv: "/usr/bin:/bin",
+    });
+
+    expect(dir).toBe(`${home}/.local/bin`);
+  });
+
+  test("honors a remembered bin directory", () => {
+    const home = "/Users/tester";
+    const dir = resolveDefaultShimDir({
+      home,
+      pathEnv: "/usr/bin:/bin",
+      configuredBinDir: "~/.arc/bin",
+    });
+
+    expect(dir).toBe(`${home}/.arc/bin`);
   });
 });
 

--- a/test/unit/sources.test.ts
+++ b/test/unit/sources.test.ts
@@ -12,6 +12,10 @@ import {
 } from "../../src/lib/sources.js";
 import type { SourcesConfig, RegistrySource } from "../../src/types.js";
 import YAML from "yaml";
+import { join } from "path";
+import { mkdtemp } from "fs/promises";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
 
 let env: TestEnv;
 
@@ -36,6 +40,16 @@ describe("loadSources", () => {
     expect(config.sources[1].name).toBe("metafactory-registry");
     expect(config.sources[1].tier).toBe("community");
     expect(config.sources[1].type).toBeUndefined();
+  });
+
+  test("creates parent config directory on a fresh machine", async () => {
+    const root = await mkdtemp(join(tmpdir(), "arc-fresh-sources-"));
+    const sourcesPath = join(root, ".config", "metafactory", "sources.yaml");
+
+    const config = await loadSources(sourcesPath);
+
+    expect(config.sources).toHaveLength(2);
+    expect(existsSync(sourcesPath)).toBe(true);
   });
 
   test("loads valid sources.yaml", async () => {


### PR DESCRIPTION
## Summary
- default Arc command shims to ~/.local/bin, prefer it over ~/bin when already on PATH, and honor a remembered bin-dir from ~/.config/metafactory/config.yaml
- add arc install --bin-dir, arc config get/set bin-dir, and arc doctor path with shell-specific PATH repair guidance
- make sources.yaml bootstrap create its parent config directory on fresh installs
- document the new local configuration commands

Closes #210

## Verification
- bun test test/unit/sources.test.ts test/unit/paths.test.ts
- bunx tsc --noEmit
- bun run lint
- git diff --check
- ARC_CONFIG_ROOT=/private/tmp/arc-210-smoke bun src/cli.ts config set bin-dir ~/.local/bin
- ARC_CONFIG_ROOT=/private/tmp/arc-210-smoke bun src/cli.ts config get bin-dir
- ARC_CONFIG_ROOT=/private/tmp/arc-210-smoke bun src/cli.ts doctor path
- bun test (990 pass, 3 skip, 0 fail)