### PR TITLE
fix: roll back extension wiring on install failure

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -447,7 +447,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // 5c. Wire extensions (if declared)
   if (manifest.extensions) {
     const wired = await wireExtensions(manifest, installPath, host.paths.root);
-    tx.recordExtensions(wired);
+    tx.recordExtensions(wired, host.paths.root);
     if (wired.length && !opts.yes) {
       for (const ext of wired) {
         console.log(`  \u2713 Extension wired: ${ext}`);

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -3,6 +3,7 @@ import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { createSymlink, removeSymlink } from "./symlinks.js";
 import type { ArcManifest } from "../types.js";
+import { errorMessage } from "./errors.js";
 
 /**
  * Wire extensions declared in a package manifest.
@@ -60,4 +61,36 @@ export async function unwireExtensions(
   }
 
   return removed;
+}
+
+/**
+ * Roll back extensions using the exact extension records returned by
+ * wireExtensions(). This is used when install fails after extension wiring
+ * but before the package database row is committed.
+ */
+export async function rollbackWiredExtensions(
+  wired: string[],
+  claudeRoot: string,
+): Promise<string[]> {
+  const warnings: string[] = [];
+
+  for (const record of wired) {
+    const [kind, name] = record.split(":", 2);
+    if (kind !== "statusline" || !name) {
+      warnings.push(`unknown extension record ${record}`);
+      continue;
+    }
+
+    const linkPath = join(claudeRoot, "statusline.d", `${name}.sh`);
+    try {
+      const removed = await removeSymlink(linkPath);
+      if (!removed && existsSync(linkPath)) {
+        warnings.push(`failed to remove extension ${record}: ${linkPath} is not a symlink`);
+      }
+    } catch (err) {
+      warnings.push(`failed to remove extension ${record}: ${errorMessage(err)}`);
+    }
+  }
+
+  return warnings;
 }

--- a/src/lib/install-transaction.ts
+++ b/src/lib/install-transaction.ts
@@ -4,6 +4,7 @@ import type { LaunchdInstallRecord } from "./hosts/launchd-install.js";
 import { rollbackLaunchdArtifacts } from "./hosts/launchd-install.js";
 import { removeHooks } from "./hooks.js";
 import { errorMessage } from "./errors.js";
+import { rollbackWiredExtensions } from "./extensions.js";
 
 export interface InstallAuthorization {
   approved: boolean;
@@ -32,7 +33,7 @@ export interface InstallTransaction {
   recordSymlinks(record: ArtifactSymlinkRecord): void;
   recordLaunchd(records: LaunchdInstallRecord[]): void;
   recordHookRegistration(settingsPath: string, count: number): void;
-  recordExtensions(names: string[]): void;
+  recordExtensions(names: string[], claudeRoot: string): void;
   recordDbCommit(name: string): void;
   rollback(): Promise<InstallTransactionEvidence>;
 }
@@ -48,6 +49,7 @@ export function beginInstallTransaction(opts: {
   const symlinkRecords: ArtifactSymlinkRecord[] = [];
   const launchdRecords: LaunchdInstallRecord[] = [];
   const hookRegistrations: { settingsPath: string; packageName: string }[] = [];
+  const extensionRecords: { names: string[]; claudeRoot: string }[] = [];
   const evidence: InstallTransactionEvidence = {
     packageName: opts.packageName,
     landedArtifacts: [],
@@ -91,7 +93,8 @@ export function beginInstallTransaction(opts: {
       evidence.landedArtifacts.push({ kind: "hook", settingsPath, count });
     },
 
-    recordExtensions(names) {
+    recordExtensions(names, claudeRoot) {
+      extensionRecords.push({ names, claudeRoot });
       for (const name of names) {
         evidence.landedArtifacts.push({ kind: "extension", name });
       }
@@ -109,6 +112,16 @@ export function beginInstallTransaction(opts: {
           await removeHooks(hook.packageName, hook.settingsPath);
         } catch (err) {
           warn(`failed to remove hooks from ${hook.settingsPath}: ${errorMessage(err)}`);
+        }
+      }
+      for (const record of extensionRecords) {
+        try {
+          const warnings = await rollbackWiredExtensions(record.names, record.claudeRoot);
+          for (const warning of warnings) {
+            warn(warning);
+          }
+        } catch (err) {
+          warn(`failed to roll back extensions: ${errorMessage(err)}`);
         }
       }
       for (const record of symlinkRecords) {

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -684,6 +684,7 @@ describe("install provides.files (issue #84)", () => {
     providesFiles?: { source: string; target: string }[];
     providesHooks?: { event: string; command: string }[];
     providesCli?: { command: string; name: string }[];
+    statuslineExtensions?: { name: string; source: string }[];
     postinstall?: { path: string; content: string };
   }): Promise<string> {
     const repoDir = join(env.root, `mock-${opts.name}`);
@@ -729,6 +730,14 @@ describe("install provides.files (issue #84)", () => {
       for (const c of opts.providesCli) {
         lines.push(`    - command: ${JSON.stringify(c.command)}`);
         lines.push(`      name: ${c.name}`);
+      }
+    }
+    if (opts.statuslineExtensions?.length) {
+      lines.push(`extensions:`);
+      lines.push(`  statusline:`);
+      for (const ext of opts.statuslineExtensions) {
+        lines.push(`    - name: ${ext.name}`);
+        lines.push(`      source: ${JSON.stringify(ext.source)}`);
       }
     }
     if (opts.postinstall) {
@@ -1013,6 +1022,46 @@ describe("install provides.files (issue #84)", () => {
     // No DB row — recordInstall happens after postinstall.
     const fromDb = getSkill(env.db, "PostinstallRollback");
     expect(fromDb).toBeNull();
+  });
+
+  test("postinstall failure rolls back extension wiring", async () => {
+    const repoUrl = await buildRepoWithProvides({
+      name: "ExtensionRollback",
+      extraFiles: { "statusline/extension.sh": "#!/bin/bash\necho status\n" },
+      statuslineExtensions: [
+        { name: "extension-rollback", source: "statusline/extension.sh" },
+      ],
+      postinstall: {
+        path: "scripts/postinstall.sh",
+        content: "#!/bin/bash\nexit 1\n",
+      },
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host,
+      db: env.db,
+      repoUrl,
+      yes: true,
+    });
+
+    const extensionPath = join(
+      env.host.paths.root,
+      "statusline.d",
+      "extension-rollback.sh",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Postinstall script failed");
+    expect(result.evidence?.rollback.attempted).toBe(true);
+    expect(result.evidence?.landedArtifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "extension",
+          name: "statusline:extension-rollback",
+        }),
+      ]),
+    );
+    expect(existsSync(extensionPath)).toBe(false);
   });
 
   test("install succeeds when ${PAI_DIR} hook target is landed via provides.files", async () => {

--- a/test/unit/install-transaction.test.ts
+++ b/test/unit/install-transaction.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { beginInstallTransaction } from "../../src/lib/install-transaction.js";
+
+describe("InstallTransaction", () => {
+  test("captures extension rollback cleanup warnings in evidence", async () => {
+    const root = await mkdtemp(join(tmpdir(), "arc-install-tx-"));
+    const statuslineDir = join(root, "statusline.d");
+    await mkdir(statuslineDir, { recursive: true });
+    await writeFile(join(statuslineDir, "blocked.sh"), "#!/bin/bash\n");
+
+    const tx = beginInstallTransaction({
+      packageName: "BlockedExtension",
+      authorization: { approved: true },
+    });
+    tx.recordExtensions(["statusline:blocked"], root);
+
+    const evidence = await tx.rollback();
+
+    expect(evidence.rollback.attempted).toBe(true);
+    expect(evidence.rollback.warnings).toEqual([
+      expect.stringContaining("statusline:blocked"),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add rollback support for extension records returned by `wireExtensions()`.
- Teach `InstallTransaction` to keep extension rollback state and capture extension cleanup warnings in Transaction Evidence.
- Cover postinstall failure cleanup for statusline extension wiring and warning propagation.

Closes #214.

## Verification

- `rtk bunx tsc --noEmit`
- `rtk bun run lint:errors`
- `rtk bun test test/unit/install-transaction.test.ts`
- `rtk bun test test/commands/install.test.ts -t "postinstall failure rolls back extension wiring"`
- `rtk bun test test/commands/install.test.ts test/unit/install-transaction.test.ts`
- `rtk bun test`

Note: the first full-suite run failed only in `ensureCosignBinary` after 60s because the fresh worktree lacked the untracked local `vendor/cosign/cosign-darwin-arm64` binary. After copying the existing local vendor binary into this worktree, the full suite passed: 997 pass, 3 skip.
