### PR TITLE
fix(install): #219 — cross-platform path guard so Windows installs don't false-reject

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -27,7 +27,7 @@ import {
   rollbackArtifactSymlinks,
 } from "../lib/artifact-installer.js";
 import { wireExtensions } from "../lib/extensions.js";
-import { extractRepoName } from "../lib/repo-name.js";
+import { extractRepoName, isInsideRepos, repoNameFromPreExtracted } from "../lib/repo-name.js";
 import { requireBrokerForManifest } from "../lib/nats-broker.js";
 import {
   type HostOverrides,
@@ -108,16 +108,17 @@ export interface InstallResult {
 export async function install(opts: InstallOptions): Promise<InstallResult> {
   const { arc, host, db, repoUrl } = opts;
 
-  // 1. Clone repo (or use pre-extracted path for registry installs)
-  const repoName = opts.preExtractedPath
-    ? opts.preExtractedPath.split("/").pop() ?? extractRepoName(repoUrl)
-    : extractRepoName(repoUrl);
+  // 1. Clone repo (or use pre-extracted path for registry installs).
+  // basename (via repoNameFromPreExtracted) is separator-safe — `split("/")`
+  // returned the whole path on Windows `\`-separated paths (#219).
+  const repoName = repoNameFromPreExtracted(opts.preExtractedPath) ?? extractRepoName(repoUrl);
   const installPath = opts.preExtractedPath ?? join(arc.reposDir, repoName);
 
-  // S2: Path traversal guard — ensure installPath stays inside reposDir
-  const normalizedInstall = join(installPath); // resolves ../ segments
-  const normalizedRepos = join(arc.reposDir);
-  if (!normalizedInstall.startsWith(normalizedRepos + "/") && normalizedInstall !== normalizedRepos) {
+  // S2: Path traversal guard — ensure installPath stays inside reposDir.
+  // Uses a path.relative-based containment check (isInsideRepos) instead of a
+  // separator-naive `startsWith(reposDir + "/")` that false-rejected valid
+  // `\`-separated Windows child paths while still blocking `..` escapes (#219).
+  if (!isInsideRepos(arc.reposDir, installPath)) {
     return {
       success: false,
       error: `Refusing to install: repo name "${repoName}" would escape repos directory`,

--- a/src/lib/repo-name.ts
+++ b/src/lib/repo-name.ts
@@ -1,3 +1,64 @@
+import nodePath from "path";
+
+/**
+ * A subset of the Node `path` API selectable per OS flavor.
+ *
+ * The install path guard must behave correctly on the OS it runs on, but the
+ * platform-default `path` resolves to posix on a macOS/Linux CI — so the
+ * Windows (`\`-separator) behavior would be untestable there. By threading a
+ * `PathFlavor` through the pure helpers below, the install call sites use the
+ * platform default (`nodePath`) while tests can pass `path.win32` / `path.posix`
+ * explicitly to prove cross-platform correctness on any host. See issue #219.
+ */
+export type PathFlavor = Pick<typeof nodePath, "basename" | "relative" | "isAbsolute">;
+
+/**
+ * Containment guard: is `installPath` the repos dir itself, or a path nested
+ * inside it? Uses `path.relative` so a `..`-escape (the relative path starts
+ * with `..`) or an absolute relative path (different drive/root on Windows) is
+ * rejected, while a legitimately nested child is accepted — on every separator
+ * flavor. Replaces the separator-naive `startsWith(reposDir + "/")` check that
+ * false-rejected valid `\`-separated Windows paths (#219).
+ *
+ * @param reposDir    The configured repos directory.
+ * @param installPath The resolved install destination.
+ * @param p           Path flavor (defaults to the platform's `path`).
+ */
+export function isInsideRepos(
+  reposDir: string,
+  installPath: string,
+  p: PathFlavor = nodePath,
+): boolean {
+  const rel = p.relative(reposDir, installPath);
+  // rel === "" → installPath IS reposDir (the boundary case, allowed).
+  // rel starts with ".." → escapes above reposDir.
+  // rel is absolute → unrelated root (e.g. different Windows drive).
+  return rel === "" || (!rel.startsWith("..") && !p.isAbsolute(rel));
+}
+
+/**
+ * Derive the repo (directory) name from a pre-extracted registry install path.
+ *
+ * Uses `path.basename` so it works for both `/`- and `\`-separated paths —
+ * unlike the previous `split("/").pop()`, which returned the WHOLE path on
+ * Windows (the install then echoed the full path as the "repo name" in the
+ * escape error — #219). Returns `undefined` when there is no pre-extracted
+ * path so the caller can fall back to deriving the name from the repo URL.
+ *
+ * @param preExtractedPath The extracted directory path, or undefined.
+ * @param p                Path flavor (defaults to the platform's `path`).
+ */
+export function repoNameFromPreExtracted(
+  preExtractedPath: string | undefined,
+  p: PathFlavor = nodePath,
+): string | undefined {
+  if (!preExtractedPath) return undefined;
+  // Strip a trailing separator so basename doesn't return "" on "…/name/".
+  const trimmed = preExtractedPath.replace(/[/\\]+$/, "");
+  const name = p.basename(trimmed);
+  return name === "" ? undefined : name;
+}
+
 /**
  * Extract a safe directory name from a git repo URL.
  *

--- a/test/unit/install-path-guard.test.ts
+++ b/test/unit/install-path-guard.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import path from "path";
+import { isInsideRepos, repoNameFromPreExtracted } from "../../src/lib/repo-name.js";
+
+/**
+ * Regression coverage for #219 — the cross-platform install path guard.
+ *
+ * The operator cannot test on Windows, so these win32 cases ARE the
+ * verification that the fix works on Windows. They exercise the `\`-separator
+ * (Windows) path via `path.win32` explicitly, independent of the host OS.
+ */
+describe("isInsideRepos — containment guard", () => {
+  describe("win32 (Windows separators)", () => {
+    const reposDir = "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos";
+
+    test("#219 git-URL repro: a valid child path is INSIDE", () => {
+      const installPath = "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos\\soma";
+      expect(isInsideRepos(reposDir, installPath, path.win32)).toBe(true);
+    });
+
+    test("#219 registry repro: a valid scoped child path is INSIDE", () => {
+      const installPath =
+        "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos\\metafactory__soma";
+      expect(isInsideRepos(reposDir, installPath, path.win32)).toBe(true);
+    });
+
+    test("a `..`-escape attempt is NOT inside (escape protection intact)", () => {
+      const installPath =
+        "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos\\..\\evil";
+      expect(isInsideRepos(reposDir, installPath, path.win32)).toBe(false);
+    });
+
+    test("the repos dir itself is inside (boundary)", () => {
+      expect(isInsideRepos(reposDir, reposDir, path.win32)).toBe(true);
+    });
+
+    test("a sibling directory sharing a prefix is NOT inside", () => {
+      // `repos-evil` shares the `repos` text prefix but is not a child of `repos`.
+      const installPath = "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos-evil\\soma";
+      expect(isInsideRepos(reposDir, installPath, path.win32)).toBe(false);
+    });
+  });
+
+  describe("posix (forward-slash separators — no regression)", () => {
+    const reposDir = "/home/klittle/.config/metafactory/pkg/repos";
+
+    test("a valid nested child path is INSIDE", () => {
+      expect(isInsideRepos(reposDir, `${reposDir}/soma`, path.posix)).toBe(true);
+    });
+
+    test("a `..`-escape attempt is NOT inside", () => {
+      expect(isInsideRepos(reposDir, `${reposDir}/../evil`, path.posix)).toBe(false);
+    });
+
+    test("the repos dir itself is inside (boundary)", () => {
+      expect(isInsideRepos(reposDir, reposDir, path.posix)).toBe(true);
+    });
+
+    test("a sibling directory sharing a prefix is NOT inside", () => {
+      expect(isInsideRepos(reposDir, `${reposDir}-evil/soma`, path.posix)).toBe(false);
+    });
+  });
+});
+
+describe("repoNameFromPreExtracted — repo-name extraction", () => {
+  test("win32: returns the basename, not the whole path (#219 registry repro)", () => {
+    const preExtracted =
+      "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos\\metafactory__soma";
+    expect(repoNameFromPreExtracted(preExtracted, path.win32)).toBe("metafactory__soma");
+  });
+
+  test("posix: returns the basename", () => {
+    expect(
+      repoNameFromPreExtracted("/home/klittle/.config/metafactory/pkg/repos/soma", path.posix),
+    ).toBe("soma");
+  });
+
+  test("win32: trailing separator does not yield an empty name", () => {
+    const preExtracted =
+      "C:\\Users\\klittle\\.config\\metafactory\\pkg\\repos\\metafactory__soma\\";
+    expect(repoNameFromPreExtracted(preExtracted, path.win32)).toBe("metafactory__soma");
+  });
+
+  test("undefined pre-extracted path yields undefined (caller falls back)", () => {
+    expect(repoNameFromPreExtracted(undefined, path.win32)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #219 — two separator-naive bugs in the `arc install` path guard (`src/commands/install.ts`) that broke **every** `arc install` on Windows. macOS/Linux were unaffected, which is why it went unnoticed.

| Line | Bug | Effect on Windows |
|------|-----|-------------------|
| L113 | `opts.preExtractedPath.split("/").pop()` — `split("/")` doesn't split on `\` | `.pop()` returned the **whole** path, so the registry error echoed the full path as the "repo name" |
| L120 | `normalizedInstall.startsWith(normalizedRepos + "/")` — hardcoded `/` | `join()` returns `\`-separated paths on Windows, so a valid child (`C:\…\repos\soma`) never matched the `/`-suffixed prefix → rejected with `Refusing to install: repo name "…" would escape repos directory` |

## The fix

Refactor the containment + repo-name logic out of the install path into two **pure helpers** in `src/lib/repo-name.ts`, each accepting a *path flavor* (a `Pick` of the Node `path` API):

- `isInsideRepos(reposDir, installPath, p = path)` — replaces the `startsWith` prefix check with a `path.relative`-based containment check. `inside` ⇔ `rel === "" || (!rel.startsWith("..") && !p.isAbsolute(rel))`. This keeps the `..`-escape protection cross-platform while accepting valid nested paths, and additionally blocks cross-drive Windows paths (relative across roots is absolute).
- `repoNameFromPreExtracted(preExtractedPath, p = path)` — replaces `split("/").pop()` with `p.basename(...)` (separator-safe on both flavors), trims a trailing separator, and returns `undefined` so the caller falls back to `extractRepoName(repoUrl)`.

The install call sites pass the **platform default** `path`, so posix behavior is byte-for-byte identical (the full 662-test unit suite is green, including 4 new posix guard cases — no regression).

## Why this is verifiable without a Windows machine

The operator **cannot test on Windows**, so the cross-platform unit tests ARE the verification. On a macOS/Linux host the platform-default `path` resolves to posix, so a naive test can't prove the Windows behavior. By threading a `PathFlavor` through the pure helpers, the new test file (`test/unit/install-path-guard.test.ts`) calls them with **both `path.win32` and `path.posix`**, genuinely exercising the `\`-separator path on this macOS host.

The win32 assertions (all passing on macOS CI):

1. **win32** valid child `C:\…\repos\soma` → inside (the #219 git-URL repro now passes)
2. **win32** scoped child `C:\…\repos\metafactory__soma` → inside (the #219 registry repro)
3. **win32** `..`-escape `C:\…\repos\..\evil` → NOT inside (escape protection intact on Windows)
4. **win32** sibling-prefix `…\repos-evil\soma` → NOT inside (no false-prefix match)
5. **win32** repo-name `C:\…\repos\metafactory__soma` → `"metafactory__soma"` (not the whole path — fixes the registry-error repro)
6. **posix** valid nested → inside; `..`-escape → NOT inside; repo-name `/…/repos/soma` → `"soma"` (no regression)
7. Boundary: install path === repos dir → inside

## Acceptance criteria (from #219)

- [x] `arc install @metafactory/soma` resolves under reposDir → install proceeds on Windows (registry repro now passes the guard)
- [x] `arc install <git-url>` resolves under reposDir → install proceeds on Windows
- [x] `..`-escape attempts still blocked on **all** platforms
- [x] Unit tests added for Windows path separators in install path validation

## Verification

- `bunx tsc --noEmit` → 0 errors
- `bunx eslint` on touched files → clean
- `bun test test/unit/` → 662 pass, 0 fail (includes the 13 new cross-platform guard cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
