### PR TITLE
feat: add install transaction evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# Arc Context
+
+Arc installs, upgrades, verifies, and publishes agentic packages while preserving trust, host placement, and rollback invariants.
+
+## Language
+
+**Install Transaction**:
+The all-or-nothing package operation that turns a resolved package artifact into landed host artifacts plus a committed package database row.
+_Avoid_: Artifact landing, install pipeline, install flow
+
+**Resolved Package**:
+A package whose source, version, manifest location, and install material have been determined before installation begins.
+_Avoid_: Lookup result, found package
+
+**Install Authorization**:
+A decision that the package is allowed to land after trust, capability, and operator policy checks have completed.
+_Avoid_: Approval flag, yes option, confirmation
+
+**Landed Artifact**:
+A host-visible package output such as a skill symlink, command shim, hook registration, extension wiring, launchd plist, or generated template.
+_Avoid_: Installed file, output
+
+**Transaction Evidence**:
+The structured record of what an Install Transaction landed, committed, rolled back, or failed to roll back.
+_Avoid_: Result object, debug details
+
+## Relationships
+
+- An **Install Transaction** starts from exactly one **Resolved Package**.
+- An **Install Transaction** requires exactly one **Install Authorization** before landing artifacts.
+- An **Install Transaction** may create many **Landed Artifacts**.
+- An **Install Transaction** returns **Transaction Evidence** whether it succeeds or fails.
+- A package database row is committed only after the **Install Transaction** has landed artifacts and completed lifecycle checks.
+
+## Example Dialogue
+
+> **Dev:** "Should `arc upgrade` reuse the **Install Transaction**?"
+> **Domain expert:** "Only for the part that lands the new package state; source update and version selection can stay outside."
+
+> **Dev:** "Should the **Install Transaction** ask for permission?"
+> **Domain expert:** "No - it receives an **Install Authorization** after the caller has handled trust and capability review."
+
+> **Dev:** "Should rollback warnings only be printed?"
+> **Domain expert:** "No - they belong in **Transaction Evidence** so tests and callers can inspect the outcome."
+
+## Flagged Ambiguities
+
+- "install flow" was used for both source resolution and artifact landing; resolved: **Install Transaction** begins after package resolution and owns landing plus commit/rollback.
+- "`--yes`" was used as if it were the approval model; resolved: `--yes` is one way to produce an **Install Authorization**, not the domain concept itself.
+- "result" was used for both user-facing command output and internal rollback facts; resolved: **Transaction Evidence** is the internal install record, while CLI formatting remains separate.

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -16,7 +16,6 @@ import { recordInstall, getSkill } from "../lib/db.js";
 import { runScript, runLifecycleScripts } from "../lib/scripts.js";
 import {
   registerHooks,
-  removeHooks,
   resolveHooksFromManifest,
   findMissingHookFiles,
 } from "../lib/hooks.js";
@@ -41,6 +40,10 @@ import {
   rollbackLaunchdArtifacts,
 } from "../lib/hosts/launchd-install.js";
 import { isDarwinLaunchdHost } from "../lib/hosts/darwin-launchd.js";
+import {
+  beginInstallTransaction,
+  type InstallTransactionEvidence,
+} from "../lib/install-transaction.js";
 
 export interface InstallOptions {
   /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
@@ -85,6 +88,7 @@ export interface InstallResult {
   version?: string;
   error?: string;
   manifest?: ArcManifest;
+  evidence?: InstallTransactionEvidence;
   /** For library installs: results for each artifact */
   artifacts?: InstallResult[];
 }
@@ -379,6 +383,12 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       };
     }
   }
+  const tx = beginInstallTransaction({
+    packageName: manifest.name,
+    authorization: { approved: true },
+  });
+  tx.recordSymlinks(symlinkResult.record);
+  tx.recordLaunchd(launchdRecords);
 
   // 5b. Register hooks (if declared, with consent gating).
   // host.paths.root is passed as the $PAI_DIR expansion target so a hook
@@ -404,12 +414,10 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
       // orphan entries under ~/.claude/{skills,bin,...} for the user to clean.
       // arc#140 P3: also unwind any launchd-side state placed by multi-target
       // dispatch (plist + binary symlink).
