### PR TITLE
fix: Windows CLI shims are .cmd launchers, not bash scripts

### DIFF
--- a/src/lib/symlinks.ts
+++ b/src/lib/symlinks.ts
@@ -158,9 +158,11 @@ function shimFileName(binName: string, platform: string): string {
  * can't run the bash shim because PATHEXT has no entry for extensionless files.
  *
  * For bun commands (`command` starts with `bun `) the shim runs `bun run
- * <script>`. Non-bun commands are exec'd directly; on Windows this is
- * best-effort (`<command> %*`), since arbitrary POSIX entrypoints (e.g. a
- * `.sh`) aren't natively runnable there — but nearly all arc CLIs are bun.
+ * <script>`. Non-bun commands are invoked explicitly relative to the bin dir
+ * on both platforms (`./` / `.\`), never via PATH lookup — a bare name would
+ * let a same-named program elsewhere on PATH shadow the installed one. On
+ * Windows this is still best-effort, since arbitrary POSIX entrypoints (e.g.
+ * a `.sh`) aren't natively runnable there — but nearly all arc CLIs are bun.
  */
 function buildShimContent(
   info: { scriptPath: string; command: string },
@@ -170,7 +172,9 @@ function buildShimContent(
   const isBunCommand = info.command.startsWith("bun ");
 
   if (platform === "win32") {
-    const invoke = isBunCommand ? `bun run ${info.scriptPath}` : info.command;
+    const invoke = isBunCommand
+      ? `bun run ${info.scriptPath}`
+      : `.\\${info.command}`;
     return `@echo off\r\nsetlocal\r\ncd /d "${binPath}" || exit /b 1\r\n${invoke} %*\r\n`;
   }
 
@@ -227,9 +231,9 @@ export async function removeCliShim(
   binName: string,
   platform: string = process.platform
 ): Promise<boolean> {
-  // win32: the current `.cmd` shim plus any pre-fix extensionless shim.
-  const candidates =
-    platform === "win32" ? [`${binName}.cmd`, binName] : [binName];
+  const candidates = [shimFileName(binName, platform)];
+  // win32: also sweep a pre-fix extensionless shim left by older arc versions.
+  if (platform === "win32") candidates.push(binName);
 
   let removed = false;
   for (const name of candidates) {

--- a/src/lib/symlinks.ts
+++ b/src/lib/symlinks.ts
@@ -141,14 +141,59 @@ export function extractAllCliInfo(
 }
 
 /**
- * Create PATH-accessible bash shims for all CLI entries in a manifest.
- * For bun commands: cd into bin dir and exec bun run.
- * For non-bun commands: exec the script directly from the bin dir.
+ * Filesystem name of a CLI shim. On Windows, PATH execution is driven by file
+ * extension (PATHEXT) — an extensionless `#!/bin/bash` script is not runnable —
+ * so shims get a `.cmd` suffix there. POSIX shims stay extensionless.
+ */
+function shimFileName(binName: string, platform: string): string {
+  return platform === "win32" ? `${binName}.cmd` : binName;
+}
+
+/**
+ * Build the contents of a CLI shim for the target platform.
+ *
+ * POSIX: a `#!/bin/bash` script that `cd`s into the bin dir and execs the CLI.
+ * Windows: a `.cmd` launcher that does the same with `cd /d` (so it follows the
+ * bin symlink and switches drive if needed) and forwards args via `%*`. cmd.exe
+ * can't run the bash shim because PATHEXT has no entry for extensionless files.
+ *
+ * For bun commands (`command` starts with `bun `) the shim runs `bun run
+ * <script>`. Non-bun commands are exec'd directly; on Windows this is
+ * best-effort (`<command> %*`), since arbitrary POSIX entrypoints (e.g. a
+ * `.sh`) aren't natively runnable there — but nearly all arc CLIs are bun.
+ */
+function buildShimContent(
+  info: { scriptPath: string; command: string },
+  binPath: string,
+  platform: string
+): string {
+  const isBunCommand = info.command.startsWith("bun ");
+
+  if (platform === "win32") {
+    const invoke = isBunCommand ? `bun run ${info.scriptPath}` : info.command;
+    return `@echo off\r\nsetlocal\r\ncd /d "${binPath}" || exit /b 1\r\n${invoke} %*\r\n`;
+  }
+
+  const invoke = isBunCommand
+    ? `exec bun run ${info.scriptPath}`
+    : `exec ./${info.command}`;
+  return `#!/bin/bash\ncd "${binPath}" && ${invoke} "$@"\n`;
+}
+
+/**
+ * Create PATH-accessible shims for all CLI entries in a manifest.
+ *
+ * The shim flavor follows `platform` (defaults to the host, overridable for
+ * tests — mirrors `detectPlatform` in cosign.ts): a `#!/bin/bash` script on
+ * POSIX, a `.cmd` launcher on Windows. Returns the logical bin names created
+ * (not the on-disk filenames), which is what the DB and {@link removeCliShim}
+ * key on.
  */
 export async function createCliShim(
   shimDir: string,
   binDir: string,
-  manifest: ArcManifest
+  manifest: ArcManifest,
+  platform: string = process.platform
 ): Promise<string[]> {
   const entries = extractAllCliInfo(manifest);
   if (!entries.length) return [];
@@ -157,15 +202,12 @@ export async function createCliShim(
 
   const created: string[] = [];
   for (const info of entries) {
-    const shimPath = join(shimDir, info.binName);
+    const shimPath = join(shimDir, shimFileName(info.binName, platform));
     const binPath = join(binDir, info.binName);
 
-    const isBunCommand = info.command.startsWith("bun ");
-    const content = isBunCommand
-      ? `#!/bin/bash\ncd "${binPath}" && exec bun run ${info.scriptPath} "$@"\n`
-      : `#!/bin/bash\ncd "${binPath}" && exec ./${info.command} "$@"\n`;
-
-    await writeFile(shimPath, content, { mode: 0o755 });
+    await writeFile(shimPath, buildShimContent(info, binPath, platform), {
+      mode: 0o755,
+    });
     created.push(info.binName);
   }
 
@@ -174,17 +216,30 @@ export async function createCliShim(
 
 /**
  * Remove a CLI shim from the shim directory.
+ *
+ * Removes the platform-native shim (`<bin>.cmd` on Windows, `<bin>` on POSIX).
+ * On Windows it also sweeps a legacy extensionless shim left by older arc
+ * versions, so `arc remove` never orphans the broken bash file. Returns true if
+ * any shim was removed.
  */
 export async function removeCliShim(
   shimDir: string,
-  binName: string
+  binName: string,
+  platform: string = process.platform
 ): Promise<boolean> {
-  const shimPath = join(shimDir, binName);
-  try {
-    await unlink(shimPath);
-    return true;
-  } catch (err) {
-    if (isErrno(err) && err.code === "ENOENT") return false;
-    throw err;
+  // win32: the current `.cmd` shim plus any pre-fix extensionless shim.
+  const candidates =
+    platform === "win32" ? [`${binName}.cmd`, binName] : [binName];
+
+  let removed = false;
+  for (const name of candidates) {
+    try {
+      await unlink(join(shimDir, name));
+      removed = true;
+    } catch (err) {
+      if (isErrno(err) && err.code === "ENOENT") continue;
+      throw err;
+    }
   }
+  return removed;
 }

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -505,7 +505,7 @@ describe("Full lifecycle: install → list → info → audit → disable → en
       join(env.arc.shimDir, shim("multi-alt")),
     ).text();
     if (process.platform === "win32") {
-      expect(altShimContent).toContain("bin/multi-alt %*");
+      expect(altShimContent).toContain(".\\bin/multi-alt %*");
     } else {
       expect(altShimContent).toContain("exec ./bin/multi-alt");
     }

--- a/test/e2e/lifecycle.test.ts
+++ b/test/e2e/lifecycle.test.ts
@@ -487,21 +487,34 @@ describe("Full lifecycle: install → list → info → audit → disable → en
 
     expect(result.success).toBe(true);
 
+    // Shim filenames are platform-specific: `.cmd` on Windows (PATHEXT-driven
+    // execution), bare on POSIX. Bin symlinks stay extensionless on both.
+    const shim = (n: string): string =>
+      process.platform === "win32" ? `${n}.cmd` : n;
+
     // Both bin symlinks exist
     expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(true);
     expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(true);
 
     // Both shims exist
-    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, shim("multitool")))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, shim("multi-alt")))).toBe(true);
 
-    // Second shim uses direct exec (not bun) for non-bun command
-    const altShimContent = await Bun.file(join(env.arc.shimDir, "multi-alt")).text();
-    expect(altShimContent).toContain("exec ./bin/multi-alt");
+    // Second shim invokes the script directly (not bun) for a non-bun command
+    const altShimContent = await Bun.file(
+      join(env.arc.shimDir, shim("multi-alt")),
+    ).text();
+    if (process.platform === "win32") {
+      expect(altShimContent).toContain("bin/multi-alt %*");
+    } else {
+      expect(altShimContent).toContain("exec ./bin/multi-alt");
+    }
     expect(altShimContent).not.toContain("bun run");
 
     // First shim uses bun run
-    const mainShimContent = await Bun.file(join(env.arc.shimDir, "multitool")).text();
+    const mainShimContent = await Bun.file(
+      join(env.arc.shimDir, shim("multitool")),
+    ).text();
     expect(mainShimContent).toContain("bun run");
 
     // --- DISABLE removes all ---
@@ -509,23 +522,23 @@ describe("Full lifecycle: install → list → info → audit → disable → en
     expect(disableResult.success).toBe(true);
     expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(false);
     expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(false);
-    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, shim("multitool")))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, shim("multi-alt")))).toBe(false);
 
     // --- ENABLE restores all ---
     const enableResult = await enable(env.db, env.arc, env.host, "multitool");
     expect(enableResult.success).toBe(true);
     expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(true);
     expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(true);
