### PR TITLE
fix: derive repo name from Windows local paths so installs don't false-reject

### DIFF
--- a/src/lib/repo-name.ts
+++ b/src/lib/repo-name.ts
@@ -60,18 +60,38 @@ export function repoNameFromPreExtracted(
 }
 
 /**
- * Extract a safe directory name from a git repo URL.
+ * Does `url` denote a local filesystem path rather than a remote git URL?
  *
- * Handles local paths, SSH URLs, and HTTPS URLs.
- * Rejects names containing path traversal characters.
+ * Covers POSIX absolute (`/repo`), relative (`./repo`, `..\repo`), and — via
+ * the path flavor's `isAbsolute` — Windows absolute paths (`C:\repo`, `\\unc`).
+ * Remote forms (`https://…`, `git@host:…`) are not absolute under either flavor
+ * and don't start with `/` or `.`, so they fall through to URL parsing (even on
+ * win32, where `isAbsolute("https://…")`/`isAbsolute("git@…")` are both false).
  */
-export function extractRepoName(url: string): string {
+function isLocalPath(url: string, p: PathFlavor): boolean {
+  return url.startsWith("/") || url.startsWith(".") || p.isAbsolute(url);
+}
+
+/**
+ * Extract a safe directory name from a git repo URL or local path.
+ *
+ * Handles local paths, SSH URLs, and HTTPS URLs. Rejects names containing path
+ * traversal characters.
+ *
+ * Takes an injectable path flavor (defaults to the platform's `path`) so the
+ * Windows `\`-separator behavior is testable on a posix CI host — mirroring
+ * {@link isInsideRepos} / {@link repoNameFromPreExtracted}. A #219 follow-on:
+ * that fix made the registry / pre-extracted path separator-safe, but this
+ * URL-derived path still used `split("/")`, which returned the WHOLE string for
+ * a `\`-separated Windows local path (e.g. `C:\…\repo`) — it never matched the
+ * `/`-only local-path test, fell through to URL parsing, and then tripped the
+ * traversal guard below. `basename` is separator-aware for the active flavor.
+ */
+export function extractRepoName(url: string, p: PathFlavor = nodePath): string {
   let name: string;
 
-  // Local path
-  if (url.startsWith("/") || url.startsWith(".")) {
-    const parts = url.split("/").filter(Boolean);
-    name = parts[parts.length - 1].replace(/\.git$/, "");
+  if (isLocalPath(url, p)) {
+    name = p.basename(url).replace(/\.git$/, "");
   }
   // SSH: git@github.com:user/repo.git
   else {

--- a/test/unit/install-path-guard.test.ts
+++ b/test/unit/install-path-guard.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect } from "bun:test";
 import path from "path";
-import { isInsideRepos, repoNameFromPreExtracted } from "../../src/lib/repo-name.js";
+import {
+  isInsideRepos,
+  repoNameFromPreExtracted,
+  extractRepoName,
+} from "../../src/lib/repo-name.js";
 
 /**
  * Regression coverage for #219 — the cross-platform install path guard.
@@ -83,5 +87,67 @@ describe("repoNameFromPreExtracted — repo-name extraction", () => {
 
   test("undefined pre-extracted path yields undefined (caller falls back)", () => {
     expect(repoNameFromPreExtracted(undefined, path.win32)).toBeUndefined();
+  });
+});
+
+/**
+ * #219 follow-on: extractRepoName derives the name from the repo URL / local
+ * path. The original `split("/")` returned the whole string for a Windows
+ * `\`-separated local path, which then tripped the traversal guard — so
+ * `arc install C:\path\to\repo` (and every command/e2e test that installs from
+ * a local mock-repo path) failed on Windows. These win32 cases ARE the
+ * Windows verification; the remote-URL cases prove the fix didn't regress URL
+ * parsing on win32.
+ */
+describe("extractRepoName — URL / local-path → safe name", () => {
+  describe("win32 local paths (the bug)", () => {
+    test("absolute Windows path returns the basename, not the whole path", () => {
+      const url = "C:\\Users\\klittle\\AppData\\Local\\Temp\\arc-xyz\\mock-soma";
+      expect(extractRepoName(url, path.win32)).toBe("mock-soma");
+    });
+
+    test("strips a trailing .git suffix", () => {
+      expect(extractRepoName("C:\\dev\\soma.git", path.win32)).toBe("soma");
+    });
+
+    test("relative Windows path (.\\repo)", () => {
+      expect(extractRepoName(".\\my-skill", path.win32)).toBe("my-skill");
+    });
+
+    test("UNC path returns the basename", () => {
+      expect(extractRepoName("\\\\server\\share\\repo", path.win32)).toBe("repo");
+    });
+
+    test("traversal guard still fires for a `..` basename", () => {
+      expect(() => extractRepoName("C:\\repos\\..", path.win32)).toThrow();
+    });
+  });
+
+  describe("win32 remote URLs (must still parse — no regression)", () => {
+    test("HTTPS URL", () => {
+      expect(extractRepoName("https://github.com/user/repo.git", path.win32)).toBe("repo");
+    });
+
+    test("SSH URL", () => {
+      expect(extractRepoName("git@github.com:user/repo.git", path.win32)).toBe("repo");
+    });
+  });
+
+  describe("posix (unchanged behavior)", () => {
+    test("absolute local path", () => {
+      expect(extractRepoName("/home/klittle/dev/soma", path.posix)).toBe("soma");
+    });
+
+    test("relative local path", () => {
+      expect(extractRepoName("./my-skill", path.posix)).toBe("my-skill");
+    });
+
+    test("HTTPS URL", () => {
+      expect(extractRepoName("https://github.com/user/repo.git", path.posix)).toBe("repo");
+    });
+
+    test("SSH URL", () => {
+      expect(extractRepoName("git@github.com:user/repo.git", path.posix)).toBe("repo");
+    });
   });
 });

--- a/test/unit/install-path-guard.test.ts
+++ b/test/unit/install-path-guard.test.ts
@@ -131,6 +131,10 @@ describe("extractRepoName — URL / local-path → safe name", () => {
     test("SSH URL", () => {
       expect(extractRepoName("git@github.com:user/repo.git", path.win32)).toBe("repo");
     });
+
+    test("HTTPS URL without a .git suffix", () => {
+      expect(extractRepoName("https://github.com/user/repo", path.win32)).toBe("repo");
+    });
   });
 
   describe("posix (unchanged behavior)", () => {
@@ -148,6 +152,10 @@ describe("extractRepoName — URL / local-path → safe name", () => {
 
     test("SSH URL", () => {
       expect(extractRepoName("git@github.com:user/repo.git", path.posix)).toBe("repo");
+    });
+
+    test("HTTPS URL without a .git suffix", () => {
+      expect(extractRepoName("https://github.com/user/repo", path.posix)).toBe("repo");
     });
   });
 });


### PR DESCRIPTION
## Problem

On Windows, `arc install <local-path>` false-rejects an absolute or backslash-separated path (e.g. `C:\dev\my-skill`) as an "unsafe repo name", and the command/e2e test suite can't run on Windows for the same reason (the harness installs from local mock-repo paths).

Closes #221.

## Root cause

`extractRepoName` (`src/lib/repo-name.ts`) detected local paths only via `startsWith("/") || startsWith(".")` and extracted the name with `split("/")`. A Windows absolute path `C:\...\repo` matched neither local branch, fell through to URL parsing, and `split("/")` (no forward slashes) returned the whole path as the "name" — tripping the traversal guard.

## Fix

- Detect local paths with `path.isAbsolute` (covers `C:\...` and `\\UNC`) in addition to `/` and `.`.
- Extract with separator-aware `path.basename` instead of `split("/")`.
- `extractRepoName` takes an injectable `PathFlavor` (defaults to the platform's `path`), mirroring the #219/#220 sibling helpers (`isInsideRepos`, `repoNameFromPreExtracted`) so the win32 behavior is unit-tested on a posix CI host.

The path-traversal guard and SSH/HTTPS URL parsing are unchanged. This is a follow-on to #220, which made the registry / pre-extracted path separator-safe but left this URL/local-path branch.

## Safety

- No weakening of the guard: `name` is still a pure basename, re-rooted via `join(reposDir, name)` and backstopped by `isInsideRepos`. Adversarial inputs (`C:\evil\..\..\repo`, `.\..\evil`, `..`) still resolve to a guard-throw or a contained child.
- POSIX behavior is unchanged.

## Tests

`test/unit/install-path-guard.test.ts` (+13), following the file's existing `path.win32` / `path.posix` pattern:

- win32 local: absolute path -> basename, `.git` strip, relative (`.\repo`), UNC, and `..` still throws.
- win32 remote regression (must still parse): HTTPS, SSH, and HTTPS without a `.git` suffix.
- posix unchanged: absolute, relative, HTTPS, SSH, HTTPS without `.git`.

`bun run lint:errors` and `bunx tsc --noEmit` are clean.

---

<details><summary>Suggested CHANGELOG entry (for the maintainer to place at release)</summary>

- **`arc install` of a local path no longer false-rejects on Windows** (closes #221). `extractRepoName` detected local paths only by a `/`-prefix and split on `/`, so a `\`-separated Windows path (`C:\…\repo`) returned the whole path as the name and tripped the traversal guard. It now detects local paths via `path.isAbsolute` and extracts with `path.basename`, with an injectable `PathFlavor` so the win32 branch is unit-tested on posix CI. A follow-on to #220.
</details>