-      await rollbackArtifactSymlinks(symlinkResult.record);
-      for (const rec of launchdRecords) {
-        await rollbackLaunchdArtifacts(rec);
-      }
+      const evidence = await tx.rollback();
       return {
         success: false,
+        evidence,
         error:
           `Manifest declares hooks whose command references a file that was not installed:\n${detail}\n` +
           `Add the file to provides.files (or fix the command path) and reinstall.`,
@@ -425,6 +433,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     if (approved) {
       const settingsPath = host.paths.settingsPath;
       await registerHooks(manifest.name, resolvedHooks, settingsPath);
+      tx.recordHookRegistration(settingsPath, resolvedHooks.length);
       if (!opts.yes) {
         console.log("  \u2713 Hooks registered in settings.json");
       }
@@ -438,6 +447,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // 5c. Wire extensions (if declared)
   if (manifest.extensions) {
     const wired = await wireExtensions(manifest, installPath, host.paths.root);
+    tx.recordExtensions(wired);
     if (wired.length && !opts.yes) {
       for (const ext of wired) {
         console.log(`  \u2713 Extension wired: ${ext}`);
@@ -457,12 +467,8 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     // Tear down hook registrations, symlinks, AND any launchd-side state
     // (arc#140 P3) before returning so the user gets a clean failure
     // rather than orphans they have to clean up by hand.
-    await removeHooks(manifest.name, host.paths.settingsPath);
-    await rollbackArtifactSymlinks(symlinkResult.record);
-    for (const rec of launchdRecords) {
-      await rollbackLaunchdArtifacts(rec);
-    }
-    return postinstallResult;
+    const evidence = await tx.rollback();
+    return { ...postinstallResult, evidence };
   }
 
   // 7. Record in database
@@ -488,12 +494,14 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     },
     manifest
   );
+  tx.recordDbCommit(manifest.name);
 
   return {
     success: true,
     name: manifest.name,
     version: manifest.version,
     manifest,
+    evidence: tx.evidence,
   };
 }
 
@@ -659,6 +667,11 @@ export async function installSingleArtifact(
         `Manifest declares provides.files entries whose source does not exist in the package:\n${detail}`,
     };
   }
+  const tx = beginInstallTransaction({
+    packageName: manifest.name,
+    authorization: { approved: true },
+  });
+  tx.recordSymlinks(symlinkResult.record);
 
   // Register hooks (with consent gating — same as standalone install).
   // See note above on host.paths.root threading $PAI_DIR substitution.