-    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(true);
-    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, shim("multitool")))).toBe(true);
+    expect(existsSync(join(env.arc.shimDir, shim("multi-alt")))).toBe(true);
 
     // --- REMOVE cleans up all ---
     const removeResult = await remove(env.db, env.arc, env.host, "multitool");
     expect(removeResult.success).toBe(true);
     expect(existsSync(join(env.host.paths.binDir, "multitool"))).toBe(false);
     expect(existsSync(join(env.host.paths.binDir, "multi-alt"))).toBe(false);
-    expect(existsSync(join(env.arc.shimDir, "multitool"))).toBe(false);
-    expect(existsSync(join(env.arc.shimDir, "multi-alt"))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, shim("multitool")))).toBe(false);
+    expect(existsSync(join(env.arc.shimDir, shim("multi-alt")))).toBe(false);
   });
 });

--- a/test/unit/symlinks.test.ts
+++ b/test/unit/symlinks.test.ts
@@ -3,7 +3,18 @@ import { mkdir, writeFile, rm, lstat, readlink } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { createSymlink, removeSymlink, SymlinkConflictError } from "../../src/lib/symlinks.js";
+import {
+  createSymlink,
+  removeSymlink,
+  SymlinkConflictError,
+  createCliShim,
+  removeCliShim,
+} from "../../src/lib/symlinks.js";
+import type { ArcManifest } from "../../src/types.js";
+
+function cliManifest(cli: { command: string; name?: string }[]): ArcManifest {
+  return { name: "soma", version: "1.0.0", type: "tool", provides: { cli } };
+}
 
 let root: string;
 
