### PR TITLE
feat(install): F-6c — ordered library installs + atomic rollback

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -12,7 +12,7 @@ import type {
 import type { Database } from "bun:sqlite";
 import { errorMessage } from "../lib/errors.js";
 import { readManifest, readLibraryArtifacts, assessRisk, formatCapabilities } from "../lib/manifest.js";
-import { recordInstall, getSkill } from "../lib/db.js";
+import { recordInstall, getSkill, removeSkill } from "../lib/db.js";
 import { runScript, runLifecycleScripts } from "../lib/scripts.js";
 import {
   registerHooks,
@@ -25,6 +25,7 @@ import {
   resolveArtifactSourceDir,
   installNodeDependencies,
   rollbackArtifactSymlinks,
+  toposortArtifacts,
 } from "../lib/artifact-installer.js";
 import { wireExtensions } from "../lib/extensions.js";
 import { extractRepoName, isInsideRepos, repoNameFromPreExtracted } from "../lib/repo-name.js";
@@ -41,8 +42,12 @@ import {
 } from "../lib/hosts/launchd-install.js";
 import { isDarwinLaunchdHost } from "../lib/hosts/darwin-launchd.js";
 import {
+  ArtifactInstallState,
   beginInstallTransaction,
+  beginLibraryInstallTransaction,
+  type InstallTransaction,
   type InstallTransactionEvidence,
+  type LibraryInstallJournal,
 } from "../lib/install-transaction.js";
 
 export interface InstallOptions {
@@ -64,6 +69,16 @@ export interface InstallOptions {
   artifactName?: string;
   /** When installing from a library, the library name (for DB tracking) */
   libraryName?: string;
+  /**
+   * Resume a failed library install from the named artifact (arc#227 / F-6c).
+   *
+   * Skips every artifact that orders BEFORE this one in the dependency-sorted
+   * sequence (they are assumed already installed or deliberately skipped), then
+   * installs from this artifact onward with the same ordered / atomic-rollback
+   * semantics. Library installs only; ignored for standalone installs.
+   * Example: `arc install dev-loop --resume-from=dev` after fixing the broker.
+   */
+  resumeFromArtifact?: string;
   /**
    * Pre-extracted install path (for registry installs from F-4).
    * When provided, skips git clone and uses this directory as the source.
@@ -89,8 +104,20 @@ export interface InstallResult {
   error?: string;
   manifest?: ArcManifest;
   evidence?: InstallTransactionEvidence;
-  /** For library installs: results for each artifact */
+  /**
+   * For library installs: per-artifact result (backward-compat shape).
+   *
+   * Retained as `InstallResult[]` so existing callers/tests keep reading
+   * `.success` / `.name` / `.version`. The authoritative per-artifact STATE
+   * (skipped / success / failed / rolled_back) lives in `journal` (arc#227).
+   */
   artifacts?: InstallResult[];
+  /**
+   * For library installs (arc#227 / F-6c): the full transactional journal —
+   * ordered per-artifact state, errors, and landed-artifact evidence. Present
+   * on every library install (success or failure), absent for standalone.
+   */
+  journal?: LibraryInstallJournal;
 }
 
 /**
@@ -535,7 +562,10 @@ async function installLibrary(
     return { success: false, error: errorMessage(err) };
   }
 
-  // Filter to specific artifact if requested
+  // Filter to specific artifact if requested. A single-artifact install keeps
+  // the original semantics — no ordering / atomic-rollback applies to a set of
+  // one — but still flows through the ordered path below (toposort of one
+  // element is itself).
   if (opts.artifactName) {
     const match = artifactEntries.find(
       (a) => a.manifest.name === opts.artifactName
@@ -550,23 +580,85 @@ async function installLibrary(
     artifactEntries = [match];
   }
 
-  if (!opts.yes && !opts.artifactName) {
-    console.log(`\nArtifacts (${artifactEntries.length}):`);
-    for (const { entry, manifest } of artifactEntries) {
-      console.log(`  ${manifest.name} [${manifest.type}] v${manifest.version} — ${entry.description ?? entry.path}`);
+  // arc#227 / F-6c: order artifacts by depends_on so each lands after the
+  // intra-library artifacts it depends on. A cycle (or unresolvable graph) is
+  // a manifest authoring error — fail before touching the filesystem.
+  let orderedArtifacts: typeof artifactEntries;
+  try {
+    orderedArtifacts = toposortArtifacts(artifactEntries);
+  } catch (err) {
+    return {
+      success: false,
+      name: libraryName,
+      version: libraryManifest.version,
+      error: `Cannot order artifacts of library '${libraryName}': ${errorMessage(err)}`,
+    };
+  }
+
+  // arc#227 / F-6c: resume a failed install from a named artifact. Everything
+  // ordered before it is assumed already installed (or deliberately skipped).
+  let startIndex = 0;
+  if (opts.resumeFromArtifact) {
+    startIndex = orderedArtifacts.findIndex(
+      (a) => a.manifest.name === opts.resumeFromArtifact,
+    );
+    if (startIndex === -1) {
+      const available = orderedArtifacts.map((a) => a.manifest.name).join(", ");
+      return {
+        success: false,
+        name: libraryName,
+        version: libraryManifest.version,
+        error: `Resume artifact '${opts.resumeFromArtifact}' not found in library '${libraryName}'. Available: ${available}`,
+      };
     }
   }
 
-  // Install each artifact
-  const results: InstallResult[] = [];
+  if (!opts.yes && !opts.artifactName) {
+    console.log(`\nArtifact install order (${orderedArtifacts.length}):`);
+    for (const { entry, manifest } of orderedArtifacts) {
+      const depNames = manifest.depends_on?.packages?.map((p) => p.name) ?? [];
+      const deps = depNames.length ? depNames.join(", ") : "(none)";
+      console.log(
+        `  → ${manifest.name} [${manifest.type}] v${manifest.version} — ${entry.description ?? entry.path} [depends on: ${deps}]`,
+      );
+    }
+    if (opts.resumeFromArtifact) {
+      console.log(`  (resuming from '${opts.resumeFromArtifact}')`);
+    }
+  }
 
-  for (const { entry, manifest: artifactManifest } of artifactEntries) {
-    // Check if this specific artifact is already installed
+  // arc#227 / F-6c: a multi-artifact transaction journals each artifact's
+  // outcome and, on a mid-sequence failure, unwinds every artifact landed in
+  // THIS run in reverse order (symlinks/hooks/launchd via each sub-transaction;
+  // committed DB rows via removeDbRow). This lifts the arc#140 P4 single-package
+  // rollback model to the library level.
+  const tx = beginLibraryInstallTransaction({
+    libraryName,
+    removeDbRow: (name) => {
+      removeSkill(db, name);
+    },
+  });
+
+  // Backward-compat result shape (callers read `.success` / `.name`).
+  const results: InstallResult[] = [];
+  let firstFailure: { name: string; error: string } | null = null;
+
+  for (let i = startIndex; i < orderedArtifacts.length; i++) {
+    const { entry, manifest: artifactManifest } = orderedArtifacts[i];
+
+    // Already installed (from a previous run, a sibling library, or this
+    // session's resume): a skip counts as success and is NEVER rolled back —
+    // it predates this transaction.
     const existing = getSkill(db, artifactManifest.name);
     if (existing?.status === "active") {
       if (!opts.yes) {
         console.log(`  ⏩ ${artifactManifest.name} already installed, skipping`);
       }
+      tx.recordArtifactSkipped(
+        artifactManifest.name,
+        artifactManifest.version,
+        artifactManifest.type,
+      );
       results.push({
         success: true,
         name: artifactManifest.name,
@@ -575,44 +667,124 @@ async function installLibrary(
       continue;
     }
 
-    // The artifact's install path is the artifact subdirectory within the library clone
     const artifactInstallPath = join(installPath, entry.path);
 
-    // Re-use the standard install flow for each artifact, pointing at the artifact subdir
-    // We call install() recursively with libraryName set to track provenance
-    const artifactResult = await installSingleArtifact(opts, artifactInstallPath, artifactManifest, libraryName);
+    // Capture the live sub-transaction so a LATER failure can roll this one
+    // back. installSingleArtifact rolls back its OWN partial state on internal
+    // failure; on success it hands us the committed transaction here.
+    let artifactTx: InstallTransaction | undefined;
+    const artifactResult = await installSingleArtifact(
+      opts,
+      artifactInstallPath,
+      artifactManifest,
+      libraryName,
+      (handle) => {
+        artifactTx = handle;
+      },
+    );
     results.push(artifactResult);
 
     if (!artifactResult.success) {
       if (!opts.yes) {
         console.log(`  ❌ ${artifactManifest.name}: ${artifactResult.error}`);
       }
-    } else if (!opts.yes) {
+      const failureError = artifactResult.error ?? "unknown error";
+      tx.recordArtifactFailure(
+        artifactManifest.name,
+        failureError,
+        artifactManifest.version,
+        artifactManifest.type,
+      );
+      firstFailure = {
+        name: artifactManifest.name,
+        error: failureError,
+      };
+      // Stop the sequence — do not attempt later artifacts. Rollback follows.
+      break;
+    }
+
+    if (!opts.yes) {
       console.log(`  ✅ ${artifactResult.name} v${artifactResult.version}`);
+    }
+    if (artifactTx) {
+      tx.recordArtifactSuccess(
+        artifactManifest.name,
+        artifactTx,
+        artifactManifest.version,
+        artifactManifest.type,
+      );
+    } else {
+      // Defensive: a success without a captured transaction means nothing for
+      // us to unwind — record state but with no rollback handle.
+      tx.recordArtifactSkipped(
+        artifactManifest.name,
+        artifactManifest.version,
+        artifactManifest.type,
+      );
     }
   }
 
-  const allSuccess = results.every((r) => r.success);
-  const installedCount = results.filter((r) => r.success).length;
+  // Mid-sequence failure → atomically roll back everything this run landed.
+  if (firstFailure) {
+    if (!opts.yes) {
+      console.log(
+        `\n↩️  Rolling back ${libraryName} — artifact '${firstFailure.name}' failed; unwinding landed artifacts in reverse order…`,
+      );
+    }
+    const journal = await tx.rollback();
+    if (!opts.yes) {
+      for (const detail of journal.artifacts) {
+        const icon =
+          detail.state === ArtifactInstallState.ROLLED_BACK
+            ? "↩️ "
+            : detail.state === ArtifactInstallState.FAILED
+              ? "❌"
+              : detail.state === ArtifactInstallState.SKIPPED
+                ? "⏩"
+                : "✅";
+        console.log(`  ${icon} ${detail.name}: ${detail.state}`);
+        if (detail.error) console.log(`     ${detail.error}`);
+      }
+    }
+    return {
+      success: false,
+      name: libraryName,
+      version: libraryManifest.version,
+      error: `Library '${libraryName}' install failed at artifact '${firstFailure.name}': ${firstFailure.error}. Rolled back all artifacts installed in this run.`,
+      artifacts: results,
+      journal,
+    };
+  }
 
+  const journal = tx.journal();
   return {
-    success: allSuccess || installedCount > 0,
+    success: true,
     name: libraryName,
     version: libraryManifest.version,
     manifest: libraryManifest,
     artifacts: results,
+    journal,
   };
 }
 
 /**
  * Install a single artifact from a library (or standalone).
  * The artifactDir is the resolved directory containing the artifact's manifest.
+ *
+ * @param onTransaction Optional hook (arc#227 / F-6c) invoked with the live
+ *   InstallTransaction once it is opened — BEFORE any hook/postinstall gate.
+ *   The library-install caller captures the handle so that, if a LATER artifact
+ *   in the sequence fails, this artifact's landed state can be rolled back.
+ *   On a SUCCESS return the handle is the committed transaction; on a failure
+ *   return installSingleArtifact has already rolled its own state back, so the
+ *   library caller does not record it as a rollback target.
  */
 export async function installSingleArtifact(
   opts: InstallOptions,
   artifactDir: string,
   manifest: ArcManifest,
   libraryName: string,
+  onTransaction?: (tx: InstallTransaction) => void,
 ): Promise<InstallResult> {
   const { arc, host, db, repoUrl } = opts;
 
@@ -672,6 +844,10 @@ export async function installSingleArtifact(
     packageName: manifest.name,
     authorization: { approved: true },
   });
+  // Hand the live transaction to the library-install caller (arc#227 / F-6c)
+  // so a later artifact's failure can roll this one back. No-op for standalone
+  // installs (callback absent).
+  onTransaction?.(tx);
   tx.recordSymlinks(symlinkResult.record);
 
   // Register hooks (with consent gating — same as standalone install).

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -73,9 +73,10 @@ export interface InstallOptions {
    * Resume a failed library install from the named artifact (arc#227 / F-6c).
    *
    * Skips every artifact that orders BEFORE this one in the dependency-sorted
-   * sequence (they are assumed already installed or deliberately skipped), then
-   * installs from this artifact onward with the same ordered / atomic-rollback
-   * semantics. Library installs only; ignored for standalone installs.
+   * sequence (they are assumed already installed or deliberately skipped — NOT
+   * verified against the DB in v1; known gap arc#232), then installs from this
+   * artifact onward with the same ordered / atomic-rollback semantics. Library
+   * installs only; ignored for standalone installs.
    * Example: `arc install dev-loop --resume-from=dev` after fixing the broker.
    */
   resumeFromArtifact?: string;
@@ -596,7 +597,11 @@ async function installLibrary(
   }
 
   // arc#227 / F-6c: resume a failed install from a named artifact. Everything
-  // ordered before it is assumed already installed (or deliberately skipped).
+  // ordered before it is assumed already installed (or deliberately skipped) —
+  // this is NOT verified against the DB in v1, so resuming from an artifact
+  // whose predecessors never landed can install it against a missing
+  // dependency. Known gap, tracked in arc#232 (verify predecessors before
+  // resuming).
   let startIndex = 0;
   if (opts.resumeFromArtifact) {
     startIndex = orderedArtifacts.findIndex(
@@ -706,22 +711,21 @@ async function installLibrary(
     if (!opts.yes) {
       console.log(`  ✅ ${artifactResult.name} v${artifactResult.version}`);
     }
-    if (artifactTx) {
-      tx.recordArtifactSuccess(
-        artifactManifest.name,
-        artifactTx,
-        artifactManifest.version,
-        artifactManifest.type,
-      );
-    } else {
-      // Defensive: a success without a captured transaction means nothing for
-      // us to unwind — record state but with no rollback handle.
-      tx.recordArtifactSkipped(
-        artifactManifest.name,
-        artifactManifest.version,
-        artifactManifest.type,
+    // onTransaction always fires (before any hook/postinstall gate) on the path
+    // that reaches a success return, so artifactTx is guaranteed set here. Guard
+    // the invariant rather than branch on it — a missing handle would mean this
+    // artifact could not be rolled back if a later one fails, so fail loud.
+    if (!artifactTx) {
+      throw new Error(
+        `internal: artifact '${artifactManifest.name}' succeeded without a captured install transaction`,
       );
     }
+    tx.recordArtifactSuccess(
+      artifactManifest.name,
+      artifactTx,
+      artifactManifest.version,
+      artifactManifest.type,
+    );
   }
 
   // Mid-sequence failure → atomically roll back everything this run landed.

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -2,7 +2,13 @@ import { join, dirname } from "path";
 import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
-import type { ArtifactType, ArcManifest, ArcPaths, HostAdapter } from "../types.js";
+import type {
+  ArtifactType,
+  ArcManifest,
+  ArcPaths,
+  HostAdapter,
+  LibraryArtifactEntry,
+} from "../types.js";
 import { errorMessage, isErrno } from "./errors.js";
 import {
   createSymlink,
@@ -366,4 +372,87 @@ export function parseLibraryRef(ref: string): { libraryName: string; artifactNam
   }
 
   return { libraryName, artifactName: artifactName || undefined };
+}
+
+/** A library artifact paired with its manifest, as read by readLibraryArtifacts. */
+export interface ArtifactEntry {
+  entry: LibraryArtifactEntry;
+  manifest: ArcManifest;
+}
+
+/**
+ * Topologically sort a library's artifacts by `depends_on.packages`.
+ *
+ * F-6c (arc#227): library installs must land each artifact AFTER the artifacts
+ * it depends on, so that e.g. `pilot` (depends_on agent-state) installs only
+ * once `agent-state` is in place. Only intra-library dependencies constrain
+ * ordering — a `depends_on.packages` entry that names a package NOT contained
+ * in this library (an external dep such as a tool, or another repo's package)
+ * is an install-time gate handled elsewhere (`install.ts` dep check), not an
+ * ordering edge, so it is ignored here.
+ *
+ * Algorithm: Kahn's algorithm over the dependency DAG. Independent peers keep
+ * their declaration order (stable), which keeps console output and the journal
+ * deterministic. A cycle (direct, self, or transitive) leaves nodes unemitted
+ * and throws with the offending names so the operator can fix the manifests.
+ *
+ * @throws Error if a dependency cycle is detected.
+ */
+export function toposortArtifacts(artifacts: ArtifactEntry[]): ArtifactEntry[] {
+  // Index by artifact name so we can tell intra-library deps from external ones.
+  const byName = new Map<string, ArtifactEntry>();
+  for (const a of artifacts) {
+    byName.set(a.manifest.name, a);
+  }
+
+  // Build the dependency edges (dependency -> dependent) and in-degrees,
+  // counting only deps that resolve to another artifact in THIS library.
+  const inDegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  for (const a of artifacts) {
+    inDegree.set(a.manifest.name, inDegree.get(a.manifest.name) ?? 0);
+  }
+  for (const a of artifacts) {
+    const deps = a.manifest.depends_on?.packages ?? [];
+    for (const dep of deps) {
+      if (!byName.has(dep.name)) continue; // external dep — not an ordering edge
+      const list = dependents.get(dep.name) ?? [];
+      list.push(a.manifest.name);
+      dependents.set(dep.name, list);
+      inDegree.set(a.manifest.name, (inDegree.get(a.manifest.name) ?? 0) + 1);
+    }
+  }
+
+  // Kahn's algorithm. Seed the queue in declaration order to keep peers stable.
+  const queue: string[] = [];
+  for (const a of artifacts) {
+    if ((inDegree.get(a.manifest.name) ?? 0) === 0) {
+      queue.push(a.manifest.name);
+    }
+  }
+
+  const ordered: ArtifactEntry[] = [];
+  let cursor = 0;
+  while (cursor < queue.length) {
+    const name = queue[cursor++];
+    const node = byName.get(name);
+    if (node) ordered.push(node);
+    for (const dependent of dependents.get(name) ?? []) {
+      const next = (inDegree.get(dependent) ?? 0) - 1;
+      inDegree.set(dependent, next);
+      if (next === 0) queue.push(dependent);
+    }
+  }
+
+  if (ordered.length !== artifacts.length) {
+    const emitted = new Set(ordered.map((o) => o.manifest.name));
+    const unresolved = artifacts
+      .map((a) => a.manifest.name)
+      .filter((n) => !emitted.has(n));
+    throw new Error(
+      `Dependency cycle detected among library artifacts: ${unresolved.join(", ")}`,
+    );
+  }
+
+  return ordered;
 }

--- a/src/lib/install-transaction.ts
+++ b/src/lib/install-transaction.ts
@@ -38,6 +38,135 @@ export interface InstallTransaction {
   rollback(): Promise<InstallTransactionEvidence>;
 }
 
+// ── Library (multi-artifact) install transaction (arc#227 / F-6c) ───────────
+//
+// The single-package InstallTransaction above (arc#140 P4 lineage) tracks ONE
+// artifact's landed state and unwinds it on failure. A `type: library` install
+// lands an ORDERED SEQUENCE of artifacts; if artifact N fails, artifacts 1..N-1
+// — which have already committed their DB rows + symlinks + hooks + launchd —
+// must be unwound in REVERSE order to leave the stack in a known-good state.
+//
+// beginLibraryInstallTransaction is that lift: it holds each successful
+// artifact's live sub-transaction handle (so rollback reuses the exact same
+// rollback path, not a re-derived one) plus a `removeDbRow` callback for the
+// committed DB rows the sub-transaction itself does not undo (the DB commit is
+// the last step of a single-artifact install, so single-artifact rollback never
+// needs it — the library level does).
+
+/** Per-artifact outcome within a library install (arc#227 / F-6c). */
+export enum ArtifactInstallState {
+  /** Already installed before this run; left untouched. */
+  SKIPPED = "skipped",
+  /** Installed cleanly in this run. */
+  SUCCESS = "success",
+  /** Install attempt failed — the sequence stops here. */
+  FAILED = "failed",
+  /** Installed in this run, then unwound because a later artifact failed. */
+  ROLLED_BACK = "rolled_back",
+}
+
+/** Reported per-artifact state for a library install (extends InstallResult). */
+export interface ArtifactInstallDetail {
+  name: string;
+  version?: string;
+  type?: string;
+  state: ArtifactInstallState;
+  /** Failure reason when state === FAILED. */
+  error?: string;
+  /** Landed-artifact evidence captured for SUCCESS / ROLLED_BACK entries. */
+  evidence?: InstallTransactionEvidence;
+}
+
+/** Full transactional journal of a library install (arc#227 / F-6c). */
+export interface LibraryInstallJournal {
+  libraryName: string;
+  artifacts: ArtifactInstallDetail[];
+  /** ISO timestamp the library transaction opened. */
+  startedAt: string;
+}
+
+export interface LibraryInstallTransaction {
+  /** Record an artifact that was already installed (pre-existing — not unwound). */
+  recordArtifactSkipped(name: string, version?: string, type?: string): void;
+  /** Record a successful artifact install, capturing its live sub-transaction. */
+  recordArtifactSuccess(
+    name: string,
+    tx: InstallTransaction,
+    version?: string,
+    type?: string,
+  ): void;
+  /** Record the failing artifact; the sequence stops and rollback follows. */
+  recordArtifactFailure(name: string, error: string, version?: string, type?: string): void;
+  /** Unwind every SUCCESS artifact in reverse order (symlinks/hooks/launchd + DB row). */
+  rollback(): Promise<LibraryInstallJournal>;
+  /** Snapshot of the journal as it currently stands. */
+  journal(): LibraryInstallJournal;
+}
+
+export function beginLibraryInstallTransaction(opts: {
+  libraryName: string;
+  /**
+   * Teardown callback for a committed DB row. Injected (rather than importing
+   * the db module) so this transaction stays a pure unit. install.ts passes a
+   * closure over `removeSkill(db, name)`.
+   */
+  removeDbRow?: (name: string) => void;
+}): LibraryInstallTransaction {
+  const startedAt = new Date().toISOString();
+
+  // Ordered details, mirrored by the live sub-transaction handles for the
+  // SUCCESS entries (parallel arrays keyed by insertion order).
+  const details: ArtifactInstallDetail[] = [];
+  const landed: { name: string; tx: InstallTransaction }[] = [];
+
+  const find = (name: string) => details.find((d) => d.name === name);
+
+  return {
+    recordArtifactSkipped(name, version, type) {
+      details.push({ name, version, type, state: ArtifactInstallState.SKIPPED });
+    },
+
+    recordArtifactSuccess(name, tx, version, type) {
+      details.push({
+        name,
+        version,
+        type,
+        state: ArtifactInstallState.SUCCESS,
+        evidence: tx.evidence,
+      });
+      landed.push({ name, tx });
+    },
+
+    recordArtifactFailure(name, error, version, type) {
+      details.push({ name, version, type, state: ArtifactInstallState.FAILED, error });
+    },
+
+    async rollback() {
+      // Reverse order: last landed artifact unwinds first.
+      for (let i = landed.length - 1; i >= 0; i--) {
+        const { name, tx } = landed[i];
+        await tx.rollback();
+        // The sub-transaction's own rollback does NOT remove the committed DB
+        // row (the DB commit is the last step of a single-artifact install, so
+        // it never had to). The library level removes it here.
+        if (opts.removeDbRow) {
+          opts.removeDbRow(name);
+        }
+        const detail = find(name);
+        if (detail) {
+          detail.state = ArtifactInstallState.ROLLED_BACK;
+          detail.evidence = tx.evidence;
+        }
+      }
+      return { libraryName: opts.libraryName, artifacts: details, startedAt };
+    },
+
+    journal() {
+      return { libraryName: opts.libraryName, artifacts: details, startedAt };
+    },
+  };
+}
+
 export function beginInstallTransaction(opts: {
   packageName: string;
   authorization: InstallAuthorization;

--- a/src/lib/install-transaction.ts
+++ b/src/lib/install-transaction.ts
@@ -143,15 +143,44 @@ export function beginLibraryInstallTransaction(opts: {
 
     async rollback() {
       // Reverse order: last landed artifact unwinds first.
+      //
+      // Every teardown step here is best-effort and MUST NOT abort the loop:
+      // the atomic-rollback invariant (no earlier-sequence artifact left with
+      // its symlinks/hooks/launchd behind) requires that we unwind ALL landed
+      // artifacts even if one step throws. The filesystem teardown
+      // (tx.rollback()) runs first and is itself best-effort across its own
+      // steps; the DB-row removal that follows is the one call the
+      // sub-transaction does not own, so we wrap it here to match the same
+      // warn-and-continue discipline.
       for (let i = landed.length - 1; i >= 0; i--) {
         const { name, tx } = landed[i];
-        await tx.rollback();
+
+        // Filesystem teardown (symlinks/hooks/launchd/extensions). Internally
+        // best-effort; if it ever threw, the DB row + later artifacts must
+        // still be cleaned, so guard it too.
+        try {
+          await tx.rollback();
+        } catch (err) {
+          process.stderr.write(
+            `  ⚠ rollback: failed to unwind artifact '${name}': ${errorMessage(err)}\n`,
+          );
+        }
+
         // The sub-transaction's own rollback does NOT remove the committed DB
         // row (the DB commit is the last step of a single-artifact install, so
-        // it never had to). The library level removes it here.
+        // it never had to). The library level removes it here — and a failure
+        // (SQLITE_BUSY, locked DB, schema drift) must not abort the unwind of
+        // the remaining artifacts.
         if (opts.removeDbRow) {
-          opts.removeDbRow(name);
+          try {
+            opts.removeDbRow(name);
+          } catch (err) {
+            process.stderr.write(
+              `  ⚠ rollback: failed to remove DB row for '${name}': ${errorMessage(err)}\n`,
+            );
+          }
         }
+
         const detail = find(name);
         if (detail) {
           detail.state = ArtifactInstallState.ROLLED_BACK;

--- a/src/types.ts
+++ b/src/types.ts
@@ -402,6 +402,28 @@ export interface ArcManifest {
   category?: string;
 }
 
+/**
+ * Per-artifact outcome state for a library install (arc#227 / F-6c).
+ *
+ * Distinguishes the four terminal states an artifact reaches inside a
+ * library-install transaction so InstallResult can report partial state:
+ *   - SKIPPED      — already installed before this run; left untouched.
+ *   - SUCCESS      — installed cleanly in this run.
+ *   - FAILED       — install attempt failed (this is where the sequence stops).
+ *   - ROLLED_BACK  — installed in this run, then unwound because a LATER
+ *                    artifact failed (atomic rollback).
+ *
+ * Canonical definition + the journal types live with the transaction in
+ * `lib/install-transaction.ts`; re-exported here so the public manifest/result
+ * surface stays in one place. (Defined there, not here, to keep the
+ * lib → types dependency arrow one-directional — see arc#227 PR notes.)
+ */
+export {
+  ArtifactInstallState,
+  type ArtifactInstallDetail,
+  type LibraryInstallJournal,
+} from "./lib/install-transaction.js";
+
 /** Trust tier for installed packages */
 export type PackageTier = "official" | "community" | "custom";
 

--- a/test/commands/library-install-ordering.test.ts
+++ b/test/commands/library-install-ordering.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { existsSync } from "fs";
+import { join } from "path";
+import { install } from "../../src/commands/install.js";
+import { list } from "../../src/commands/list.js";
+import { ArtifactInstallState } from "../../src/types.js";
+import { createTestEnv, createMockLibraryRepo, type TestEnv } from "../helpers/test-env.js";
+
+/**
+ * arc#227 / F-6c: ordered library installs + atomic multi-artifact rollback.
+ *
+ * Exercises the four spec pillars through the real `install()` entrypoint:
+ *   1. depends_on-ordered install (dependencies land before dependents)
+ *   2. reverse-order rollback when an artifact fails mid-sequence
+ *   3. partial-state reporting via the install journal
+ *   4. resume semantics (retry from the failed artifact)
+ */
+
+let env: TestEnv;
+
+afterEach(async () => {
+  if (env) await env.cleanup();
+});
+
+/** A postinstall that always fails — simulates e.g. an unreachable broker. */
+const FAILING_POSTINSTALL = {
+  path: "scripts/postinstall.sh",
+  content: "#!/usr/bin/env bash\necho 'simulated failure' >&2\nexit 1\n",
+};
+
+describe("library install ordering (arc#227)", () => {
+  test("installs artifacts in dependency order, not declaration order", async () => {
+    env = await createTestEnv();
+    // Declaration order puts dependents BEFORE dependencies on purpose.
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "dev-loop",
+      artifacts: [
+        { path: "agents/dev", name: "dev", type: "skill", dependsOn: ["pilot"] },
+        { path: "agents/pilot", name: "pilot", type: "skill", dependsOn: ["agent-state"] },
+        { path: "agents/agent-state", name: "agent-state", type: "skill" },
+      ],
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.journal).toBeDefined();
+
+    const order = result.journal!.artifacts.map((a) => a.name);
+    // agent-state before pilot before dev.
+    expect(order.indexOf("agent-state")).toBeLessThan(order.indexOf("pilot"));
+    expect(order.indexOf("pilot")).toBeLessThan(order.indexOf("dev"));
+    expect(result.journal!.artifacts.every((a) => a.state === ArtifactInstallState.SUCCESS)).toBe(true);
+
+    const installed = list(env.db);
+    expect(installed.skills).toHaveLength(3);
+  });
+
+  test("rolls back all landed artifacts in reverse order when one fails", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "dev-loop",
+      artifacts: [
+        { path: "agents/agent-state", name: "agent-state", type: "skill" },
+        { path: "agents/pilot", name: "pilot", type: "skill", dependsOn: ["agent-state"] },
+        // dev fails in postinstall AFTER agent-state + pilot have landed.
+        { path: "agents/dev", name: "dev", type: "skill", dependsOn: ["pilot"], postinstall: FAILING_POSTINSTALL },
+        { path: "agents/release", name: "release", type: "skill", dependsOn: ["dev"] },
+      ],
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("dev");
+    expect(result.error).toContain("Rolled back");
+
+    // Atomic: nothing remains installed — agent-state + pilot were unwound.
+    const installed = list(env.db);
+    expect(installed.skills).toHaveLength(0);
+
+    // Atomic at the FILESYSTEM layer too — symlinks for the landed artifacts
+    // are gone, not just their DB rows.
+    expect(existsSync(join(env.host.paths.skillsDir, "agent-state"))).toBe(false);
+    expect(existsSync(join(env.host.paths.skillsDir, "pilot"))).toBe(false);
+
+    // Journal records the rollback shape: the two that landed are rolled_back,
+    // dev is failed, release was never attempted (absent from journal).
+    const states = Object.fromEntries(
+      result.journal!.artifacts.map((a) => [a.name, a.state]),
+    );
+    expect(states["agent-state"]).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.pilot).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.dev).toBe(ArtifactInstallState.FAILED);
+    expect(states.release).toBeUndefined();
+  });
+
+  test("stops the sequence on first failure — later artifacts are never attempted", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "lib",
+      artifacts: [
+        { path: "a/first", name: "first", type: "skill", postinstall: FAILING_POSTINSTALL },
+        { path: "a/second", name: "second", type: "skill", dependsOn: ["first"] },
+      ],
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    const names = result.journal!.artifacts.map((a) => a.name);
+    expect(names).toEqual(["first"]); // 'second' never reached
+    const installed = list(env.db);
+    expect(installed.skills).toHaveLength(0);
+  });
+
+  test("resume installs only from the named artifact onward", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "dev-loop",
+      artifacts: [
+        { path: "agents/agent-state", name: "agent-state", type: "skill" },
+        { path: "agents/pilot", name: "pilot", type: "skill", dependsOn: ["agent-state"] },
+        { path: "agents/dev", name: "dev", type: "skill", dependsOn: ["pilot"] },
+      ],
+    });
+
+    // Pre-install agent-state + pilot the normal way by filtering to each.
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true, artifactName: "agent-state" });
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true, artifactName: "pilot" });
+
+    let installed = list(env.db);
+    expect(installed.skills.map((s) => s.name).sort()).toEqual(["agent-state", "pilot"]);
+
+    // Resume from dev — the two earlier artifacts are skipped (already active).
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+      resumeFromArtifact: "dev",
+    });
+
+    expect(result.success).toBe(true);
+    const devDetail = result.journal!.artifacts.find((a) => a.name === "dev");
+    expect(devDetail?.state).toBe(ArtifactInstallState.SUCCESS);
+    // agent-state + pilot are not even in the resumed journal (started at dev).
+    expect(result.journal!.artifacts.map((a) => a.name)).toEqual(["dev"]);
+
+    installed = list(env.db);
+    expect(installed.skills.map((s) => s.name).sort()).toEqual(["agent-state", "dev", "pilot"]);
+  });
+
+  test("resume rejects an unknown artifact name", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "lib",
+      artifacts: [{ path: "a/alpha", name: "alpha", type: "skill" }],
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+      resumeFromArtifact: "nonexistent",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Resume artifact 'nonexistent' not found");
+  });
+
+  test("reports a dependency cycle without touching the filesystem", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "cyclic",
+      artifacts: [
+        { path: "a/x", name: "x", type: "skill", dependsOn: ["y"] },
+        { path: "a/y", name: "y", type: "skill", dependsOn: ["x"] },
+      ],
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/cycle/i);
+    const installed = list(env.db);
+    expect(installed.skills).toHaveLength(0);
+  });
+
+  test("already-installed artifacts are skipped (not re-installed, not rolled back)", async () => {
+    env = await createTestEnv();
+    const lib = await createMockLibraryRepo(env.root, {
+      name: "lib",
+      artifacts: [
+        { path: "a/alpha", name: "alpha", type: "skill" },
+        { path: "a/beta", name: "beta", type: "skill", dependsOn: ["alpha"] },
+      ],
+    });
+
+    await install({ arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true });
+
+    const result2 = await install({
+      arc: env.arc, host: env.host, db: env.db, repoUrl: lib.url, yes: true,
+    });
+
+    expect(result2.success).toBe(true);
+    expect(result2.journal!.artifacts.every((a) => a.state === ArtifactInstallState.SKIPPED)).toBe(true);
+    const installed = list(env.db);
+    expect(installed.skills).toHaveLength(2); // not duplicated
+  });
+});

