### PR TITLE
feat(manifest): add type: process arc-manifest schema (dev-loop F-6d)

### DIFF
--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -76,6 +76,16 @@ async function readManifestFromDir(
         return parsed;
       }
 
+      // Process-specific validation (dev-loop F-6d, meta-factory#550). A
+      // process declares its dependencies per-node, so the top-level
+      // `capabilities` block is optional (like component/rules/agent).
+      if (parsed.type === "process") {
+        validateProcess(parsed, filename);
+        validateTargets(parsed, filename);
+        validateLifecycle(parsed, filename);
+        return parsed;
+      }
+
       // capabilities optional for component, rules, and agent types, required for others.
       // Persona-driven agents (arc#100 §12 / arc#102) declare authority via
       // `guardrails` instead of `capabilities` — the host enforces guardrails
@@ -90,7 +100,7 @@ async function readManifestFromDir(
         throw new Error(
           [
             `Invalid ${filename}: missing required field 'capabilities'`,
-            `Required for type: skill, tool, prompt, pipeline, system (optional only for: component, rules, agent).`,
+            `Required for type: skill, tool, prompt, pipeline, system (optional only for: component, rules, agent, process).`,
             ``,
             `Minimal example:`,
             ``,
@@ -292,6 +302,151 @@ export function validateLifecycle(manifest: ArcManifest, filename: string): void
         );
       }
     }