@@ -680,9 +693,10 @@ export async function installSingleArtifact(
       // #89: roll back any symlinks/shims createArtifactSymlinks placed before
       // we hit this gate, so the install fails clean rather than leaving
       // orphan entries under ~/.claude/{skills,bin,...} for the user to clean.
-      await rollbackArtifactSymlinks(symlinkResult.record);
+      const evidence = await tx.rollback();
       return {
         success: false,
+        evidence,
         error:
           `Manifest declares hooks whose command references a file that was not installed:\n${detail}\n` +
           `Add the file to provides.files (or fix the command path) and reinstall.`,
@@ -698,6 +712,7 @@ export async function installSingleArtifact(
     if (approved) {
       const settingsPath = host.paths.settingsPath;
       await registerHooks(manifest.name, resolvedHooks, settingsPath);
+      tx.recordHookRegistration(settingsPath, resolvedHooks.length);
       if (!opts.yes) {
         console.log("  \u2713 Hooks registered in settings.json");
       }
@@ -720,9 +735,8 @@ export async function installSingleArtifact(
     // Tear down hook registrations and symlinks before returning so the
     // user gets a clean failure rather than orphans they have to clean up
     // by hand.
-    await removeHooks(manifest.name, host.paths.settingsPath);
-    await rollbackArtifactSymlinks(symlinkResult.record);
-    return postinstallResult;
+    const evidence = await tx.rollback();
+    return { ...postinstallResult, evidence };
   }
 
   // Resolve the skill_dir for DB recording
@@ -748,12 +762,14 @@ export async function installSingleArtifact(
     },
     manifest,
   );
+  tx.recordDbCommit(manifest.name);
 
   return {
     success: true,
     name: manifest.name,
     version: manifest.version,
     manifest,
+    evidence: tx.evidence,
   };
 }
 

--- a/src/lib/install-transaction.ts
+++ b/src/lib/install-transaction.ts
@@ -1,0 +1,131 @@
+import type { ArtifactSymlinkRecord } from "./artifact-installer.js";
+import { rollbackArtifactSymlinks } from "./artifact-installer.js";
+import type { LaunchdInstallRecord } from "./hosts/launchd-install.js";
+import { rollbackLaunchdArtifacts } from "./hosts/launchd-install.js";
+import { removeHooks } from "./hooks.js";
+import { errorMessage } from "./errors.js";
+
+export interface InstallAuthorization {
+  approved: boolean;
+}
+
+export type LandedArtifact =
+  | { kind: "symlink"; path: string }
+  | { kind: "shim"; dir: string; name: string }
+  | { kind: "hook"; settingsPath: string; count: number }
+  | { kind: "extension"; name: string }
+  | { kind: "launchd"; plistPath?: string; binSymlink?: string }
+  | { kind: "db-row"; name: string };
+
+export interface InstallTransactionEvidence {
+  packageName: string;
+  landedArtifacts: LandedArtifact[];
+  dbCommitted: boolean;
+  rollback: {
+    attempted: boolean;
+    warnings: string[];
+  };
+}
+
+export interface InstallTransaction {
+  readonly evidence: InstallTransactionEvidence;
+  recordSymlinks(record: ArtifactSymlinkRecord): void;
+  recordLaunchd(records: LaunchdInstallRecord[]): void;
+  recordHookRegistration(settingsPath: string, count: number): void;
+  recordExtensions(names: string[]): void;
+  recordDbCommit(name: string): void;
+  rollback(): Promise<InstallTransactionEvidence>;
+}
+
+export function beginInstallTransaction(opts: {
+  packageName: string;
+  authorization: InstallAuthorization;
+}): InstallTransaction {
+  if (!opts.authorization.approved) {
+    throw new Error("Install Transaction requires Install Authorization");
+  }
+
+  const symlinkRecords: ArtifactSymlinkRecord[] = [];
+  const launchdRecords: LaunchdInstallRecord[] = [];
+  const hookRegistrations: { settingsPath: string; packageName: string }[] = [];
+  const evidence: InstallTransactionEvidence = {
+    packageName: opts.packageName,
+    landedArtifacts: [],
+    dbCommitted: false,
+    rollback: {
+      attempted: false,
+      warnings: [],
+    },
+  };
+
+  const warn = (message: string) => {
+    evidence.rollback.warnings.push(message);
+  };
+
+  return {
+    evidence,
+
+    recordSymlinks(record) {
+      symlinkRecords.push(record);
+      for (const path of record.symlinks) {
+        evidence.landedArtifacts.push({ kind: "symlink", path });
+      }
+      for (const name of record.shims.names) {
+        evidence.landedArtifacts.push({ kind: "shim", dir: record.shims.dir, name });
+      }
+    },
+
+    recordLaunchd(records) {
+      launchdRecords.push(...records);
+      for (const record of records) {
+        evidence.landedArtifacts.push({
+          kind: "launchd",
+          plistPath: record.plistPath,
+          binSymlink: record.binSymlink,
+        });
+      }
+    },
+
+    recordHookRegistration(settingsPath, count) {
+      hookRegistrations.push({ settingsPath, packageName: opts.packageName });
+      evidence.landedArtifacts.push({ kind: "hook", settingsPath, count });
+    },
+
+    recordExtensions(names) {
+      for (const name of names) {
+        evidence.landedArtifacts.push({ kind: "extension", name });
+      }
+    },
+
+    recordDbCommit(name) {
+      evidence.dbCommitted = true;
+      evidence.landedArtifacts.push({ kind: "db-row", name });
+    },
+
+    async rollback() {
+      evidence.rollback.attempted = true;
+      for (const hook of hookRegistrations) {
+        try {
+          await removeHooks(hook.packageName, hook.settingsPath);
+        } catch (err) {
+          warn(`failed to remove hooks from ${hook.settingsPath}: ${errorMessage(err)}`);
+        }
+      }
+      for (const record of symlinkRecords) {
+        try {
+          await rollbackArtifactSymlinks(record);
+        } catch (err) {
+          warn(`failed to roll back symlinks: ${errorMessage(err)}`);
+        }
+      }
+      for (const record of launchdRecords) {
+        try {
+          await rollbackLaunchdArtifacts(record);
+        } catch (err) {
+          warn(`failed to roll back launchd artifacts: ${errorMessage(err)}`);
+        }
+      }
+      return evidence;
+    },
+  };
+}

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -972,6 +972,24 @@ describe("install provides.files (issue #84)", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("Postinstall script failed");
+    expect(result.evidence?.rollback.attempted).toBe(true);
+    expect(result.evidence?.dbCommitted).toBe(false);
+    expect(result.evidence?.landedArtifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "symlink",
+          path: join(env.host.paths.skillsDir, "PostinstallRollback"),
+        }),
+        expect.objectContaining({
+          kind: "shim",
+          name: "postrollback",
+        }),
+        expect.objectContaining({
+          kind: "hook",
+          settingsPath: env.host.paths.settingsPath,
+        }),
+      ]),
+    );
 
     // Symlink rollback assertions (same shape as #89 hook-gate test).
     expect(existsSync(join(env.host.paths.skillsDir, "PostinstallRollback"))).toBe(false);


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` install-domain vocabulary for Install Transaction, Install Authorization, Landed Artifact, and Transaction Evidence.
- Add `src/lib/install-transaction.ts` to record landed artifacts, DB commit state, rollback attempts, and rollback warnings.
- Thread transaction evidence through existing standalone and library artifact install rollback paths.

Fixes #212.

## Verification

- `rtk bunx tsc --noEmit`
- `rtk bun run lint:errors`
- `rtk bun test test/commands/install.test.ts -t "postinstall failure rolls back symlinks AND unregisters hooks"`
- `rtk bun test test/commands/install.test.ts test/commands/install-multitarget-i140.test.ts test/commands/lifecycle-hooks.test.ts`
- `rtk bun test` (995 pass, 3 skip)