--- a/test/helpers/test-env.ts
+++ b/test/helpers/test-env.ts
@@ -316,6 +316,18 @@ export async function createMockLibraryRepo(
       type: "skill" | "tool" | "agent" | "prompt" | "pipeline" | "component" | "action";
       version?: string;
       description?: string;
+      /**
+       * Names of OTHER artifacts in this library this one depends on (arc#227).
+       * Rendered into `depends_on.packages` as `{ name, repo }` so the library
+       * install toposort orders this artifact after its dependencies.
+       */
+      dependsOn?: string[];
+      /**
+       * Optional postinstall script (arc#227 rollback tests). Written to disk
+       * and declared in the artifact manifest's `scripts.postinstall`. Use a
+       * non-zero exit (`exit 1`) to simulate a mid-sequence install failure.
+       */
+      postinstall?: { path: string; content: string };
     }[];
   }
 ): Promise<MockLibraryRepo> {
@@ -341,7 +353,13 @@ export async function createMockLibraryRepo(
   for (const artifact of opts.artifacts) {
     const artifactDir = join(repoDir, artifact.path);
 
-    const artifactManifest = {
+    // Intra-library package deps (arc#227) plus the default bun tool dep.
+    const packageDeps = (artifact.dependsOn ?? []).map((name) => ({
+      name,
+      repo: `the-metafactory/${name}`,
+    }));
+
+    const artifactManifest: Record<string, unknown> = {
       schema: "arc/v1",
       name: artifact.name,
       version: artifact.version ?? "1.0.0",
@@ -350,7 +368,13 @@ export async function createMockLibraryRepo(
       provides: artifact.type === "skill"
         ? { skill: [{ trigger: artifact.name.toLowerCase() }] }
         : {},
-      depends_on: { tools: [{ name: "bun", version: ">=1.0.0" }] },
+      depends_on: {
+        tools: [{ name: "bun", version: ">=1.0.0" }],
+        ...(packageDeps.length ? { packages: packageDeps } : {}),
+      },
+      ...(artifact.postinstall
+        ? { scripts: { postinstall: artifact.postinstall.path } }
+        : {}),
       capabilities: {
         filesystem: { read: ["./"], write: [] },
         network: [],
@@ -360,6 +384,13 @@ export async function createMockLibraryRepo(
     };
 
     await Bun.write(join(artifactDir, "arc-manifest.yaml"), buildYaml(artifactManifest));
+
+    // Write the postinstall script (executable) when declared.
+    if (artifact.postinstall) {
+      const scriptAbsPath = join(artifactDir, artifact.postinstall.path);
+      await Bun.write(scriptAbsPath, artifact.postinstall.content);
+      Bun.spawnSync(["chmod", "+x", scriptAbsPath], { stdout: "pipe", stderr: "pipe" });
+    }
 
     // Create type-specific content
     if (artifact.type === "skill") {

--- a/test/unit/artifact-toposort.test.ts
+++ b/test/unit/artifact-toposort.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { toposortArtifacts } from "../../src/lib/artifact-installer.js";
+import type { ArcManifest, LibraryArtifactEntry } from "../../src/types.js";
+
+/**
+ * Build a minimal artifact entry+manifest pair for toposort tests.
+ *
+ * `deps` lists the names of OTHER artifacts in the same library this one
+ * depends on. They are rendered into `depends_on.packages` exactly the way a
+ * real library artifact manifest declares them (`{ name, repo }`).
+ */
+function artifact(name: string, deps: string[] = []): {
+  entry: LibraryArtifactEntry;
+  manifest: ArcManifest;
+} {
+  return {
+    entry: { path: `artifacts/${name}` },
+    manifest: {
+      schema: "arc/v1",
+      name,
+      version: "1.0.0",
+      type: "skill",
+      depends_on: {
+        packages: deps.map((d) => ({ name: d, repo: `the-metafactory/${d}` })),
+      },
+    },
+  };
+}
+
+/** Assert `a` is ordered strictly before `b` in the result. */
+function before(order: string[], a: string, b: string): boolean {
+  return order.indexOf(a) < order.indexOf(b);
+}
+
+describe("toposortArtifacts", () => {
+  test("returns artifacts unchanged when there are no dependencies", () => {
+    const input = [artifact("a"), artifact("b"), artifact("c")];
+    const sorted = toposortArtifacts(input);
+    expect(sorted.map((s) => s.manifest.name)).toEqual(["a", "b", "c"]);
+  });
+
+  test("orders a dependency before its dependent", () => {
+    // pilot depends on agent-state -> agent-state must come first
+    const input = [artifact("pilot", ["agent-state"]), artifact("agent-state")];
+    const order = toposortArtifacts(input).map((s) => s.manifest.name);
+    expect(before(order, "agent-state", "pilot")).toBe(true);
+  });
+
+  test("resolves a transitive chain (dev -> pilot -> agent-state)", () => {
+    const input = [
+      artifact("dev", ["pilot"]),
+      artifact("pilot", ["agent-state"]),
+      artifact("agent-state"),
+    ];
+    const order = toposortArtifacts(input).map((s) => s.manifest.name);
+    expect(before(order, "agent-state", "pilot")).toBe(true);
+    expect(before(order, "pilot", "dev")).toBe(true);
+  });
+
+  test("resolves a diamond (two dependents share one root)", () => {
+    // approver + release both depend on pilot; pilot depends on agent-state.
+    const input = [
+      artifact("release", ["pilot"]),
+      artifact("approver", ["pilot"]),
+      artifact("pilot", ["agent-state"]),
+      artifact("agent-state"),
+    ];
+    const order = toposortArtifacts(input).map((s) => s.manifest.name);
+    expect(before(order, "agent-state", "pilot")).toBe(true);
+    expect(before(order, "pilot", "approver")).toBe(true);
+    expect(before(order, "pilot", "release")).toBe(true);
+  });
+
+  test("ignores depends_on packages that are not artifacts of this library", () => {
+    // 'bun' / external repos are install-time gates, not ordering constraints.
+    const input = [artifact("alpha", ["some-external-tool"]), artifact("beta")];
+    const order = toposortArtifacts(input).map((s) => s.manifest.name);
+    expect(order.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  test("throws on a direct cycle (a -> b -> a)", () => {
+    const input = [artifact("a", ["b"]), artifact("b", ["a"])];
+    expect(() => toposortArtifacts(input)).toThrow(/cycle/i);
+  });
+
+  test("throws on a self-cycle (a -> a)", () => {
+    const input = [artifact("a", ["a"])];
+    expect(() => toposortArtifacts(input)).toThrow(/cycle/i);
+  });
+
+  test("is deterministic — preserves declaration order among independent peers", () => {
+    const input = [artifact("z"), artifact("y"), artifact("x")];
+    const order = toposortArtifacts(input).map((s) => s.manifest.name);
+    expect(order).toEqual(["z", "y", "x"]);
+  });
+});

--- a/test/unit/library-install-transaction.test.ts
+++ b/test/unit/library-install-transaction.test.ts
@@ -122,4 +122,60 @@ describe("LibraryInstallTransaction", () => {
     const skipped = journal.artifacts.find((a) => a.name === "agent-state");
     expect(skipped?.state).toBe(ArtifactInstallState.SKIPPED);
   });
+
+  test("a removeDbRow failure mid-unwind does NOT abort rollback of the other artifacts", async () => {
+    // arc#231 review (MAJOR): if removeSkill throws (SQLITE_BUSY / locked DB /
+    // schema drift) on one artifact, every OTHER landed artifact must still get
+    // its filesystem rollback and ROLLED_BACK journal state — the loop cannot
+    // abort, or earlier-sequence artifacts are left with their symlinks behind.
+    const filesystemRolledBack: string[] = [];
+    const dbAttempts: string[] = [];
+
+    const tx = beginLibraryInstallTransaction({
+      libraryName: "dev-loop",
+      removeDbRow: (name) => {
+        dbAttempts.push(name);
+        // Throw on the SECOND artifact unwound (pilot — landed[1], reverse).
+        if (name === "pilot") {
+          throw new Error("SQLITE_BUSY: database is locked");
+        }
+      },
+    });
+
+    // Three artifacts succeed (a, b=pilot, c). Reverse-unwind order: c, pilot, a.
+    const names = ["a", "pilot", "c"];
+    for (const name of names) {
+      const sub = beginInstallTransaction({
+        packageName: name,
+        authorization: { approved: true },
+      });
+      const realRollback = sub.rollback.bind(sub);
+      sub.rollback = async () => {
+        filesystemRolledBack.push(name);
+        return realRollback();
+      };
+      sub.recordDbCommit(name);
+      tx.recordArtifactSuccess(name, sub);
+    }
+
+    tx.recordArtifactFailure("dev", "boom");
+
+    // Must not throw despite removeDbRow throwing on 'pilot'.
+    const journal = await tx.rollback();
+
+    // ALL three got their filesystem rollback, in reverse order.
+    expect(filesystemRolledBack).toEqual(["c", "pilot", "a"]);
+    // The DB removal was ATTEMPTED for all three (the throw didn't skip any).
+    expect(dbAttempts).toEqual(["c", "pilot", "a"]);
+
+    // Every landed artifact is journaled ROLLED_BACK — even the one whose DB
+    // row removal threw — so partial-state reporting stays truthful.
+    const states = Object.fromEntries(
+      journal.artifacts.map((a) => [a.name, a.state]),
+    );
+    expect(states.a).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.pilot).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.c).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.dev).toBe(ArtifactInstallState.FAILED);
+  });
 });

--- a/test/unit/library-install-transaction.test.ts
+++ b/test/unit/library-install-transaction.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import {
+  beginInstallTransaction,
+  beginLibraryInstallTransaction,
+} from "../../src/lib/install-transaction.js";
+import { ArtifactInstallState } from "../../src/types.js";
+
+/**
+ * A library-install transaction tracks an ORDERED sequence of artifact
+ * sub-transactions and, on failure, rolls them back in REVERSE order — the
+ * arc#140 P4 single-package rollback model lifted to the library level
+ * (arc#227 / F-6c).
+ */
+describe("LibraryInstallTransaction", () => {
+  test("journal starts with every artifact pending", () => {
+    const tx = beginLibraryInstallTransaction({ libraryName: "dev-loop" });
+    const journal = tx.journal();
+    expect(journal.libraryName).toBe("dev-loop");
+    expect(journal.artifacts).toEqual([]);
+    expect(typeof journal.startedAt).toBe("string");
+  });
+
+  test("records skip / success / failure states per artifact", () => {
+    const tx = beginLibraryInstallTransaction({ libraryName: "dev-loop" });
+
+    tx.recordArtifactSkipped("agent-state");
+
+    const okTx = beginInstallTransaction({
+      packageName: "pilot",
+      authorization: { approved: true },
+    });
+    okTx.recordDbCommit("pilot");
+    tx.recordArtifactSuccess("pilot", okTx);
+
+    tx.recordArtifactFailure("dev", "postinstall exited 1");
+
+    const journal = tx.journal();
+    expect(journal.artifacts.map((a) => [a.name, a.state])).toEqual([
+      ["agent-state", ArtifactInstallState.SKIPPED],
+      ["pilot", ArtifactInstallState.SUCCESS],
+      ["dev", ArtifactInstallState.FAILED],
+    ]);
+    expect(journal.artifacts[2].error).toBe("postinstall exited 1");
+  });
+
+  test("rollback unwinds successful artifacts in reverse order and removes DB rows", async () => {
+    const order: string[] = [];
+
+    const tx = beginLibraryInstallTransaction({
+      libraryName: "dev-loop",
+      // The library tx delegates DB-row teardown to this callback so it does
+      // not have to import the db module (keeps the transaction pure).
+      removeDbRow: (name) => {
+        order.push(`db:${name}`);
+      },
+    });
+
+    // Two artifacts succeed; each owns a single-package sub-transaction whose
+    // rollback we observe via a recorded extension (rollback is async + real).
+    const first = beginInstallTransaction({
+      packageName: "agent-state",
+      authorization: { approved: true },
+    });
+    const firstRollback = first.rollback.bind(first);
+    first.rollback = async () => {
+      order.push("rollback:agent-state");
+      return firstRollback();
+    };
+    first.recordDbCommit("agent-state");
+    tx.recordArtifactSuccess("agent-state", first);
+
+    const second = beginInstallTransaction({
+      packageName: "pilot",
+      authorization: { approved: true },
+    });
+    const secondRollback = second.rollback.bind(second);
+    second.rollback = async () => {
+      order.push("rollback:pilot");
+      return secondRollback();
+    };
+    second.recordDbCommit("pilot");
+    tx.recordArtifactSuccess("pilot", second);
+
+    // Third artifact fails.
+    tx.recordArtifactFailure("dev", "broker unreachable");
+
+    const journal = await tx.rollback();
+
+    // Reverse order: pilot rolled back before agent-state; DB rows removed too.
+    expect(order).toEqual([
+      "rollback:pilot",
+      "db:pilot",
+      "rollback:agent-state",
+      "db:agent-state",
+    ]);
+
+    // Journal reflects the rolled-back state for the two that had landed.
+    const states = Object.fromEntries(
+      journal.artifacts.map((a) => [a.name, a.state]),
+    );
+    expect(states.pilot).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states["agent-state"]).toBe(ArtifactInstallState.ROLLED_BACK);
+    expect(states.dev).toBe(ArtifactInstallState.FAILED);
+  });
+
+  test("skipped artifacts are NOT rolled back (they predate this install)", async () => {
+    const removed: string[] = [];
+    const tx = beginLibraryInstallTransaction({
+      libraryName: "dev-loop",
+      removeDbRow: (name) => removed.push(name),
+    });
+
+    tx.recordArtifactSkipped("agent-state"); // already installed before this run
+
+    tx.recordArtifactFailure("pilot", "boom");
+
+    await tx.rollback();
+
+    // agent-state was pre-existing — rollback must not touch its DB row.
+    expect(removed).toEqual([]);
+    const journal = tx.journal();
+    const skipped = journal.artifacts.find((a) => a.name === "agent-state");
+    expect(skipped?.state).toBe(ArtifactInstallState.SKIPPED);
+  });
+});


### PR DESCRIPTION
## What

dev-loop **F-6c**: `type: library` installs now (1) land artifacts in **dependency order**, (2) **roll back atomically in reverse order** when an artifact fails mid-sequence, (3) report **partial per-artifact state** via a transactional journal, and (4) support **resume** from a named artifact. Lifts the arc#140 P4 single-package rollback model to multi-artifact library sequences.

Closes #227
Refs cortex#835 (agentic dev pipeline — design §6.4 F-6c)

## Design as built

**1. Dependency ordering** — `toposortArtifacts()` in `src/lib/artifact-installer.ts`. Kahn's algorithm over `depends_on.packages` edges, but **only intra-library edges constrain order** — a `depends_on.packages` entry naming a package not contained in this library (an external tool/repo dep) is an install-time gate handled elsewhere, not an ordering edge, so it is ignored. Independent peers keep declaration order (deterministic journal/console). A cycle (direct, self, transitive) throws with the offending names before any filesystem mutation.

**2. Transaction journal** — `beginLibraryInstallTransaction()` in `src/lib/install-transaction.ts`. Rather than re-deriving rollback from an evidence blob, the library transaction **holds each successful artifact's live `InstallTransaction` handle** (the exact arc#140 P4 sub-transaction) plus a `removeDbRow` callback. `rollback()` walks the landed artifacts in **reverse order**, calling each sub-transaction's `rollback()` (symlinks/hooks/launchd/extensions) and then `removeDbRow` for the committed DB row the sub-transaction itself never had to undo (the DB commit is the last step of a single-artifact install). Skipped (pre-existing) artifacts are **never** rolled back. New types: `ArtifactInstallState` (skipped/success/failed/rolled_back), `ArtifactInstallDetail`, `LibraryInstallJournal`.

**3. Library install logic** — `installLibrary()` in `src/commands/install.ts`: toposort → ordered install → **stop on first failure** → reverse-order rollback → journal. `installSingleArtifact()` gains an optional `onTransaction` hook so the library can capture the live sub-transaction; **standalone installs are unaffected** (callback absent). `InstallResult` gains `journal` (authoritative per-artifact state) while keeping `artifacts: InstallResult[]` for backward compatibility.

**4. Resume** — `InstallOptions.resumeFromArtifact`: skips every artifact ordered before the named one (assumed already installed/skipped) and installs from it onward with the same ordered + atomic-rollback semantics. Unknown name → clear error.

## Divergences from spec (followed the code's reality)

1. **`InstallResult.artifacts` kept as `InstallResult[]`** (spec proposed switching it to `ArtifactInstallDetail[]`). Existing library tests read `.success`/`.name`/`.version` off it; changing the shape would break acceptance criterion #6 (backward compat). The spec's intent — authoritative per-artifact state — is delivered via the **new `journal` field** (`journal.artifacts: ArtifactInstallDetail[]`).
2. **Journal/state types live in `lib/install-transaction.ts`, re-exported from `types.ts`** (spec placed `ArtifactInstallState`/`ArtifactInstallDetail` in `types.ts`). `types.ts` imports nothing from `lib/`, and the journal references `InstallTransactionEvidence` (a lib type); defining there + re-exporting keeps the lib→types dependency arrow one-directional and avoids an import cycle. They are still importable from `../types.js`.
3. **Rollback model holds live sub-transaction handles, not an evidence blob** (spec sketched an evidence-replay model). Reusing the live `InstallTransaction.rollback()` is the literal "extend, don't fork" of arc#140 P4 — one rollback path, not two.
4. **`PackageDependency` is `{ name, repo }`** (no `version` field) in this repo; `depends_on.packages[].name` is the ordering key, matching the spec's `.map(p => p.name)`.

## Tests (TDD — 19 new)

- `test/unit/artifact-toposort.test.ts` (8): no-deps passthrough, dependency-before-dependent, transitive chain, diamond, external-dep ignored, direct cycle, self-cycle, deterministic peer order.
- `test/unit/library-install-transaction.test.ts` (4): journal pending state, skip/success/failure recording, reverse-order rollback + DB-row removal, skipped-not-rolled-back.
- `test/commands/library-install-ordering.test.ts` (7): dependency-ordered install, reverse-order rollback (DB **and** filesystem symlinks), stop-on-first-failure, resume-from-artifact, resume-unknown-name rejection, cycle reporting (no filesystem touch), already-installed skip.

Test helper `createMockLibraryRepo` extended with per-artifact `dependsOn` + `postinstall` (to inject mid-sequence failures).

## Gates

```
$ bun run lint:errors
$ eslint --quiet .
# exit 0 — clean

$ bunx tsc --noEmit
# exit 0 — clean

$ bun test
 1048 pass
 3 skip
 0 fail
 2733 expect() calls
Ran 1051 tests across 69 files.
```

(The 3 skips are pre-existing and unrelated; 0 fail. CI's `test` job is `continue-on-error` per arc#151 — lint + typecheck are the gating jobs and both pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)