+  }
+}
+
+/** Step keywords arc understands. `agent`/`gate` carry the D/A/H surface arc
+ *  validates; the rest are pulse composition primitives accepted opaquely. */
+const KNOWN_PROCESS_STEP_KEYWORDS = new Set([
+  "agent",
+  "gate",
+  "map",
+  "filter",
+  "reduce",
+  "parallel",
+  "retry",
+]);
+
+/**
+ * Validate a `type: process` manifest (dev-loop F-6d, meta-factory#550).
+ *
+ * The schema DESCRIBES pulse's real process vocabulary, NOT the idealised
+ * explicit-DAG (`nodes`/`startNode`/`endNodes`/`dependsOn`) sketched in the
+ * issue body — that shape does not round-trip a real pulse pipeline. A process
+ * is an ORDERED `actions:` array; sequencing is positional, there are no edge
+ * declarations, so there is no DAG/cycle check to run. arc validates only the
+ * D/A/H step surface and trusts pulse for runner semantics (DD-47 / Anti-
+ * Abstraction Gate).
+ *
+ * Rules:
+ *   1. `process` block present with a non-empty `actions` array.
+ *   2. Every step is a string (D action ref) or a single-keyword map.
+ *   3. The keyword is one arc recognises (agent/gate or a composition primitive).
+ *   4. `agent:` steps declare `name` + `capability` + `prompt`.
+ *   5. `gate:` steps declare `name` + `prompt`.
+ *   6. `timeout_ms` (agent or gate), when present, is a positive number — pulse
+ *      uses milliseconds, NOT ISO-8601 durations.
+ */
+export function validateProcess(manifest: ArcManifest, filename: string): void {
+  // YAML is untyped at the parse boundary — treat the block as `unknown` and
+  // validate it up to the typed ProcessSpec contract rather than trusting the
+  // optimistic cast. This is what makes the guards below genuinely load-bearing.
+  const proc = manifest.process as unknown;
+  if (!isRecord(proc)) {
+    throw new Error(
+      `Invalid ${filename}: type 'process' requires a 'process' block with a 'name' and an 'actions' array.`,
+    );
+  }
+  if (typeof proc.name !== "string" || proc.name.length === 0) {
+    throw new Error(
+      `Invalid ${filename}: process requires a 'name' (e.g. 'P_BUILD_JOURNAL').`,
+    );
+  }
+  if (!Array.isArray(proc.actions) || proc.actions.length === 0) {
+    throw new Error(
+      `Invalid ${filename}: process 'actions' must be a non-empty array (at least one step).`,
+    );
+  }
+
+  proc.actions.forEach((step: unknown, i: number) => {
+    // A bare string is a deterministic [D] action reference.
+    if (typeof step === "string") {
+      if (step.length === 0) {
+        throw new Error(
+          `Invalid ${filename}: process action[${i}] is an empty string; a deterministic action ref must be named.`,
+        );
+      }
+      return;
+    }
+
+    if (!isRecord(step)) {
+      throw new Error(
+        `Invalid ${filename}: process action[${i}] must be a string (deterministic action ref) or a single-keyword map (agent/gate/…), got ${JSON.stringify(step)}.`,
+      );
+    }
+
+    const keys = Object.keys(step);
+    if (keys.length !== 1) {
+      throw new Error(
+        `Invalid ${filename}: process action[${i}] must have exactly one keyword, got [${keys.join(", ")}].`,
+      );
+    }
+    const keyword = keys[0];
+    if (!KNOWN_PROCESS_STEP_KEYWORDS.has(keyword)) {
+      throw new Error(
+        `Invalid ${filename}: process action[${i}] has unknown step keyword '${keyword}'. Known: ${[...KNOWN_PROCESS_STEP_KEYWORDS].join(", ")}.`,
+      );
+    }
+
+    if (keyword === "agent") {
+      validateAgentStep(step.agent, i, filename);
+    } else if (keyword === "gate") {
+      validateGateStep(step.gate, i, filename);
+    }
+    // map/filter/reduce/parallel/retry: accepted opaquely — pulse owns their
+    // runner semantics (Anti-Abstraction Gate). No further validation here.
+  });
+}
+
+/** Narrow an `unknown` to a plain object (not null, not an array). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validate an `agent:` step's required surface (name + capability + prompt). */
+function validateAgentStep(value: unknown, i: number, filename: string): void {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid ${filename}: process action[${i}] 'agent' must be an object.`);
+  }
+  const name = value.name;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(`Invalid ${filename}: agent step at action[${i}] is missing required 'name'.`);
+  }
+  if (typeof value.capability !== "string" || value.capability.length === 0) {
+    throw new Error(`Invalid ${filename}: agent step '${name}' is missing required 'capability'.`);
+  }
+  if (typeof value.prompt !== "string" || value.prompt.length === 0) {
+    throw new Error(`Invalid ${filename}: agent step '${name}' is missing required 'prompt'.`);
+  }
+  assertPositiveTimeout(value.timeout_ms, `agent step '${name}'`, filename);
+}
+
+/** Validate a `gate:` step's required surface (name + prompt). */
+function validateGateStep(value: unknown, i: number, filename: string): void {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid ${filename}: process action[${i}] 'gate' must be an object.`);
+  }
+  const name = value.name;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(`Invalid ${filename}: gate step at action[${i}] is missing required 'name'.`);
+  }
+  if (typeof value.prompt !== "string" || value.prompt.length === 0) {
+    throw new Error(`Invalid ${filename}: gate step '${name}' is missing required 'prompt'.`);
+  }
+  assertPositiveTimeout(value.timeout_ms, `gate step '${name}'`, filename);
+}
+
+/** Reject a present-but-non-positive `timeout_ms`. Pulse timeouts are in ms. */
+function assertPositiveTimeout(
+  timeout: unknown,
+  where: string,
+  filename: string,
+): void {
+  if (timeout === undefined) return;
+  if (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout <= 0) {
+    throw new Error(
+      `Invalid ${filename}: ${where} timeout_ms must be a positive number of milliseconds, got ${JSON.stringify(timeout)}.`,
+    );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 // ── Catalog types ──────────────────────────────────────────────
 
 /** Artifact types in the catalog */
-export type ArtifactType = "skill" | "agent" | "prompt" | "tool" | "component" | "pipeline" | "rules" | "library" | "action";
+export type ArtifactType = "skill" | "agent" | "prompt" | "tool" | "component" | "pipeline" | "process" | "rules" | "library" | "action";
 
 /** Catalog entry type — controls trust level and install behavior */
 export type CatalogEntryType = "builtin" | "community" | "system" | "custom";
@@ -265,14 +265,109 @@ export interface ExtensionEntry {
   name: string;
 }
 
+// ── Process types (DD-47 D/A/H taxonomy, dev-loop F-6d, meta-factory#550) ──
+//
+// A `type: process` manifest packages a pulse process definition. The schema
+// DESCRIBES pulse's real vocabulary (the-metafactory/pulse src/types/pipeline.ts
+// + src/types/agent.ts), NOT the idealised explicit-DAG sketched in the issue
+// body. A process is an ORDERED `actions:` array — sequencing is positional,
+// there are no edge/`dependsOn` declarations. Each step is one of:
+//   - a bare string           → Deterministic [D] action ref (e.g. "A_BUILD")
+//   - `{ agent: AgentStep }`  → Agentic [A] step (capability-addressed LLM task)
+//   - `{ gate: GateStep }`    → Human gate [H] step (approval pause)
+// The composition primitives pulse also supports (map/filter/reduce/parallel/
+// retry) are accepted as opaque pass-through objects — arc validates the D/A/H
+// surface only and does not re-implement pulse's runner semantics (DD-47).
+
+/**
+ * Sovereignty constraints carried in an agent task envelope. Mirrors pulse
+ * `AgentSovereignty` (src/types/agent.ts), itself mirroring the myelin v3
+ * envelope schema. Declared by the process; enforced by the bus + fleet.
+ */
+export interface ProcessAgentSovereignty {
+  classification?: "local" | "federated" | "public";
+  data_residency?: string;
+  max_hop?: number;
+  frontier_ok?: boolean;
+  model_class?: "local-only" | "frontier" | "any";
+}
+
+/** Cross-principal routing for a federated agent step (pulse `AgentFederation`). */
+export interface ProcessAgentFederation {
+  principal: string;
+  stack?: string;
+}
+
+/**
+ * Agentic [A] step — a capability-addressed, sovereignty-constrained LLM task.
+ * Mirrors pulse `AgentStepSpec`. `capability` + `name` + `prompt` are required;
+ * everything else is optional routing/sovereignty metadata.
+ */
+export interface ProcessAgentStep {
+  name: string;
+  capability: string;
+  prompt: string;
+  sovereignty?: ProcessAgentSovereignty;
+  distribution_mode?: "offer" | "direct" | "delegate";
+  target_assistant?: string;
+  federate?: ProcessAgentFederation;
+  /** Soft deadline in MILLISECONDS (pulse uses ms, not ISO-8601 durations). */
+  timeout_ms?: number;
+  collect?: string;
+}
+
+/**
+ * Human gate [H] step — pauses execution for an operator verdict.
+ * Mirrors pulse `GateStepSpec`. `name` + `prompt` are required.
+ */
+export interface ProcessGateStep {
+  name: string;
+  prompt: string;
+  /** Optional timeout in MILLISECONDS. Omit for an indefinite wait. */
+  timeout_ms?: number;
+  collect?: string;
+}
+
+/**
+ * A single process step (pulse `PipelineStep`). A bare string is a
+ * Deterministic [D] action reference; the keyword maps select A/H steps;
+ * the composition-primitive maps are accepted opaquely.
+ */
+export type ProcessStep =
+  | string
+  | { agent: ProcessAgentStep }
+  | { gate: ProcessGateStep }
+  | { map: Record<string, unknown> }
+  | { filter: Record<string, unknown> }
+  | { reduce: Record<string, unknown> }
+  | { parallel: Record<string, unknown> }
+  | { retry: Record<string, unknown> };
+
+/**
+ * The `process:` block on a `type: process` manifest — a named, ordered
+ * pulse process definition. Mirrors the shape of a pulse pipeline.yaml.
+ */
+export interface ProcessSpec {
+  /** Process name, e.g. "P_BUILD_JOURNAL". */
+  name: string;
+  description?: string;
+  /** Ordered D/A/H steps. Sequencing is positional; non-empty. */
+  actions: ProcessStep[];
+}
+
 /** The full arc-manifest.yaml schema (also accepts legacy pai-manifest.yaml) */
 export interface ArcManifest {
   schema?: "arc/v1" | "pai/v1";
   name: string;
   version: string;
-  type: "skill" | "system" | "tool" | "agent" | "prompt" | "component" | "pipeline" | "rules" | "library";
+  type: "skill" | "system" | "tool" | "agent" | "prompt" | "component" | "pipeline" | "process" | "rules" | "library";
   /** Only present when type is "library" — lists contained artifacts */
   artifacts?: LibraryArtifactEntry[];
+  /**
+   * Only present when type is "process" — the packaged pulse process
+   * definition (DD-47 D/A/H taxonomy, dev-loop F-6d). See ProcessSpec.
+   */
+  process?: ProcessSpec;
   /**
    * Multi-target install destinations (arc#117 multi-backend HostAdapter).
    *

--- a/test/unit/manifest-process.test.ts
+++ b/test/unit/manifest-process.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Process-manifest validation tests (dev-loop F-6d, meta-factory#550).
+ *
+ * The schema here DESCRIBES pulse's real process vocabulary — an ordered
+ * `actions:` array of steps that are either a bare string (deterministic
+ * action ref), an `agent:` map (agentic step), or a `gate:` map (human gate).
+ * It is NOT the idealised explicit-DAG (`nodes`/`startNode`/`endNodes`/
+ * `dependsOn`) sketched in the issue body; that shape does not round-trip a
+ * real pulse pipeline. See design/dev-loop-process-schema.md (meta-factory)
+ * and the PR notes for the spec-vs-reality divergence.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { readManifest, MANIFEST_FILENAME } from "../../src/lib/manifest.js";
+import type { ArcManifest } from "../../src/types.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-process-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+/** Write an arc-manifest.yaml into the temp dir and read it back. */
+async function writeAndRead(yaml: string): Promise<ArcManifest | null> {
+  await Bun.write(join(tempDir, MANIFEST_FILENAME), yaml);
+  return readManifest(tempDir);
+}
+
+describe("process manifest — valid", () => {
+  test("parses a minimal D/A/H process (pulse `actions:` vocabulary)", async () => {
+    const manifest = await writeAndRead(`name: test-process
+version: 1.0.0
+type: process
+process:
+  name: P_TEST
+  actions:
+    - A_BUILD
+    - agent:
+        name: review
+        capability: code-review.typescript
+        prompt: "Review the diff."
+    - gate:
+        name: approve
+        prompt: "Ship it?"
+`);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.type).toBe("process");
+    expect(manifest!.process!.actions).toHaveLength(3);
+    // Bare string = deterministic action ref.
+    expect(manifest!.process!.actions[0]).toBe("A_BUILD");
+  });
+
+  test("accepts agent step optional fields (sovereignty, federate, timeout_ms, collect)", async () => {
+    const manifest = await writeAndRead(`name: fed-process
+version: 0.1.0
+type: process
+process:
+  name: P_FED
+  actions:
+    - agent:
+        name: perspective
+        capability: ecosystem.perspective
+        prompt: "Add your view."
+        federate:
+          principal: andreas
+          stack: meta-factory
+        sovereignty:
+          classification: federated
+          frontier_ok: true
+        timeout_ms: 300000
+        collect: perspective
+`);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.process!.actions).toHaveLength(1);
+  });
+
+  test("does not require `capabilities` for a process manifest", async () => {
+    // Process manifests declare their needs per-node; the top-level
+    // `capabilities` block is optional (like component/rules/agent).
+    const manifest = await writeAndRead(`name: no-caps
+version: 1.0.0
+type: process
+process:
+  name: P_NOCAPS
+  actions:
+    - A_ONLY
+`);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.capabilities).toBeUndefined();
+  });
+});
+
+describe("process manifest — invalid", () => {
+  test("rejects a process with no `process` block", async () => {
+    await expect(
+      writeAndRead(`name: bad
+version: 1.0.0
+type: process
+`),
+    ).rejects.toThrow(/process/i);
+  });
+
+  test("rejects an empty `actions` array", async () => {
+    await expect(
+      writeAndRead(`name: empty
+version: 1.0.0
+type: process
+process:
+  name: P_EMPTY
+  actions: []
+`),
+    ).rejects.toThrow(/non-empty|at least one/i);
+  });
+
+  test("rejects an agent step missing `capability`", async () => {
+    await expect(
+      writeAndRead(`name: bad-agent
+version: 1.0.0
+type: process
+process:
+  name: P_BADAGENT
+  actions:
+    - agent:
+        name: act
+        prompt: "do it"
+`),
+    ).rejects.toThrow(/capability/i);
+  });
+
+  test("rejects an agent step missing `prompt`", async () => {
+    await expect(
+      writeAndRead(`name: bad-agent2
+version: 1.0.0
+type: process
+process:
+  name: P_BADAGENT2
+  actions:
+    - agent:
+        name: act
+        capability: dev.implement
+`),
+    ).rejects.toThrow(/prompt/i);
+  });
+
+  test("rejects a gate step missing `prompt`", async () => {
+    await expect(
+      writeAndRead(`name: bad-gate
+version: 1.0.0
+type: process
+process:
+  name: P_BADGATE
+  actions:
+    - gate:
+        name: approve
+`),
+    ).rejects.toThrow(/prompt/i);
+  });
+
+  test("rejects a step that is neither a string nor a known keyword map", async () => {
+    await expect(
+      writeAndRead(`name: bad-step
+version: 1.0.0
+type: process
+process:
+  name: P_BADSTEP
+  actions:
+    - frobnicate:
+        name: huh
+`),
+    ).rejects.toThrow(/unknown step|frobnicate|string or/i);
+  });
+
+  test("rejects a non-positive agent timeout_ms", async () => {
+    await expect(
+      writeAndRead(`name: bad-timeout
+version: 1.0.0
+type: process
+process:
+  name: P_BADTIMEOUT
+  actions:
+    - agent:
+        name: act
+        capability: dev.implement
+        prompt: "do it"
+        timeout_ms: 0
+`),
+    ).rejects.toThrow(/timeout_ms/i);
+  });
+});
+
+describe("process manifest — round-trips a real pulse pipeline", () => {
+  // P_BUILD_JOURNAL, the canonical cross-principal pulse pipeline
+  // (the-metafactory/pulse examples/build-journal/pipeline.yaml): D actions,
+  // an `agent:` draft, a federated `agent:` perspective, an `gate:` editor
+  // approval, then more D actions. Validates as type: process unchanged.
+  test("P_BUILD_JOURNAL validates as a process", async () => {
+    const manifest = await writeAndRead(`name: dev-loop
+version: 0.1.0
+type: process
+process:
+  name: P_BUILD_JOURNAL
+  description: Cross-principal build journal.
+  actions:
+    - A_GATHER_FACTS
+    - agent:
+        name: draft
+        capability: ecosystem.narrative
+        prompt: "Turn this week's activity into a build-journal draft.\\n{facts}"
+        sovereignty:
+          classification: public
+          frontier_ok: true
+          model_class: any
+        timeout_ms: 300000
+        collect: draft
+    - agent:
+        name: perspective
+        capability: ecosystem.perspective
+        prompt: "Add your perspective.\\n{draft.output}"
+        federate:
+          principal: andreas
+          stack: meta-factory
+        sovereignty:
+          classification: federated
+          frontier_ok: true
+          model_class: any
+          max_hop: 1
+        timeout_ms: 300000
+        collect: perspective
+    - gate:
+        name: editor-approval
+        prompt: "Publish to Discord + build log?"
+        collect: approval
+    - A_FORMAT_JOURNAL
+    - A_POST_DISCORD
+    - A_WRITE_BUILDLOG
+    - A_DEPLOY_SITE
+`);
+    expect(manifest).not.toBeNull();
+    expect(manifest!.type).toBe("process");
+    const actions = manifest!.process!.actions;
+    expect(actions).toHaveLength(8);
+    // 5 deterministic string steps, 2 agent steps, 1 gate step.
+    expect(actions.filter((s) => typeof s === "string")).toHaveLength(5);
+    expect(
+      actions.filter((s) => typeof s === "object" && s !== null && "agent" in s),
+    ).toHaveLength(2);
+    expect(
+      actions.filter((s) => typeof s === "object" && s !== null && "gate" in s),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

dev-loop **F-6d** (arc side) — the minimal `type: process` type-enum + manifest validation. Promotes DD-47's process-node taxonomy (Deterministic [D] / Agentic [A] / Human gate [H]) to a first-class arc-manifest, validated at parse time.

Schema spec (the normative authority for this PR): **the-metafactory/meta-factory#551** (`design/dev-loop-process-schema.md`).

## Changes

- **`src/types.ts`** — add `process` to `ArtifactType` and the `ArcManifest.type` union; add `ProcessSpec`, `ProcessStep`, `ProcessAgentStep`, `ProcessGateStep`, `ProcessAgentSovereignty`, `ProcessAgentFederation`, mirroring pulse `src/types/pipeline.ts` + `src/types/agent.ts`.
- **`src/lib/manifest.ts`** — add `validateProcess`; make `capabilities` optional for `type: process` (a process declares deps per-node).
- **`test/unit/manifest-process.test.ts`** — 11 tests (RED→GREEN), incl. round-tripping pulse's real cross-principal `P_BUILD_JOURNAL`.

## The schema DESCRIBES pulse reality, not the issue's idealised DAG

The framing contract (meta-factory#550) requires the schema to describe what **pulse actually executes**. A pulse process is an **ordered `actions:` array**: a bare string is a [D] action ref, an `agent:` map is an [A] step, a `gate:` map is an [H] step. This is **not** the explicit-DAG (`nodes`/`startNode`/`endNodes`/`dependsOn`, ISO-8601 timeouts, gate `approvalRoles`, agent `costCap`/`maxRetries`) sketched in the issue body — that shape does not round-trip a real pulse pipeline. Full divergence table + rationale: meta-factory#551 §4.

Concretely, two consequences for this PR:
- **No cycle check.** There are no edges in an ordered array, so the issue's `hasCycle`/topological-sort logic has nothing to operate on. (A branching-DAG future is tracked — meta-factory#551 §6.)
- **`timeout_ms` is validated as a positive number of milliseconds**, not an ISO-8601 duration — pulse uses ms throughout; validating `PT1H` would reject every real pulse definition.

## Validation rules (`validateProcess`)

1. `process` block present, with a non-empty `name` and a **non-empty** `actions` array.
2. Every step is a bare non-empty string or a **single-keyword** map.
3. Keyword ∈ {`agent`, `gate`, `map`, `filter`, `reduce`, `parallel`, `retry`}.
4. `agent:` steps need `name` + `capability` + `prompt`.
5. `gate:` steps need `name` + `prompt`.
6. `timeout_ms`, when present, is a positive number (ms).

Composition primitives (`map`/`filter`/…) pass opaquely — pulse owns their runner semantics (Anti-Abstraction Gate).

## Round-trip (one of the 11 tests)

`P_BUILD_JOURNAL` (pulse `examples/build-journal/pipeline.yaml`) validates unchanged: 8 ordered steps — 5 [D] action refs, 2 [A] agent steps (one federated to `andreas`/`meta-factory`), 1 [H] gate — `sovereignty` + `federate` preserved exactly.

## Scope guard

Does **NOT** touch `src/commands/install.ts`. Capability-resolution at install time (the issue's "agent step with missing capability fails install") crosses into install and is owned by another lane — noted as a follow-up in meta-factory#551 §6, not implemented here.

## Gates

- `bunx tsc --noEmit` ✅
- `bun run lint` (eslint) ✅
- `bun test test/unit/` ✅ (686 pass, 0 fail; the new file adds 11)

Refs cortex#835, cortex#869, meta-factory#550

🤖 Generated with [Claude Code](https://claude.com/claude-code)