@@ -113,5 +124,119 @@ describe("removeSymlink", () => {
 
     expect(removed).toBe(false);
     expect(existsSync(file)).toBe(true);
+  });
+});
+
+describe("createCliShim", () => {
+  test("POSIX: writes an extensionless #!/bin/bash shim", async () => {
+    const shimDir = join(root, "shim");
+    const binDir = join(root, "bin");
+
+    const created = await createCliShim(
+      shimDir,
+      binDir,
+      cliManifest([{ name: "soma", command: "bun src/cli.ts" }]),
+      "linux",
+    );
+
+    expect(created).toEqual(["soma"]);
+    const shimPath = join(shimDir, "soma");
+    expect(existsSync(shimPath)).toBe(true);
+    expect(existsSync(join(shimDir, "soma.cmd"))).toBe(false);
+
+    const content = await Bun.file(shimPath).text();
+    expect(content.startsWith("#!/bin/bash")).toBe(true);
+    expect(content).toContain(`cd "${join(binDir, "soma")}"`);
+    expect(content).toContain('exec bun run src/cli.ts "$@"');
+  });
+
+  test("Windows: writes a .cmd launcher, not a bash shim", async () => {
+    const shimDir = join(root, "shim");
+    const binDir = join(root, "bin");
+
+    const created = await createCliShim(
+      shimDir,
+      binDir,
+      cliManifest([{ name: "soma", command: "bun src/cli.ts" }]),
+      "win32",
+    );
+
+    // Returns the logical bin name, not the on-disk filename.
+    expect(created).toEqual(["soma"]);
+    const cmdPath = join(shimDir, "soma.cmd");
+    expect(existsSync(cmdPath)).toBe(true);
+    // No extensionless shim — that's the bug being fixed (Windows can't run it).
+    expect(existsSync(join(shimDir, "soma"))).toBe(false);
+
+    const content = await Bun.file(cmdPath).text();
+    expect(content.startsWith("@echo off")).toBe(true);
+    expect(content).toContain("setlocal");
+    expect(content).toContain(`cd /d "${join(binDir, "soma")}"`);
+    expect(content).toContain("bun run src/cli.ts %*");
+    expect(content).not.toContain("#!/bin/bash");
+  });
+
+  test("non-bun command: exec'd directly per platform", async () => {
+    const shimDir = join(root, "shim");
+    const binDir = join(root, "bin");
+    const manifest = cliManifest([{ name: "tool", command: "run.sh" }]);
+
+    await createCliShim(shimDir, binDir, manifest, "linux");
+    expect(await Bun.file(join(shimDir, "tool")).text()).toContain(
+      'exec ./run.sh "$@"',
+    );
+
+    await createCliShim(shimDir, binDir, manifest, "win32");
+    expect(await Bun.file(join(shimDir, "tool.cmd")).text()).toContain(
+      "run.sh %*",
+    );
+  });
+
+  test("no CLI entries: creates nothing and returns []", async () => {
+    const shimDir = join(root, "shim");
+
+    const created = await createCliShim(
+      shimDir,
+      join(root, "bin"),
+      cliManifest([]),
+      "win32",
+    );
+
+    expect(created).toEqual([]);
+    expect(existsSync(shimDir)).toBe(false);
+  });
+});
+
+describe("removeCliShim", () => {
+  test("POSIX: removes the extensionless shim", async () => {
+    const shimDir = join(root, "shim");
+    await mkdir(shimDir, { recursive: true });
+    await writeFile(join(shimDir, "soma"), "#!/bin/bash\n");
+
+    expect(await removeCliShim(shimDir, "soma", "linux")).toBe(true);
+    expect(existsSync(join(shimDir, "soma"))).toBe(false);
+  });
+
+  test("Windows: removes the .cmd shim", async () => {
+    const shimDir = join(root, "shim");
+    await mkdir(shimDir, { recursive: true });
+    await writeFile(join(shimDir, "soma.cmd"), "@echo off\n");
+
+    expect(await removeCliShim(shimDir, "soma", "win32")).toBe(true);
+    expect(existsSync(join(shimDir, "soma.cmd"))).toBe(false);
+  });
+
+  test("Windows: also sweeps a legacy extensionless shim", async () => {
+    const shimDir = join(root, "shim");
+    await mkdir(shimDir, { recursive: true });
+    // Simulates a shim written by a pre-fix arc, with no matching .cmd.
+    await writeFile(join(shimDir, "soma"), "#!/bin/bash\n");
+
+    expect(await removeCliShim(shimDir, "soma", "win32")).toBe(true);
+    expect(existsSync(join(shimDir, "soma"))).toBe(false);
+  });
+
+  test("returns false when no shim exists", async () => {
+    expect(await removeCliShim(join(root, "shim"), "soma", "win32")).toBe(false);
   });
 });

