### PR TITLE
Extract resolved package verification

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: Artifact landing, install pipeline, install flow
 A package whose source, version, manifest location, and install material have been determined before installation begins.
 _Avoid_: Lookup result, found package
 
+**Package Verification Evidence**:
+The structured record of checksum, registry signature, Sigstore, quarantine, and source-trust facts gathered while resolving install material.
+_Avoid_: Verification result, install check, warning flags
+
 **Install Authorization**:
 A decision that the package is allowed to land after trust, capability, and operator policy checks have completed.
 _Avoid_: Approval flag, yes option, confirmation
@@ -27,6 +31,8 @@ _Avoid_: Result object, debug details
 ## Relationships
 
 - An **Install Transaction** starts from exactly one **Resolved Package**.
+- A **Resolved Package** carries **Package Verification Evidence** when it comes from a verifiable registry source.
+- **Package Verification Evidence** informs **Install Authorization** but does not decide it.
 - An **Install Transaction** requires exactly one **Install Authorization** before landing artifacts.
 - An **Install Transaction** may create many **Landed Artifacts**.
 - An **Install Transaction** returns **Transaction Evidence** whether it succeeds or fails.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,15 +74,10 @@ import {
 import {
   parsePackageRef,
   formatPackageRef,
-  resolveFromRegistry,
-  downloadPackage,
-  verifyChecksum,
-  extractPackage,
+  resolveVerifiedPackage,
   formatQuarantineMessage,
   QUARANTINE_EXIT_CODE,
 } from "./lib/registry-install.js";
-import { verifyVersionSignature } from "./lib/registry-signing.js";
-import { verifyPackageSigstore } from "./lib/cosign-verify.js";
 import { loadCatalog, saveCatalog, findEntry } from "./lib/catalog.js";
 import {
   loadSources,
@@ -99,6 +94,8 @@ import {
 } from "./lib/remote-registry.js";
 import { homedir } from "os";
 import { join } from "path";
+import { existsSync } from "fs";
+import { rename, rm } from "fs/promises";
 import { parseLibraryRef } from "./lib/artifact-installer.js";
 import { errorMessage } from "./lib/errors.js";
 import pkg from "../package.json" with { type: "json" };
@@ -216,159 +213,86 @@ program
     if (pkgRef) {
       // Registry install: @scope/name[@version] → download from metafactory API
       const sources = await loadSources(paths.sourcesPath);
-      const resolved = await resolveFromRegistry(pkgRef, sources.sources);
+      console.log(`Resolving ${formatPackageRef(pkgRef)}...`);
+      const verified = await resolveVerifiedPackage({
+        ref: pkgRef,
+        sources: sources.sources,
+        reposDir: paths.reposDir,
+        targetDirName: `${pkgRef.scope}__${pkgRef.name}.arc-install-tmp-${Date.now()}`,
+      });
 
-      if (!resolved) {
-        console.error(`Package "${formatPackageRef(pkgRef)}" not found in any metafactory registry.`);
-        console.error(`Try: arc search ${pkgRef.name}`);
-        process.exit(1);
-      }
-
-      console.log(`Found ${formatPackageRef(pkgRef)} v${resolved.version} in ${resolved.source.name} [${resolved.source.tier}]`);
-
-      // arc#158: bail before download if a row already exists for this name.
-      // Resolved name is known here (no clone needed), so we save the bytes.
-      const existingRow = getSkill(db, resolved.name);
-      if (existingRow && !existingRow.library_name) {
-        let hint: string;
-        if (existingRow.status === "disabled") {
-          hint = `Run \`arc enable ${resolved.name}\` to re-enable it, or \`arc remove ${resolved.name}\` first if you want a clean install.`;
-        } else if (existingRow.version === resolved.version) {
-          hint = `Already at v${resolved.version}. Run \`arc remove ${resolved.name}\` first to reinstall.`;
-        } else {
-          hint = `Run \`arc upgrade ${resolved.name}\`, or \`arc remove ${resolved.name}\` first if the existing install can't be upgraded in place.`;
-        }
-        console.error(`'${resolved.name}' v${existingRow.version} is already installed (status: ${existingRow.status}). ${hint}`);
-        process.exit(1);
-      }
-
-      // Download. Anonymous by default (DD-80); the resolved source is passed
-      // through so an auth-gated metafactory storage endpoint receives the
-      // bearer token from `arc login` (issue #83).
-      console.log(`Downloading...`);
-      const download = await downloadPackage(resolved.downloadUrl, paths.reposDir, resolved.source);
-      if (!download.success || !download.tempPath) {
-        // 451 quarantine (mf#76 / arc#105) gets dedicated UX + a distinct
-        // exit code so scripts can tell deliberate-removal apart from
-        // missing/network failures.
-        if (download.quarantine) {
+      if (!verified.success) {
+        if (verified.quarantine) {
           const colorEnabled = process.stderr.isTTY;
           for (const line of formatQuarantineMessage(
             formatPackageRef(pkgRef),
-            download.quarantine,
+            verified.quarantine,
             colorEnabled,
           )) {
             console.error(line);
           }
           process.exit(QUARANTINE_EXIT_CODE);
         }
-        console.error(`${download.error}`);
+        console.error(`${verified.error}`);
         process.exit(1);
       }
-      console.log(`Downloaded ${((download.bytesDownloaded ?? 0) / 1024).toFixed(0)} KB`);
 
-      // Verify SHA-256
-      const verify = await verifyChecksum(download.tempPath, resolved.sha256);
-      if (!verify.valid) {
-        console.error(`Checksum verification failed!`);
-        console.error(`  Expected: ${verify.expected}`);
-        console.error(`  Actual:   ${verify.actual}`);
-        console.error(`This could indicate a corrupted download or compromised package.`);
-        if (await Bun.file(download.tempPath).exists()) {
-          Bun.spawnSync(["rm", "-f", download.tempPath]);
-        }
-        process.exit(1);
-      }
+      const resolvedPackage = verified.resolvedPackage;
+      const verification = resolvedPackage.packageVerificationEvidence;
+      console.log(`Found ${formatPackageRef(pkgRef)} v${resolvedPackage.version} in ${resolvedPackage.source.name} [${resolvedPackage.source.tier}]`);
       console.log(`SHA-256 verified`);
-
-      // A-504: verify registry-level Ed25519 signature over manifest bytes.
-      // Blocks install on any verified=false. verified=null means the
-      // version is unsigned (legacy / registry in degraded mode at publish
-      // time) — arc proceeds with a warning, consistent with meta-factory's
-      // own graceful degradation.
-      const sigResult = await verifyVersionSignature(
-        resolved.source,
-        {
-          registry_signature: resolved.registrySignature,
-          registry_key_id: resolved.registryKeyId,
-        },
-        resolved.manifestCanonical,
-      );
-      if (sigResult.verified === false) {
-        // Distinguish infrastructure unavailability from a genuine
-        // signature mismatch. Both fail-closed, but the user-facing
-        // framing differs: "try again later" vs "investigate now".
-        const infraFailure = /public key unavailable|manifest_canonical missing/i.test(
-          sigResult.reason,
-        );
-        console.error(`Registry signature verification failed: ${sigResult.reason}`);
-        if (infraFailure) {
-          console.error(`The registry may be temporarily unreachable or misconfigured. Try again later.`);
-        } else {
-          console.error(`This could indicate a compromised registry or a tampered manifest.`);
-        }
-        if (await Bun.file(download.tempPath).exists()) {
-          Bun.spawnSync(["rm", "-f", download.tempPath]);
-        }
-        process.exit(1);
-      }
-      if (sigResult.verified === true) {
-        console.log(`Registry signature verified (${sigResult.reason})`);
+      if (verification.registrySignature.status === "verified") {
+        console.log(`Registry signature verified (${verification.registrySignature.reason})`);
       } else {
-        console.warn(`Registry signature: ${sigResult.reason}`);
+        console.warn(`Registry signature: ${verification.registrySignature.reason}`);
       }
 
-      // A-503: verify Sigstore bundle (cosign) when signature_bundle_key is
-      // present. Scope OQ-14: GitHub Actions OIDC only. verified=null means
-      // the version predates Sigstore signing — proceed with a warning.
-      const sigstoreResult = await verifyPackageSigstore({
-        source: resolved.source,
-        sha256: resolved.sha256,
-        signing: {
-          signature_bundle_key: resolved.signatureBundleKey,
-          signer_identity: resolved.signerIdentity,
-        },
-        artifactPath: download.tempPath,
-        tempDir: paths.reposDir,
-      });
-      if (sigstoreResult.verified === false) {
-        console.error(`Sigstore verification failed: ${sigstoreResult.reason}`);
-        console.error(`This could indicate a tampered artifact or an unexpected signer.`);
-        if (await Bun.file(download.tempPath).exists()) {
-          Bun.spawnSync(["rm", "-f", download.tempPath]);
+      // arc#158: resolved manifest identity is known here, before landing artifacts.
+      const existingRow = getSkill(db, resolvedPackage.manifest.name);
+      if (existingRow && !existingRow.library_name) {
+        let hint: string;
+        if (existingRow.status === "disabled") {
+          hint = `Run \`arc enable ${resolvedPackage.manifest.name}\` to re-enable it, or \`arc remove ${resolvedPackage.manifest.name}\` first if you want a clean install.`;
+        } else if (existingRow.version === resolvedPackage.version) {
+          hint = `Already at v${resolvedPackage.version}. Run \`arc remove ${resolvedPackage.manifest.name}\` first to reinstall.`;
+        } else {
+          hint = `Run \`arc upgrade ${resolvedPackage.manifest.name}\`, or \`arc remove ${resolvedPackage.manifest.name}\` first if the existing install can't be upgraded in place.`;
         }
+        await rm(resolvedPackage.installPath, { recursive: true, force: true }).catch(() => undefined);
+        console.error(`'${resolvedPackage.manifest.name}' v${existingRow.version} is already installed (status: ${existingRow.status}). ${hint}`);
         process.exit(1);
       }
+
       // arc#160: a missing Sigstore signature on an official-tier source is
       // a real risk, not a side note. Promote it to a prominent warning, and
       // let --strict-signing turn it into a hard failure.
-      let sigstoreVerified = false;
-      if (sigstoreResult.verified === true) {
-        console.log(`Sigstore signature verified (${sigstoreResult.reason})`);
-        sigstoreVerified = true;
-      } else if (resolved.source.tier === "official") {
+      const sigstoreVerified = verification.sigstore.status === "verified";
+      if (sigstoreVerified) {
+        console.log(`Sigstore signature verified (${verification.sigstore.reason})`);
+      } else if (resolvedPackage.source.tier === "official") {
         console.warn(`⚠️  Sigstore signature MISSING for official-tier package`);
-        console.warn(`   ${sigstoreResult.reason}`);
+        console.warn(`   ${verification.sigstore.reason}`);
         console.warn(`   SHA-256 and registry signature are verified, but the package itself is not Sigstore-signed.`);
         console.warn(`   This means the identity that produced the bytes cannot be cryptographically attested.`);
         if (opts.strictSigning) {
           console.error(`Refusing to install: --strict-signing is set and Sigstore signature is missing.`);
-          if (await Bun.file(download.tempPath).exists()) {
-            Bun.spawnSync(["rm", "-f", download.tempPath]);
-          }
+          await rm(resolvedPackage.installPath, { recursive: true, force: true }).catch(() => undefined);
           process.exit(1);
         }
       } else {
-        console.warn(`Sigstore signature: ${sigstoreResult.reason}`);
+        console.warn(`Sigstore signature: ${verification.sigstore.reason}`);
       }
 
-      // Extract
-      const packageDir = `${resolved.scope}__${resolved.name}`;
-      const extract = await extractPackage(download.tempPath, paths.reposDir, packageDir);
-      if (!extract.success) {
-        console.error(`${extract.error}`);
+      const finalInstallPath = join(
+        paths.reposDir,
+        `${resolvedPackage.ref.scope}__${resolvedPackage.ref.name}`,
+      );
+      if (existsSync(finalInstallPath)) {
+        await rm(resolvedPackage.installPath, { recursive: true, force: true }).catch(() => undefined);
+        console.error(`Refusing to install: target directory already exists at ${finalInstallPath}. Remove it first or run \`arc upgrade ${resolvedPackage.manifest.name}\`.`);
         process.exit(1);
       }
+      await rename(resolvedPackage.installPath, finalInstallPath);
 
       // Continue with standard install flow (manifest, symlinks, hooks, DB).
       // Use preExtractedPath so install() skips git clone.
@@ -376,11 +300,11 @@ program
         arc: paths,
         host,
         db,
-        repoUrl: formatPackageRef({ scope: resolved.scope, name: resolved.name, version: resolved.version }),
+        repoUrl: resolvedPackage.repoUrl,
         yes: opts.yes,
-        preExtractedPath: extract.extractedPath,
-        sourceName: resolved.source.name,
-        sourceTier: resolved.source.tier,
+        preExtractedPath: finalInstallPath,
+        sourceName: resolvedPackage.source.name,
+        sourceTier: resolvedPackage.source.tier,
       });
       if (result.success) {
         // arc#160: don't claim "(verified)" on the final line when only the

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -14,7 +14,7 @@ import { findInAllSources } from "../lib/remote-registry.js";
 import {
   parsePackageRef,
   resolveFromRegistry,
-  fetchAndVerifyRegistryPackage,
+  resolveVerifiedPackage,
 } from "../lib/registry-install.js";
 import { runScript } from "../lib/scripts.js";
 import { registerHooks, removeHooks, resolveHooksFromManifest } from "../lib/hooks.js";
@@ -202,17 +202,17 @@ export async function upgradePackage(
     // with no install — which is the remove+install hazard (bug 3).
     const sources = await loadSources(arc.sourcesPath);
     const tmpDirName = `${ref.scope}__${ref.name}.arc-upgrade-tmp`;
-    const fetched = await fetchAndVerifyRegistryPackage({
+    const fetched = await resolveVerifiedPackage({
       ref: { scope: ref.scope, name: ref.name },
       sources: sources.sources,
       reposDir: arc.reposDir,
       targetDirName: tmpDirName,
     });
-    if (!fetched.success || !fetched.extractedPath) {
+    if (!fetched.success) {
       return { success: false, name, oldVersion: skill.version, error: fetched.error ?? "registry re-download failed" };
     }
 
-    const newPath = fetched.extractedPath;
+    const newPath = fetched.resolvedPackage.installPath;
     const backupPath = `${installPath}.arc-upgrade-bak`;
     Bun.spawnSync(["rm", "-rf", backupPath], { stdout: "pipe", stderr: "pipe" });
     const aside = Bun.spawnSync(["mv", installPath, backupPath], { stdout: "pipe", stderr: "pipe" });

--- a/src/lib/registry-install.ts
+++ b/src/lib/registry-install.ts
@@ -1,8 +1,10 @@
 import { join } from "path";
 import { existsSync } from "fs";
-import { writeFile, unlink, mkdir } from "fs/promises";
+import { writeFile, unlink, mkdir, rm } from "fs/promises";
 import type {
+  ArcManifest,
   PackageRef,
+  PackageTier,
   VerifyResult,
   RegistrySource,
 } from "../types.js";
@@ -10,6 +12,7 @@ import { getSourceType } from "./sources.js";
 import { fetchMetafactoryPackageDetail } from "./metafactory-api.js";
 import { verifyVersionSignature } from "./registry-signing.js";
 import { verifyPackageSigstore } from "./cosign-verify.js";
+import { readManifest } from "./manifest.js";
 
 // ---------------------------------------------------------------------------
 // Package reference parsing
@@ -500,25 +503,82 @@ export async function extractPackage(
 }
 
 // ---------------------------------------------------------------------------
-// Verified registry fetch (shared install + upgrade path) — arc#187
+// Resolved Package verification (shared install + upgrade path) — arc#187
 // ---------------------------------------------------------------------------
 
-export interface VerifiedFetchResult {
-  success: boolean;
-  /** Path the verified tarball was extracted to (a temp dir name under reposDir). */
-  extractedPath?: string;
-  /** Resolved registry metadata (version, source, …). */
-  resolved?: ResolvedRegistryPackage;
-  error?: string;
+export interface PackageVerificationEvidence {
+  checksum: {
+    status: "verified" | "failed";
+    expected: string;
+    actual?: string;
+  };
+  registrySignature: {
+    status: "verified" | "missing" | "failed";
+    reason: string;
+    keyId?: string | null;
+  };
+  sigstore: {
+    status: "verified" | "missing" | "failed";
+    reason: string;
+    signerIdentity?: string | null;
+    bundleKey?: string | null;
+  };
+  sourceTrust: {
+    sourceName: string;
+    sourceTier: PackageTier;
+    sourceType: "metafactory";
+  };
   quarantine?: QuarantineInfo;
 }
 
+export interface VerifiedResolvedPackage {
+  ref: PackageRef;
+  version: string;
+  source: RegistrySource;
+  repoUrl: string;
+  installPath: string;
+  manifestPath: string;
+  manifest: ArcManifest;
+  packageVerificationEvidence: PackageVerificationEvidence;
+}
+
+export type ResolveVerifiedPackageResult =
+  | {
+      success: true;
+      resolvedPackage: VerifiedResolvedPackage;
+    }
+  | {
+      success: false;
+      error?: string;
+      packageVerificationEvidence?: Partial<PackageVerificationEvidence>;
+      quarantine?: QuarantineInfo;
+    };
+
+function sourceTrustEvidence(source: RegistrySource): PackageVerificationEvidence["sourceTrust"] {
+  return {
+    sourceName: source.name,
+    sourceTier: source.tier,
+    sourceType: "metafactory",
+  };
+}
+
+function manifestPathFor(extractedPath: string): string | null {
+  const arcManifestPath = join(extractedPath, "arc-manifest.yaml");
+  if (existsSync(arcManifestPath)) return arcManifestPath;
+  const paiManifestPath = join(extractedPath, "pai-manifest.yaml");
+  if (existsSync(paiManifestPath)) return paiManifestPath;
+  return null;
+}
+
 /**
- * Resolve, download, fully verify, and extract a registry package — arc#187.
+ * Resolve a metafactory package ref into verified install material.
  *
- * This is the secure registry pipeline factored out of the `arc install`
- * inline flow (cli.ts) so `arc upgrade` can re-download a registry-extracted
- * package with the SAME verification guarantees instead of a weaker check.
+ * This is the secure registry pipeline shared by `arc install @scope/name`
+ * and registry-backed `arc upgrade`. It produces a **Resolved Package**:
+ * verified, extracted material plus its manifest and **Package Verification
+ * Evidence**. Callers still own duplicate checks, strict-signing policy,
+ * user-facing rendering, Install Authorization, and artifact landing.
+ *
  * It performs, in order:
  *   1. resolveFromRegistry (metafactory API) → version + sha256 + signing block
  *   2. downloadPackage (anonymous by default; bearer attached for auth'd storage)
@@ -526,22 +586,22 @@ export interface VerifiedFetchResult {
  *   4. Ed25519 registry-signature verification (A-504; fail-closed on `false`)
  *   5. Sigstore bundle verification (A-503; fail-closed on `false`, `null` = proceed)
  *   6. extract to `<reposDir>/<targetDirName>`
+ *   7. read the extracted arc-manifest.yaml / pai-manifest.yaml
  *
  * The artifact is extracted to a caller-chosen dir name (typically a `.tmp`
  * sibling of the real install path) so the caller can atomically swap it into
  * place only after success — never destroying the working install first.
  *
- * Unsigned/legacy versions (`verified: null`) proceed, mirroring install-side
- * graceful degradation. A genuine signature mismatch (`verified: false`)
- * fails closed. Console output is the caller's responsibility — this function
- * is silent so it can be used in non-interactive upgrade flows.
+ * Missing signatures (`verified: null`) proceed with explicit evidence.
+ * Genuine signature mismatches (`verified: false`) fail closed. Console
+ * output is the caller's responsibility.
  */
-export async function fetchAndVerifyRegistryPackage(opts: {
+export async function resolveVerifiedPackage(opts: {
   ref: PackageRef;
   sources: RegistrySource[];
   reposDir: string;
   targetDirName: string;
-}): Promise<VerifiedFetchResult> {
+}): Promise<ResolveVerifiedPackageResult> {
   const resolved = await resolveFromRegistry(opts.ref, opts.sources);
   if (!resolved) {
     return {
@@ -552,15 +612,30 @@ export async function fetchAndVerifyRegistryPackage(opts: {
 
   const download = await downloadPackage(resolved.downloadUrl, opts.reposDir, resolved.source);
   if (!download.success || !download.tempPath) {
-    return { success: false, error: download.error, quarantine: download.quarantine };
+    return {
+      success: false,
+      error: download.error,
+      quarantine: download.quarantine,
+      packageVerificationEvidence: {
+        sourceTrust: sourceTrustEvidence(resolved.source),
+        ...(download.quarantine ? { quarantine: download.quarantine } : {}),
+      },
+    };
   }
 
   const checksum = await verifyChecksum(download.tempPath, resolved.sha256);
+  const checksumEvidence: PackageVerificationEvidence["checksum"] = checksum.valid
+    ? { status: "verified", expected: checksum.expected, actual: checksum.actual }
+    : { status: "failed", expected: checksum.expected, actual: checksum.actual };
   if (!checksum.valid) {
     await unlink(download.tempPath).catch(() => undefined);
     return {
       success: false,
       error: `Checksum verification failed (expected ${checksum.expected}, got ${checksum.actual}).`,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
     };
   }
 
@@ -569,9 +644,26 @@ export async function fetchAndVerifyRegistryPackage(opts: {
     { registry_signature: resolved.registrySignature, registry_key_id: resolved.registryKeyId },
     resolved.manifestCanonical,
   );
+  const registrySignatureEvidence: PackageVerificationEvidence["registrySignature"] = {
+    status: sigResult.verified === true
+      ? "verified"
+      : sigResult.verified === false
+        ? "failed"
+        : "missing",
+    reason: sigResult.reason,
+    keyId: resolved.registryKeyId,
+  };
   if (sigResult.verified === false) {
     await unlink(download.tempPath).catch(() => undefined);
-    return { success: false, error: `Registry signature verification failed: ${sigResult.reason}` };
+    return {
+      success: false,
+      error: `Registry signature verification failed: ${sigResult.reason}`,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
   }
 
   const sigstoreResult = await verifyPackageSigstore({
@@ -584,15 +676,114 @@ export async function fetchAndVerifyRegistryPackage(opts: {
     artifactPath: download.tempPath,
     tempDir: opts.reposDir,
   });
+  const sigstoreEvidence: PackageVerificationEvidence["sigstore"] = {
+    status: sigstoreResult.verified === true
+      ? "verified"
+      : sigstoreResult.verified === false
+        ? "failed"
+        : "missing",
+    reason: sigstoreResult.reason,
+    signerIdentity: resolved.signerIdentity,
+    bundleKey: resolved.signatureBundleKey,
+  };
   if (sigstoreResult.verified === false) {
     await unlink(download.tempPath).catch(() => undefined);
-    return { success: false, error: `Sigstore verification failed: ${sigstoreResult.reason}` };
+    return {
+      success: false,
+      error: `Sigstore verification failed: ${sigstoreResult.reason}`,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
   }
 
   const extract = await extractPackage(download.tempPath, opts.reposDir, opts.targetDirName);
   if (!extract.success) {
-    return { success: false, error: extract.error };
+    return {
+      success: false,
+      error: extract.error,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
   }
 
-  return { success: true, extractedPath: extract.extractedPath, resolved };
+  let manifest: ArcManifest | null;
+  try {
+    manifest = await readManifest(extract.extractedPath);
+  } catch (err) {
+    await rm(extract.extractedPath, { recursive: true, force: true }).catch(() => undefined);
+    return {
+      success: false,
+      error: `Failed to read manifest: ${err instanceof Error ? err.message : String(err)}`,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
+  }
+
+  const manifestPath = manifestPathFor(extract.extractedPath);
+  if (!manifest || !manifestPath) {
+    await rm(extract.extractedPath, { recursive: true, force: true }).catch(() => undefined);
+    return {
+      success: false,
+      error: "Failed to read manifest from verified package material.",
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
+  }
+
+  if (manifest.name !== resolved.name || manifest.version !== resolved.version) {
+    await rm(extract.extractedPath, { recursive: true, force: true }).catch(() => undefined);
+    return {
+      success: false,
+      error: `Manifest identity mismatch: registry resolved ${resolved.name} v${resolved.version}, package manifest declares ${manifest.name} v${manifest.version}.`,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    };
+  }
+
+  return {
+    success: true,
+    resolvedPackage: {
+      ref: {
+        scope: resolved.scope,
+        name: resolved.name,
+        version: resolved.version,
+      },
+      version: resolved.version,
+      source: resolved.source,
+      repoUrl: formatPackageRef({
+        scope: resolved.scope,
+        name: resolved.name,
+        version: resolved.version,
+      }),
+      installPath: extract.extractedPath,
+      manifestPath,
+      manifest,
+      packageVerificationEvidence: {
+        checksum: checksumEvidence,
+        registrySignature: registrySignatureEvidence,
+        sigstore: sigstoreEvidence,
+        sourceTrust: sourceTrustEvidence(resolved.source),
+      },
+    },
+  };
 }

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync, lstatSync, readlinkSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import {
   createTestEnv,
@@ -9,6 +10,50 @@ import {
 import { install, parseNameVersion } from "../../src/commands/install.js";
 import { remove } from "../../src/commands/remove.js";
 import { getSkill } from "../../src/lib/db.js";
+import { saveSources } from "../../src/lib/sources.js";
+
+async function buildRegistryTarball(opts: {
+  baseDir: string;
+  name: string;
+  version: string;
+}): Promise<{ bytes: Uint8Array; sha256: string }> {
+  const stageRoot = join(opts.baseDir, `__cli-registry-fixture-${opts.name}-${opts.version}`);
+  const topDir = join(stageRoot, "pkg");
+  await mkdir(join(topDir, "skill"), { recursive: true });
+  await writeFile(join(topDir, "skill", "SKILL.md"), `# ${opts.name}\n`);
+  await writeFile(
+    join(topDir, "arc-manifest.yaml"),
+    [
+      `name: ${opts.name}`,
+      `version: ${opts.version}`,
+      "type: skill",
+      "capabilities:",
+      "  filesystem:",
+      "    read: []",
+      "    write: []",
+      "  network: []",
+      "  bash:",
+      "    allowed: false",
+      "  secrets: []",
+      "",
+    ].join("\n"),
+  );
+  const tarPath = join(opts.baseDir, `__cli-registry-fixture-${opts.name}-${opts.version}.tar.gz`);
+  Bun.spawnSync(["tar", "czf", tarPath, "-C", stageRoot, "pkg"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const buf = await Bun.file(tarPath).arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buf);
+  return { bytes: new Uint8Array(buf), sha256: hasher.digest("hex") };
+}
+
+function processEnvWith(overrides: Record<string, string>): Record<string, string> {
+  const entries = Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return { ...Object.fromEntries(entries), ...overrides };
+}
 
 let env: TestEnv;
 
@@ -589,6 +634,108 @@ describe("install command", () => {
     // No `arc upgrade` suggestion when versions match — that would just no-op.
     expect(result.error).not.toContain("arc upgrade");
   });
+
+  test("registry duplicate install keeps existing final directory intact", async () => {
+    const fixture = await buildRegistryTarball({
+      baseDir: env.root,
+      name: "soma",
+      version: "1.2.3",
+    });
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.includes("/storage/download/")) {
+          return new Response(fixture.bytes as unknown as BodyInit, { status: 200 });
+        }
+        if (/\/api\/v1\/packages\/[^/]+\/[^/]+@/.test(url.pathname)) {
+          return new Response(JSON.stringify({
+            version: "1.2.3",
+            sha256: fixture.sha256,
+            manifest_canonical: '{"name":"@metafactory/soma","version":"1.2.3"}',
+            signing: { registry_signature: null, registry_key_id: null },
+          }), { status: 200 });
+        }
+        if (url.pathname.includes("/api/v1/packages/")) {
+          return new Response(JSON.stringify({
+            namespace: "@metafactory",
+            name: "soma",
+            display_name: null,
+            description: "",
+            type: "skill",
+            license: "MIT",
+            latest_version: "1.2.3",
+            versions: ["1.2.3"],
+            publisher: { display_name: "Test", tier: "official", mfa_enabled: true, github_username: null },
+            sponsor: null,
+            created_at: 0,
+            updated_at: 0,
+          }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      await saveSources(env.arc.sourcesPath, {
+        sources: [{
+          name: "mf-test",
+          url: `http://127.0.0.1:${server.port}`,
+          tier: "official",
+          enabled: true,
+          type: "metafactory",
+        }],
+      });
+
+      const finalInstallPath = join(env.arc.reposDir, "metafactory__soma");
+      await mkdir(finalInstallPath, { recursive: true });
+      await writeFile(join(finalInstallPath, "sentinel.txt"), "keep\n");
+      const now = new Date().toISOString();
+      env.db.prepare(
+        `INSERT INTO skills (name, version, repo_url, install_path, skill_dir, status, artifact_type, tier, installed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "soma",
+        "1.0.0",
+        "@metafactory/soma@1.0.0",
+        finalInstallPath,
+        finalInstallPath,
+        "active",
+        "skill",
+        "official",
+        now,
+        now,
+      );
+
+      const child = Bun.spawn(
+        ["bun", "src/cli.ts", "install", "@metafactory/soma", "--yes", "--bin-dir", env.arc.shimDir],
+        {
+          cwd: join(import.meta.dir, "..", ".."),
+          env: processEnvWith({
+            ARC_CONFIG_ROOT: env.arc.configRoot,
+            ARC_BIN_DIR: env.arc.shimDir,
+            HOME: env.root,
+          }),
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+
+      const output = `${stdout}\n${stderr}`;
+      expect(exitCode).not.toBe(0);
+      expect(output).toContain("already installed");
+      expect(existsSync(finalInstallPath)).toBe(true);
+      expect(await Bun.file(join(finalInstallPath, "sentinel.txt")).text()).toBe("keep\n");
+    } finally {
+      server.stop(true);
+    }
+  }, 15_000);
 
   test("installs pinned version by checking out git tag", async () => {
     const repo = await createMockSkillRepo(env.root, {

--- a/test/unit/registry-install.test.ts
+++ b/test/unit/registry-install.test.ts
@@ -1,13 +1,15 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
 import { join } from "path";
-import { writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
 import {
   parsePackageRef,
   formatPackageRef,
   verifyChecksum,
   extractPackage,
   resolveFromRegistry,
+  resolveVerifiedPackage,
   downloadPackage,
   formatQuarantineMessage,
   isQuarantineReasonCode,
@@ -30,6 +32,81 @@ function metafactorySource(token?: string): RegistrySource {
     enabled: true,
     type: "metafactory",
     ...(token ? { token } : {}),
+  };
+}
+
+async function buildPackageTarball(opts: {
+  baseDir: string;
+  name: string;
+  version: string;
+  manifestBody?: string;
+}): Promise<{ bytes: Uint8Array; sha256: string }> {
+  const stageRoot = join(opts.baseDir, `__resolved-fixture-${opts.name}-${opts.version}-${Date.now()}`);
+  const topDir = join(stageRoot, "pkg");
+  await mkdir(join(topDir, "skill"), { recursive: true });
+  await writeFile(join(topDir, "skill", "SKILL.md"), `# ${opts.name}\n`);
+  await writeFile(
+    join(topDir, "arc-manifest.yaml"),
+    opts.manifestBody ?? [
+      `name: ${opts.name}`,
+      `version: ${opts.version}`,
+      "type: skill",
+      "capabilities:",
+      "  filesystem:",
+      "    read: []",
+      "    write: []",
+      "  network: []",
+      "  bash:",
+      "    allowed: false",
+      "  secrets: []",
+      "",
+    ].join("\n"),
+  );
+  const tarPath = join(opts.baseDir, `__resolved-fixture-${opts.name}-${opts.version}.tar.gz`);
+  Bun.spawnSync(["tar", "czf", tarPath, "-C", stageRoot, "pkg"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const buf = await Bun.file(tarPath).arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buf);
+  return { bytes: new Uint8Array(buf), sha256: hasher.digest("hex") };
+}
+
+function metafactoryResolveHandler(opts: {
+  scope: string;
+  name: string;
+  version: string;
+  sha256: string;
+  tarball: Uint8Array;
+}) {
+  return async (input: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.includes("/storage/download/")) {
+      return new Response(opts.tarball as unknown as BodyInit, { status: 200 });
+    }
+    if (/\/packages\/[^/]+\/[^/]+@/.test(url)) {
+      return new Response(JSON.stringify({
+        version: opts.version,
+        sha256: opts.sha256,
+        manifest_canonical: `{"name":"@${opts.scope}/${opts.name}","version":"${opts.version}"}`,
+        signing: { registry_signature: null, registry_key_id: null },
+      }), { status: 200 });
+    }
+    return new Response(JSON.stringify({
+      namespace: `@${opts.scope}`,
+      name: opts.name,
+      display_name: null,
+      description: "",
+      type: "skill",
+      license: "MIT",
+      latest_version: opts.version,
+      versions: [opts.version],
+      publisher: { display_name: "Test", tier: "official", mfa_enabled: true, github_username: null },
+      sponsor: null,
+      created_at: 0,
+      updated_at: 0,
+    }), { status: 200 });
   };
 }
 
@@ -343,6 +420,139 @@ describe("resolveFromRegistry", () => {
         [metafactorySource()],
       );
       expect(result).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVerifiedPackage tests
+// ---------------------------------------------------------------------------
+
+describe("resolveVerifiedPackage", () => {
+  test("returns a Resolved Package with Package Verification Evidence", async () => {
+    const originalFetch = globalThis.fetch;
+    const fixture = await buildPackageTarball({
+      baseDir: env.arc.reposDir,
+      name: "soma",
+      version: "1.2.3",
+    });
+    globalThis.fetch = mockFetch(metafactoryResolveHandler({
+      scope: "metafactory",
+      name: "soma",
+      version: "1.2.3",
+      sha256: fixture.sha256,
+      tarball: fixture.bytes,
+    }));
+
+    try {
+      const result = await resolveVerifiedPackage({
+        ref: { scope: "metafactory", name: "soma" },
+        sources: [metafactorySource()],
+        reposDir: env.arc.reposDir,
+        targetDirName: "metafactory__soma",
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error(result.error);
+
+      expect(result.resolvedPackage.ref).toEqual({
+        scope: "metafactory",
+        name: "soma",
+        version: "1.2.3",
+      });
+      expect(result.resolvedPackage.version).toBe("1.2.3");
+      expect(result.resolvedPackage.repoUrl).toBe("@metafactory/soma@1.2.3");
+      expect(result.resolvedPackage.manifest.name).toBe("soma");
+      expect(result.resolvedPackage.manifestPath).toBe(join(
+        result.resolvedPackage.installPath,
+        "arc-manifest.yaml",
+      ));
+      expect(existsSync(result.resolvedPackage.installPath)).toBe(true);
+
+      const evidence = result.resolvedPackage.packageVerificationEvidence;
+      expect(evidence.checksum).toEqual({
+        status: "verified",
+        expected: fixture.sha256,
+        actual: fixture.sha256,
+      });
+      expect(evidence.registrySignature.status).toBe("missing");
+      expect(evidence.sigstore.status).toBe("missing");
+      expect(evidence.sourceTrust).toEqual({
+        sourceName: "mf-test",
+        sourceTier: "official",
+        sourceType: "metafactory",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("cleans up extracted material when manifest validation fails", async () => {
+    const originalFetch = globalThis.fetch;
+    const targetDirName = "bad-manifest";
+    const fixture = await buildPackageTarball({
+      baseDir: env.arc.reposDir,
+      name: "bad",
+      version: "1.0.0",
+      manifestBody: "name: bad\nversion: 1.0.0\ntype: skill\n",
+    });
+    globalThis.fetch = mockFetch(metafactoryResolveHandler({
+      scope: "metafactory",
+      name: "bad",
+      version: "1.0.0",
+      sha256: fixture.sha256,
+      tarball: fixture.bytes,
+    }));
+
+    try {
+      const result = await resolveVerifiedPackage({
+        ref: { scope: "metafactory", name: "bad" },
+        sources: [metafactorySource()],
+        reposDir: env.arc.reposDir,
+        targetDirName,
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("expected manifest validation to fail");
+      expect(result.error).toContain("Failed to read manifest");
+      expect(result.packageVerificationEvidence?.checksum?.status).toBe("verified");
+      expect(existsSync(join(env.arc.reposDir, targetDirName))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rejects and cleans up when manifest identity differs from registry identity", async () => {
+    const originalFetch = globalThis.fetch;
+    const targetDirName = "wrong-identity";
+    const fixture = await buildPackageTarball({
+      baseDir: env.arc.reposDir,
+      name: "other",
+      version: "9.9.9",
+    });
+    globalThis.fetch = mockFetch(metafactoryResolveHandler({
+      scope: "metafactory",
+      name: "soma",
+      version: "1.2.3",
+      sha256: fixture.sha256,
+      tarball: fixture.bytes,
+    }));
+
+    try {
+      const result = await resolveVerifiedPackage({
+        ref: { scope: "metafactory", name: "soma" },
+        sources: [metafactorySource()],
+        reposDir: env.arc.reposDir,
+        targetDirName,
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("expected manifest identity mismatch to fail");
+      expect(result.error).toContain("Manifest identity mismatch");
+      expect(result.packageVerificationEvidence?.checksum?.status).toBe("verified");
+      expect(existsSync(join(env.arc.reposDir, targetDirName))).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- add Package Verification Evidence vocabulary to CONTEXT.md
- extract registry resolution into resolveVerifiedPackage with manifest and evidence payloads
- wire registry install and registry-backed upgrade through the shared resolver
- add focused resolver tests for evidence and extracted-manifest cleanup

## Verification
- rtk bun test test/unit/registry-install.test.ts
- rtk bun test test/commands/upgrade.test.ts
- rtk bun test test/commands/install.test.ts
- rtk bunx tsc --noEmit
- rtk git diff --check

Unrelated existing dirty worktree files were left unstaged.