### PR TITLE
fix: detect shim dir on PATH using the platform delimiter, not hard-coded ':'

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
-import { createArcPaths, ensureDirectories, getDefaultHost } from "./lib/paths.js";
+import { createArcPaths, ensureDirectories, getDefaultHost, isDirOnPath } from "./lib/paths.js";
 import { openDatabase, getSkill } from "./lib/db.js";
 import { extractAllCliInfo, SymlinkConflictError } from "./lib/symlinks.js";
 import { install, parseNameVersion } from "./commands/install.js";
@@ -113,11 +113,6 @@ function createInstallPaths(opts: { binDir?: string }): ReturnType<typeof create
   );
 }
 
-function shimDirIsOnPath(shimDir: string, pathEnv = process.env.PATH ?? ""): boolean {
-  const entries = pathEnv.split(":").filter(Boolean).map((entry) => normalizeUserPath(entry));
-  return entries.includes(normalizeUserPath(shimDir));
-}
-
 function quoteForSingleQuotedShell(value: string): string {
   return value.replace(/'/g, "'\\''");
 }
@@ -147,7 +142,7 @@ function installResultProvidesCli(result: Awaited<ReturnType<typeof install>>): 
 }
 
 function printShimPathNotice(paths: ReturnType<typeof createArcPaths>, result: Awaited<ReturnType<typeof install>>): void {
-  if (!installResultProvidesCli(result) || shimDirIsOnPath(paths.shimDir)) return;
+  if (!installResultProvidesCli(result) || isDirOnPath(paths.shimDir)) return;
 
   console.log(`\nCommand shims were installed in ${paths.shimDir}, but that directory is not on PATH.`);
   console.log(`Add it with: ${formatPathRepairCommand(paths.shimDir)}`);
@@ -639,7 +634,7 @@ doctor
   .description("Check whether Arc command shims are on PATH")
   .action(() => {
     const paths = createArcPaths();
-    if (shimDirIsOnPath(paths.shimDir)) {
+    if (isDirOnPath(paths.shimDir)) {
       console.log(`OK: ${paths.shimDir} is on PATH`);
       return;
     }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,4 +1,4 @@
-import { join, dirname, delimiter as pathDelimiter } from "path";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { existsSync, renameSync } from "fs";
 import { mkdir } from "fs/promises";
@@ -54,39 +54,55 @@ function resolveConfigRoot(override?: string): string {
 }
 
 /**
- * Is `dir` present on a PATH-style string? Splits on the platform's PATH
- * delimiter — `;` on Windows, `:` on POSIX — which is injectable (defaults to
- * `path.delimiter`) so the Windows behavior is testable on a POSIX CI host.
- * The previous hard-coded `:` split mangled Windows `PATH` entries: it uses
- * `;`, and each entry's `C:\...` drive letter contains a `:`, so a `:`-split
- * shredded every path. Entries and `dir` are home-expanded and
- * trailing-separator-normalized so equivalent spellings compare equal.
+ * Comparison key for a PATH entry or candidate dir, after home expansion.
+ * POSIX paths compare byte-for-byte. Windows paths are case-insensitive and
+ * separator-agnostic, so the win32 key is case-folded, `/`-unified to `\`,
+ * and stripped of trailing separators — `C:\Users\K\.local\bin`,
+ * `c:\users\k\.local\bin\`, and `C:/Users/k/.local/bin` all collapse to the
+ * same key.
+ */
+function pathComparisonKey(path: string, home: string, platform: string): string {
+  const normalized = normalizeUserPath(path, home);
+  if (platform !== "win32") return normalized;
+  return normalized.toLowerCase().replaceAll("/", "\\").replace(/\\+$/, "");
+}
+
+/**
+ * Is `dir` present on a PATH-style string? The split delimiter (`;` vs `:`)
+ * and the comparison rules (Windows is case-insensitive and
+ * separator-agnostic; POSIX is byte-sensitive) are both facts of the
+ * platform, so the injectable is the platform itself — defaults to the host,
+ * overridable so the win32 behavior is unit-testable on a POSIX CI host
+ * (the same pattern as createCliShim in symlinks.ts). The previous
+ * hard-coded `:` split mangled Windows `PATH` entries: each entry's `C:\...`
+ * drive letter contains a `:`, so the split shredded every path.
  */
 export function isDirOnPath(
   dir: string,
   pathEnv: string = process.env.PATH ?? "",
-  delimiter: string = pathDelimiter,
+  platform: string = process.platform,
   home: string = homedir(),
 ): boolean {
-  const target = normalizeUserPath(dir, home);
+  const delimiter = platform === "win32" ? ";" : ":";
+  const target = pathComparisonKey(dir, home, platform);
   return pathEnv
     .split(delimiter)
     .filter(Boolean)
-    .some((entry) => normalizeUserPath(entry, home) === target);
+    .some((entry) => pathComparisonKey(entry, home, platform) === target);
 }
 
 export function resolveDefaultShimDir(opts?: {
   home?: string;
   pathEnv?: string;
   configuredBinDir?: string;
-  delimiter?: string;
+  platform?: string;
 }): string {
   const home = opts?.home ?? homedir();
   const configured = opts?.configuredBinDir?.trim();
   if (configured) return normalizeUserPath(configured, home);
 
   const pathEnv = opts?.pathEnv ?? process.env.PATH ?? "";
-  const delimiter = opts?.delimiter ?? pathDelimiter;
+  const platform = opts?.platform ?? process.platform;
 
   const preferred = [
     join(home, ".local", "bin"),
@@ -94,7 +110,7 @@ export function resolveDefaultShimDir(opts?: {
   ];
 
   for (const candidate of preferred) {
-    if (isDirOnPath(candidate, pathEnv, delimiter, home)) return candidate;
+    if (isDirOnPath(candidate, pathEnv, platform, home)) return candidate;
   }
 
   return join(home, ".local", "bin");

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from "path";
+import { join, dirname, delimiter as pathDelimiter } from "path";
 import { homedir } from "os";
 import { existsSync, renameSync } from "fs";
 import { mkdir } from "fs/promises";
@@ -53,21 +53,40 @@ function resolveConfigRoot(override?: string): string {
   return configRoot;
 }
 
+/**
+ * Is `dir` present on a PATH-style string? Splits on the platform's PATH
+ * delimiter — `;` on Windows, `:` on POSIX — which is injectable (defaults to
+ * `path.delimiter`) so the Windows behavior is testable on a POSIX CI host.
+ * The previous hard-coded `:` split mangled Windows `PATH` entries: it uses
+ * `;`, and each entry's `C:\...` drive letter contains a `:`, so a `:`-split
+ * shredded every path. Entries and `dir` are home-expanded and
+ * trailing-separator-normalized so equivalent spellings compare equal.
+ */
+export function isDirOnPath(
+  dir: string,
+  pathEnv: string = process.env.PATH ?? "",
+  delimiter: string = pathDelimiter,
+  home: string = homedir(),
+): boolean {
+  const target = normalizeUserPath(dir, home);
+  return pathEnv
+    .split(delimiter)
+    .filter(Boolean)
+    .some((entry) => normalizeUserPath(entry, home) === target);
+}
+
 export function resolveDefaultShimDir(opts?: {
   home?: string;
   pathEnv?: string;
   configuredBinDir?: string;
+  delimiter?: string;
 }): string {
   const home = opts?.home ?? homedir();
   const configured = opts?.configuredBinDir?.trim();
   if (configured) return normalizeUserPath(configured, home);
 
-  const pathEntries = new Set(
-    (opts?.pathEnv ?? process.env.PATH ?? "")
-      .split(":")
-      .filter(Boolean)
-      .map((entry) => normalizeUserPath(entry, home)),
-  );
+  const pathEnv = opts?.pathEnv ?? process.env.PATH ?? "";
+  const delimiter = opts?.delimiter ?? pathDelimiter;
 
   const preferred = [
     join(home, ".local", "bin"),
@@ -75,7 +94,7 @@ export function resolveDefaultShimDir(opts?: {
   ];
 
   for (const candidate of preferred) {
-    if (pathEntries.has(candidate)) return candidate;
+    if (isDirOnPath(candidate, pathEnv, delimiter, home)) return candidate;
   }
 
   return join(home, ".local", "bin");

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -4,6 +4,7 @@ import {
   getDefaultHost,
   migrateConfigIfNeeded,
   resolveDefaultShimDir,
+  isDirOnPath,
 } from "../../src/lib/paths.js";
 import { homedir } from "os";
 import { join } from "path";
@@ -138,6 +139,56 @@ describe("resolveDefaultShimDir", () => {
     });
 
     expect(dir).toBe(`${home}/.arc/bin`);
+  });
+});
+
+/**
+ * isDirOnPath splits a PATH-style string on the platform delimiter. The old
+ * hard-coded `:` split mangled Windows PATHs — `;`-delimited, with a `:` inside
+ * every `C:\...` drive letter — so `arc install` wrongly reported the shim dir
+ * "not on PATH". These literal-string cases prove the win32 behavior on any host.
+ */
+describe("isDirOnPath", () => {
+  test("win32: finds the dir on a ';'-delimited PATH despite drive-letter colons", () => {
+    expect(
+      isDirOnPath(
+        "C:\\Users\\k\\.local\\bin",
+        "C:\\Windows;C:\\Users\\k\\.local\\bin;C:\\Program Files\\bin",
+        ";",
+      ),
+    ).toBe(true);
+  });
+
+  test("win32: a ':' split mangles drive letters and misses the dir (the bug)", () => {
+    expect(
+      isDirOnPath(
+        "C:\\Users\\k\\.local\\bin",
+        "C:\\Windows;C:\\Users\\k\\.local\\bin",
+        ":",
+      ),
+    ).toBe(false);
+  });
+
+  test("win32: returns false when the dir is genuinely absent", () => {
+    expect(
+      isDirOnPath("C:\\Users\\k\\.local\\bin", "C:\\Windows;C:\\Other", ";"),
+    ).toBe(false);
+  });
+
+  test("posix: finds the dir on a ':'-delimited PATH", () => {
+    expect(
+      isDirOnPath("/Users/k/.local/bin", "/usr/bin:/Users/k/.local/bin:/bin", ":"),
+    ).toBe(true);
+  });
+
+  test("posix: matches an entry with a trailing slash", () => {
+    expect(
+      isDirOnPath("/Users/k/.local/bin", "/Users/k/.local/bin/:/usr/bin", ":"),
+    ).toBe(true);
+  });
+
+  test("posix: returns false when the dir is absent", () => {
+    expect(isDirOnPath("/opt/bin", "/usr/bin:/bin", ":")).toBe(false);
   });
 });
 

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -141,7 +141,7 @@ describe("resolveDefaultShimDir", () => {
     expect(dir).toBe(`${home}/.arc/bin`);
   });
 
-  test("honors the injected PATH delimiter (Windows uses ';')", () => {
+  test("honors the injected platform (win32 splits PATH on ';')", () => {
     // Host-independent: build the matching entry with the same `join` the
     // function uses, so it matches whether the host renders it with `/` or `\`.
     const home = "/Users/tester";
@@ -149,7 +149,7 @@ describe("resolveDefaultShimDir", () => {
     const dir = resolveDefaultShimDir({
       home,
       pathEnv: ["/usr/bin", localBin, "/opt/bin"].join(";"),
-      delimiter: ";",
+      platform: "win32",
     });
 
     expect(dir).toBe(localBin);
@@ -157,10 +157,11 @@ describe("resolveDefaultShimDir", () => {
 });
 
 /**
- * isDirOnPath splits a PATH-style string on the platform delimiter. The old
- * hard-coded `:` split mangled Windows PATHs — `;`-delimited, with a `:` inside
- * every `C:\...` drive letter — so `arc install` wrongly reported the shim dir
- * "not on PATH". These literal-string cases prove the win32 behavior on any host.
+ * isDirOnPath derives the split delimiter and comparison rules from the
+ * injected platform. The old hard-coded `:` split mangled Windows PATHs —
+ * `;`-delimited, with a `:` inside every `C:\...` drive letter — so
+ * `arc install` wrongly reported the shim dir "not on PATH". These
+ * literal-string cases prove the win32 behavior on any host.
  */
 describe("isDirOnPath", () => {
   test("win32: finds the dir on a ';'-delimited PATH despite drive-letter colons", () => {
@@ -168,41 +169,67 @@ describe("isDirOnPath", () => {
       isDirOnPath(
         "C:\\Users\\k\\.local\\bin",
         "C:\\Windows;C:\\Users\\k\\.local\\bin;C:\\Program Files\\bin",
-        ";",
+        "win32",
       ),
     ).toBe(true);
   });
 
-  test("win32: a ':' split mangles drive letters and misses the dir (the bug)", () => {
+  test("win32: a posix ':' split mangles drive letters and misses the dir (the original bug)", () => {
     expect(
       isDirOnPath(
         "C:\\Users\\k\\.local\\bin",
         "C:\\Windows;C:\\Users\\k\\.local\\bin",
-        ":",
+        "linux",
       ),
     ).toBe(false);
   });
 
+  test("win32: matches case-insensitively (Windows paths are case-insensitive)", () => {
+    expect(
+      isDirOnPath(
+        "C:\\Users\\K\\.LOCAL\\Bin",
+        "C:\\Windows;c:\\users\\k\\.local\\bin",
+        "win32",
+      ),
+    ).toBe(true);
+  });
+
+  test("win32: matches across separator spellings ('/' vs '\\', trailing '\\')", () => {
+    expect(
+      isDirOnPath(
+        "C:/Users/k/.local/bin",
+        "C:\\Windows;C:\\Users\\k\\.local\\bin\\",
+        "win32",
+      ),
+    ).toBe(true);
+  });
+
   test("win32: returns false when the dir is genuinely absent", () => {
     expect(
-      isDirOnPath("C:\\Users\\k\\.local\\bin", "C:\\Windows;C:\\Other", ";"),
+      isDirOnPath("C:\\Users\\k\\.local\\bin", "C:\\Windows;C:\\Other", "win32"),
     ).toBe(false);
   });
 
   test("posix: finds the dir on a ':'-delimited PATH", () => {
     expect(
-      isDirOnPath("/Users/k/.local/bin", "/usr/bin:/Users/k/.local/bin:/bin", ":"),
+      isDirOnPath("/Users/k/.local/bin", "/usr/bin:/Users/k/.local/bin:/bin", "linux"),
     ).toBe(true);
   });
 
   test("posix: matches an entry with a trailing slash", () => {
     expect(
-      isDirOnPath("/Users/k/.local/bin", "/Users/k/.local/bin/:/usr/bin", ":"),
+      isDirOnPath("/Users/k/.local/bin", "/Users/k/.local/bin/:/usr/bin", "linux"),
     ).toBe(true);
   });
 
+  test("posix: stays case-sensitive (POSIX paths are distinct by case)", () => {
+    expect(
+      isDirOnPath("/Users/K/.local/bin", "/users/k/.local/bin:/usr/bin", "linux"),
+    ).toBe(false);
+  });
+
   test("posix: returns false when the dir is absent", () => {
-    expect(isDirOnPath("/opt/bin", "/usr/bin:/bin", ":")).toBe(false);
+    expect(isDirOnPath("/opt/bin", "/usr/bin:/bin", "linux")).toBe(false);
   });
 });
 

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -140,6 +140,20 @@ describe("resolveDefaultShimDir", () => {
 
     expect(dir).toBe(`${home}/.arc/bin`);
   });
+
+  test("honors the injected PATH delimiter (Windows uses ';')", () => {
+    // Host-independent: build the matching entry with the same `join` the
+    // function uses, so it matches whether the host renders it with `/` or `\`.
+    const home = "/Users/tester";
+    const localBin = join(home, ".local", "bin");
+    const dir = resolveDefaultShimDir({
+      home,
+      pathEnv: ["/usr/bin", localBin, "/opt/bin"].join(";"),
+      delimiter: ";",
+    });
+
+    expect(dir).toBe(localBin);
+  });
 });
 
 /**


### PR DESCRIPTION
## Problem

After `arc install` on Windows, arc falsely warns that the shim dir (e.g. `C:\Users\<user>\.local\bin`) "is not on PATH" even when it is. The on-PATH check split `PATH` on a hard-coded `:`; Windows `PATH` is `;`-delimited and every `C:\...` entry contains a `:`, so the split shredded each path and never matched.

Closes #225.

## Fix

- Extract the membership check into an exported, tested `isDirOnPath(dir, pathEnv, platform = process.platform, home)` in `paths.ts`.
- Route both `resolveDefaultShimDir` and the two `cli.ts` call sites (the install notice and `arc doctor`) through it, deleting the duplicate `shimDirIsOnPath` from `cli.ts`.
- The membership check is injectable by platform (defaults to process.platform); the delimiter (;/:) and comparison rules (win32 is case-insensitive and separator-agnostic) are derived from it, so the Windows behavior is unit-tested on a POSIX CI host — mirroring the platform injection in [#224](https://github.com/the-metafactory/arc/pull/224).

POSIX behavior is unchanged.

## Tests

`test/unit/paths.test.ts` (+7): `isDirOnPath` win32 drive-letter repro (proves a `:`-split mangles `C:\...` while `;` matches) plus posix cases, and a host-independent `resolveDefaultShimDir` delimiter-passthrough test. `bun run lint:errors` and `bunx tsc --noEmit` are clean.

## Out of scope (follow-up)

When a dir is *genuinely* off PATH on Windows, the remediation hint is still POSIX-only (`export`/zsh); making it Windows-aware is a small, separate change.

---

<details><summary>Suggested CHANGELOG entry (for the maintainer to place at release)</summary>

- **`arc install` no longer falsely reports the shim dir is "not on PATH" on Windows** (closes #225). The on-PATH check split `PATH` on a hard-coded `:`; Windows `PATH` is `;`-delimited with a `:` inside every `C:\...` drive letter, so the split shredded each entry. It now derives the delimiter and comparison rules (win32 paths compare case-insensitively and separator-agnostically) from the platform, via a shared, tested `isDirOnPath` helper used by both the install notice and `resolveDefaultShimDir`.
</details>
