### PR TITLE
fix: support Windows cosign binary and fail soft on unsupported platforms (#216)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,7 +1,7 @@
 # arc-manifest.yaml — capability declaration
 schema: arc/v1
 name: arc
-version: 0.30.2
+version: 0.30.3
 type: tool
 tier: core
 description: Agentic component package manager — install, manage, and distribute AI agent skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Agentic component package manager — install, manage, and distribute AI agent skills",
   "type": "module",
   "bin": {

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -151,13 +151,23 @@ export async function verifyPackageSigstore(
     }
     return { verified: false, reason: result.error ?? "cosign verification failed" };
   } catch (err) {
-    // A thrown error here is a verification *capability* gap, not evidence of
-    // tampering — e.g. cosign has no binary for this platform/arch, so
-    // detectPlatform throws. Degrade to verified=null (the same contract as
-    // unsigned and the soma#303 missing-identity case): warn and proceed on
-    // the default path, while --strict-signing still escalates null to a
-    // refusal. A genuine cosign rejection returns valid:false above and stays
-    // verified=false; only an inability to *run* the check lands here.
+    // Deliberate resilience policy (#216): a package manager must never abort
+    // the whole install because the signature verifier could not *run*. A
+    // throw out of the verifier means verification was unable to execute — a
+    // *capability* gap, not evidence of tampering. The canonical case is
+    // cosign having no binary for this platform/arch, so detectPlatform throws.
+    //
+    // This is safe BECAUSE failures that genuinely ran-and-rejected never
+    // reach here: a ran-and-rejected cosign verify-blob returns valid:false
+    // (→ verified:false above); the bundle download fails outside this try
+    // (line 139 → verified:false); and the bundled-cosign wrapper reports
+    // binary-fetch / checksum-mismatch failures as a returned {valid:false},
+    // not a throw. So a throw is specifically "we couldn't perform the check".
+    //
+    // Degrade to verified=null — the same contract as unsigned and the
+    // soma#303 missing-identity case: warn and proceed on the default path,
+    // while --strict-signing still escalates null to a hard refusal, so the
+    // security posture is preserved.
     return {
       verified: null,
       reason: `Sigstore verification unavailable: ${errorMessage(err)}`,

--- a/src/lib/cosign-verify.ts
+++ b/src/lib/cosign-verify.ts
@@ -150,6 +150,18 @@ export async function verifyPackageSigstore(
       };
     }
     return { verified: false, reason: result.error ?? "cosign verification failed" };
+  } catch (err) {
+    // A thrown error here is a verification *capability* gap, not evidence of
+    // tampering — e.g. cosign has no binary for this platform/arch, so
+    // detectPlatform throws. Degrade to verified=null (the same contract as
+    // unsigned and the soma#303 missing-identity case): warn and proceed on
+    // the default path, while --strict-signing still escalates null to a
+    // refusal. A genuine cosign rejection returns valid:false above and stays
+    // verified=false; only an inability to *run* the check lands here.
+    return {
+      verified: null,
+      reason: `Sigstore verification unavailable: ${errorMessage(err)}`,
+    };
   } finally {
     await unlink(dl.path).catch(() => {
       // best-effort cleanup

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -28,17 +28,19 @@ interface PlatformInfo {
   downloadUrl: string;
 }
 
-const SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32"]);
-const SUPPORTED_ARCHES = new Set(["arm64", "x64"]);
-
 // Node's process.platform value -> the os token sigstore/cosign uses in its
 // release asset names. win32 maps to "windows" (cosign ships
-// cosign-windows-amd64.exe / cosign-windows-arm64.exe).
+// cosign-windows-amd64.exe / cosign-windows-arm64.exe). SUPPORTED_PLATFORMS is
+// derived from these keys so the two can never drift out of sync — adding a
+// platform here is the single edit needed to support it.
 const COSIGN_OS_NAME: Record<string, string> = {
   darwin: "darwin",
   linux: "linux",
   win32: "windows",
 };
+
+const SUPPORTED_PLATFORMS = new Set(Object.keys(COSIGN_OS_NAME));
+const SUPPORTED_ARCHES = new Set(["arm64", "x64"]);
 
 const SUPPORTED_PLATFORM_LABELS = [...SUPPORTED_PLATFORMS]
   .map((p) => COSIGN_OS_NAME[p] ?? p)
@@ -144,9 +146,7 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
       await mkdir(destDir, { recursive: true });
     }
     await writeFile(destPath, Buffer.from(buffer));
-    // Make the binary executable on unix. On Windows fs.chmod is a harmless
-    // no-op (NTFS has no POSIX permission bits), and the .exe extension is
-    // what makes the file runnable there — so this needs no platform guard.
+    // Executable bit for unix; harmless no-op on Windows (.exe is runnable).
     await chmod(destPath, 0o755);
 
     process.stderr.write(`cosign ${COSIGN_VERSION} downloaded and verified.\n`);

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -28,19 +28,37 @@ interface PlatformInfo {
   downloadUrl: string;
 }
 
-const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
+const SUPPORTED_PLATFORMS = new Set(["darwin", "linux", "win32"]);
 const SUPPORTED_ARCHES = new Set(["arm64", "x64"]);
 
-export function detectPlatform(): PlatformInfo {
-  if (!SUPPORTED_PLATFORMS.has(process.platform)) {
-    throw new Error(`Unsupported platform: ${process.platform}. cosign binaries are available for: ${[...SUPPORTED_PLATFORMS].join(", ")}`);
+// Node's process.platform value -> the os token sigstore/cosign uses in its
+// release asset names. win32 maps to "windows" (cosign ships
+// cosign-windows-amd64.exe / cosign-windows-arm64.exe).
+const COSIGN_OS_NAME: Record<string, string> = {
+  darwin: "darwin",
+  linux: "linux",
+  win32: "windows",
+};
+
+const SUPPORTED_PLATFORM_LABELS = [...SUPPORTED_PLATFORMS]
+  .map((p) => COSIGN_OS_NAME[p] ?? p)
+  .join(", ");
+
+export function detectPlatform(
+  platform: string = process.platform,
+  architecture: string = process.arch,
+): PlatformInfo {
+  if (!SUPPORTED_PLATFORMS.has(platform)) {
+    throw new Error(`Unsupported platform: ${platform}. cosign binaries are available for: ${SUPPORTED_PLATFORM_LABELS}`);
   }
-  if (!SUPPORTED_ARCHES.has(process.arch)) {
-    throw new Error(`Unsupported architecture: ${process.arch}. cosign binaries are available for: arm64, x64 (amd64)`);
+  if (!SUPPORTED_ARCHES.has(architecture)) {
+    throw new Error(`Unsupported architecture: ${architecture}. cosign binaries are available for: arm64, x64 (amd64)`);
   }
-  const os = process.platform as string;
-  const arch = process.arch === "arm64" ? "arm64" : "amd64";
-  const binaryName = `cosign-${os}-${arch}`;
+  const os = COSIGN_OS_NAME[platform];
+  const arch = architecture === "arm64" ? "arm64" : "amd64";
+  // cosign Windows assets carry a .exe suffix; unix binaries do not.
+  const ext = platform === "win32" ? ".exe" : "";
+  const binaryName = `cosign-${os}-${arch}${ext}`;
   const downloadUrl = `https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${binaryName}`;
   return { os, arch, binaryName, downloadUrl };
 }

--- a/src/lib/cosign.ts
+++ b/src/lib/cosign.ts
@@ -144,6 +144,9 @@ export async function fetchCosignBinary(): Promise<{ path?: string; error?: stri
       await mkdir(destDir, { recursive: true });
     }
     await writeFile(destPath, Buffer.from(buffer));
+    // Make the binary executable on unix. On Windows fs.chmod is a harmless
+    // no-op (NTFS has no POSIX permission bits), and the .exe extension is
+    // what makes the file runnable there — so this needs no platform guard.
     await chmod(destPath, 0o755);
 
     process.stderr.write(`cosign ${COSIGN_VERSION} downloaded and verified.\n`);

--- a/test/unit/cosign-verify.test.ts
+++ b/test/unit/cosign-verify.test.ts
@@ -246,6 +246,38 @@ describe("verifyPackageSigstore", () => {
     expect(result.reason).toMatch(/signature mismatch/i);
   });
 
+  // #216: a verifier that THROWS (e.g. cosign has no binary for this
+  // platform/arch, so detectPlatform throws) is a verification *capability*
+  // gap, not a tampered artifact. It must degrade to verified=null (warn
+  // path; --strict-signing still refuses on official tier), matching the
+  // unsigned and soma#303 contracts — never propagate the throw and abort
+  // the whole install.
+  test("verified=null when the verifier throws (platform/binary unavailable)", async () => {
+    env = await createTestEnv();
+    globalThis.fetch = mockFetch(async () =>
+      new Response('{"mediaType":"application/vnd.dev.sigstore.bundle+json"}', { status: 200 }),
+    );
+    const artifactPath = join(env.arc.reposDir, "artifact.tgz");
+    await writeFile(artifactPath, "fake");
+
+    const result = await verifyPackageSigstore({
+      source: source(),
+      sha256: "abc",
+      signing: {
+        signature_bundle_key: "packages/abc.bundle",
+        signer_identity: "https://github.com/owner/repo/.github/workflows/publish.yml@refs/heads/main",
+      },
+      artifactPath,
+      tempDir: env.arc.reposDir,
+      verifier: async () => {
+        throw new Error("Unsupported platform: sunos. cosign binaries are available for: darwin, linux, windows");
+      },
+    });
+    expect(result.verified).toBeNull();
+    expect(result.reason).toMatch(/unavailable/i);
+    expect(result.reason).toMatch(/Unsupported platform/);
+  });
+
   test("TRUSTED_OIDC_ISSUER is GitHub Actions (OQ-14 scope)", () => {
     expect(TRUSTED_OIDC_ISSUER).toBe("https://token.actions.githubusercontent.com");
   });

--- a/test/unit/cosign.test.ts
+++ b/test/unit/cosign.test.ts
@@ -11,20 +11,42 @@ import {
 describe("detectPlatform", () => {
   test("returns valid platform info", () => {
     const platform = detectPlatform();
-    expect(["darwin", "linux"]).toContain(platform.os);
+    expect(["darwin", "linux", "windows"]).toContain(platform.os);
     expect(["arm64", "amd64"]).toContain(platform.arch);
-    expect(platform.binaryName).toMatch(/^cosign-(darwin|linux)-(arm64|amd64)$/);
+    expect(platform.binaryName).toMatch(/^cosign-(darwin|linux|windows)-(arm64|amd64)(\.exe)?$/);
   });
 
   test("binary name matches os-arch pattern", () => {
     const platform = detectPlatform();
-    expect(platform.binaryName).toBe(`cosign-${platform.os}-${platform.arch}`);
+    const ext = platform.os === "windows" ? ".exe" : "";
+    expect(platform.binaryName).toBe(`cosign-${platform.os}-${platform.arch}${ext}`);
   });
 
   test("includes download URL", () => {
     const platform = detectPlatform();
     expect(platform.downloadUrl).toContain(platform.binaryName);
     expect(platform.downloadUrl).toContain("github.com/sigstore/cosign");
+  });
+
+  // #216: Windows is a supported cosign target. detectPlatform must map
+  // win32 -> windows and append .exe, matching the real release asset names
+  // cosign-windows-amd64.exe / cosign-windows-arm64.exe.
+  test("maps win32 to windows with .exe suffix (amd64)", () => {
+    const platform = detectPlatform("win32", "x64");
+    expect(platform.os).toBe("windows");
+    expect(platform.arch).toBe("amd64");
+    expect(platform.binaryName).toBe("cosign-windows-amd64.exe");
+    expect(platform.downloadUrl).toContain("cosign-windows-amd64.exe");
+  });
+
+  test("maps win32 arm64 to windows arm64 with .exe suffix", () => {
+    const platform = detectPlatform("win32", "arm64");
+    expect(platform.binaryName).toBe("cosign-windows-arm64.exe");
+  });
+
+  test("unix targets carry no .exe suffix", () => {
+    expect(detectPlatform("linux", "x64").binaryName).toBe("cosign-linux-amd64");
+    expect(detectPlatform("darwin", "arm64").binaryName).toBe("cosign-darwin-arm64");
   });
 });
 
@@ -143,13 +165,16 @@ describe("verifySigstoreBundle", () => {
 });
 
 describe("detectPlatform - unsupported", () => {
-  test("throws on unsupported platform", () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-    try {
-      expect(() => detectPlatform()).toThrow("Unsupported platform: win32");
-    } finally {
-      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
-    }
+  test("throws on a genuinely unsupported platform", () => {
+    // win32 is now supported (#216); freebsd is not a cosign release target.
+    expect(() => detectPlatform("freebsd", "x64")).toThrow("Unsupported platform: freebsd");
+  });
+
+  test("error lists the supported platforms by their cosign os names", () => {
+    expect(() => detectPlatform("freebsd", "x64")).toThrow(/darwin, linux, windows/);
+  });
+
+  test("throws on an unsupported architecture", () => {
+    expect(() => detectPlatform("linux", "ia32")).toThrow("Unsupported architecture: ia32");
   });
 });


### PR DESCRIPTION
Closes #216.

## Problem

`arc install` of a Sigstore-signed package (e.g. `@metafactory/soma`) aborted on Windows right after "Registry signature verified", with:

```
Unsupported platform: win32. cosign binaries are available for: darwin, linux
```

Two distinct bugs in `src/lib/cosign.ts` / `src/lib/cosign-verify.ts`.

## Fix

**1. Real Windows support** (`cosign.ts` `detectPlatform`)
- `win32` added to `SUPPORTED_PLATFORMS`.
- `win32` -> `windows` os token, `.exe` suffix appended → `cosign-windows-amd64.exe` / `cosign-windows-arm64.exe`, matching the real sigstore/cosign release assets.
- Error message now lists supported platforms by their cosign os names (`darwin, linux, windows`).
- `detectPlatform(platform?, arch?)` now takes optional args for testability.
- Checksum-match logic already keys off `binaryName`, so it carries over unchanged. `chmod 0o755` is a harmless no-op on Windows.

**2. Fail soft on any genuinely-unsupported platform** (`cosign-verify.ts` `verifyPackageSigstore`)
- A thrown verifier (cosign has no binary for this platform/arch → `detectPlatform` throws) is a verification *capability* gap, not tampering. It now degrades to `verified: null` — the same warn-and-proceed contract as the unsigned and soma#303 missing-identity cases.
- `--strict-signing` still escalates `null` → refusal, so the security posture is preserved.
- A genuine cosign rejection still returns `verified: false` (verify-blob exit code path is unchanged).

## Tests
- `win32` → `cosign-windows-amd64.exe` / `cosign-windows-arm64.exe` mapping
- unix targets carry no `.exe`
- genuinely-unsupported platform (`freebsd`) still throws; unsupported arch still throws
- verifier-throws → `verified: null` (degraded, not abort)

Full suite: **1003 pass, 0 fail** (network-allowed run).

Version bumped 0.30.2 → 0.30.3 (arc-manifest.yaml + package.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)