--- a/test/unit/symlinks.test.ts
+++ b/test/unit/symlinks.test.ts
@@ -176,7 +176,7 @@ describe("createCliShim", () => {
     expect(content).not.toContain("#!/bin/bash");
   });
 
-  test("non-bun command: exec'd directly per platform", async () => {
+  test("non-bun command: invoked relative to the bin dir on both platforms", async () => {
     const shimDir = join(root, "shim");
     const binDir = join(root, "bin");
     const manifest = cliManifest([{ name: "tool", command: "run.sh" }]);
@@ -186,9 +186,12 @@ describe("createCliShim", () => {
       'exec ./run.sh "$@"',
     );
 
+    // Pin the full invocation line: `.\` keeps resolution inside the bin dir.
+    // A bare `run.sh %*` would let cmd.exe resolve a same-named program
+    // elsewhere on PATH instead of the installed one.
     await createCliShim(shimDir, binDir, manifest, "win32");
     expect(await Bun.file(join(shimDir, "tool.cmd")).text()).toContain(
-      "run.sh %*",
+      "\r\n.\\run.sh %*\r\n",
     );
   });
 


### PR DESCRIPTION
## Problem

On Windows, `arc install` of a CLI/tool writes an extensionless `#!/bin/bash` shim to the PATH shim dir. Windows can't execute it (`PATHEXT` has no entry for extensionless files), so the installed command is on PATH but won't run — e.g. `arc install @metafactory/soma` leaves `soma` unrunnable.

Closes #223.

## Fix

- `createCliShim` emits a `.cmd` launcher on Windows (`@echo off` / `setlocal` / `cd /d` into the bin symlink / forward args via `%*`) and keeps the bash shim on POSIX.
- `createCliShim` / `removeCliShim` take an injectable `platform` (defaults to `process.platform`), mirroring `detectPlatform` in `cosign.ts`, so both branches are unit-tested on any host.
- `removeCliShim` on Windows also sweeps a legacy extensionless shim, so `arc remove` doesn't orphan shims written by older arc versions.

POSIX behavior is byte-for-byte unchanged (the win32 branch is purely additive).

## Tests

- `test/unit/symlinks.test.ts` (+8): both OS branches of create + remove, including the legacy-shim sweep.
- `test/e2e/lifecycle.test.ts`: the multi-CLI lifecycle test is now platform-aware (asserts `.cmd` on win32, bash on POSIX).

`bun run lint:errors` and `bunx tsc --noEmit` are clean.

## Validated end-to-end on Windows

Built this branch, re-pointed the local `arc` to it, then ran a real round-trip: `arc remove @metafactory/soma` swept the old shims (both the `.cmd` and a legacy bash `soma`), `arc install @metafactory/soma` created `~/.local/bin/soma.cmd`, and `soma --version` ran (`soma 0.8.5`).

---

<details><summary>Suggested CHANGELOG entry (for the maintainer to place at release)</summary>

- **Windows CLI shims are now `.cmd` launchers, not bash scripts** (closes #223). `createCliShim` emitted one extensionless `#!/bin/bash` shim on every platform; Windows can't execute it (no `PATHEXT` entry for extensionless files), so an installed tool's command was on PATH but unrunnable. It now emits a `.cmd` launcher on win32 (bash on POSIX), via an injectable `platform` so both branches are unit-tested on any host. `removeCliShim` also sweeps a legacy extensionless shim on Windows.
</details>
