### PR TITLE
feat(install): F-6e — secret provisioning at install

### DIFF
--- a/docs/secret-provisioning.md
+++ b/docs/secret-provisioning.md
@@ -43,6 +43,38 @@ agent's scoped forge token).
 `resolveSecretBackend()` picks the native backend when available, else the
 universal chmod-600 `FileBackend`.
 
+### macOS Keychain argv exposure (and the shared-host gate)
+
+`security add-generic-password -w <value>` places the secret **value on the
+spawned process's argv** for the lifetime of the `spawnSync` call. On a shared
+multi-user macOS host (or a shared-PID-namespace container) another user can
+read it via `ps auxww` or `/proc/<pid>/cmdline`. This is a limitation of the
+macOS `security` CLI: its `-w` flag has no stdin channel, so a value passed
+non-interactively *must* go through argv. (This is **not** how `gh auth login`
+works — gh reads its token from stdin via `--with-token`. An earlier code
+comment claimed parity with gh; that was wrong and has been corrected.)
+
+Mitigation — backend selection, not the call site:
+
+- **`--secret-backend auto`** (default): on macOS, prefer Keychain **only on a
+  single-user host**. On a shared/CI host (the `CI`, `GITHUB_ACTIONS`,
+  `CONTINUOUS_INTEGRATION`, or `ARC_SHARED_HOST` env marker is set) arc selects
+  the chmod-600 `FileBackend` instead, so the argv window is opt-in on dev
+  machines only.
+- **`--secret-backend keychain`**: force the Keychain even on a shared host
+  (you accept the argv window).
+- **`--secret-backend file`**: force the chmod-600 file backend everywhere.
+
+Residual risk on a single-user dev box: the value is on argv for the
+few-millisecond spawn duration — acceptable for a single-user machine,
+mitigated everywhere else.
+
+`arc secrets list` is **unsupported on the Keychain backend** (the `security`
+CLI can't enumerate items for a service prefix without dumping the whole login
+keychain). Rather than silently report "no secrets", it exits non-zero with a
+message pointing at `arc secrets check <agent>`, which resolves presence per
+manifest-declared name and works on every backend.
+
 ## Injection
 
 - **Postinstall env** — `arc install` injects the agent's stored secrets into
@@ -73,6 +105,10 @@ place: `(secret redacted)`.
 Other guardrails:
 
 - **chmod 600** enforced on the file fallback on every write and read.
+- **Atomic write** — the file backend writes into a fresh 0600 temp file in the
+  same directory and `rename(2)`s it over the target, so a concurrent reader
+  sees the old complete file or the new one — never a truncated value, and never
+  old content sitting at a transiently-loose mode on overwrite.
 - **No in-place overwrite on rotate** — delete then add (two steps).
 - **One secret per file** — no mixing in the file backend.
 - **Keychain/file scope** — locked to the principal's user account; a

--- a/docs/secret-provisioning.md
+++ b/docs/secret-provisioning.md
@@ -1,0 +1,80 @@
+# Secret provisioning at install (F-6e, arc#229)
+
+`type: agent` packages declare the scoped credentials they need in their
+manifest:
+
+```yaml
+capabilities:
+  secrets:
+    - APPROVER_GH_TOKEN
+    - CORTEX_DEV_GH_TOKEN
+```
+
+arc provisions those secrets at install time and injects them into the agent's
+**per-agent environment** — never into a brief or a log (cortex
+`docs/design-agentic-dev-pipeline.md` §6.2 step 5, §3.5b authority model).
+
+## Install-time flow
+
+`arc install <pkg>` detects `capabilities.secrets` and, for each declared name:
+
+| Mode | Flag | Behaviour |
+|---|---|---|
+| **Interactive** | *(default)* | Securely prompt (no echo). Press Return to skip a secret. |
+| **From env** | `--from-env` | Read each declared secret from the current environment. CI / scripted installs. |
+| **Skip** | `--skip-secrets` | Store nothing. The daemon starts and fails at first use with a clear message. |
+
+A storage failure aborts the install cleanly (no symlinks placed yet). A skipped
+secret only WARNs — listing the missing NAMES and the `arc secrets set …`
+command to provision them later.
+
+The motivating examples are the dev-loop's own credentials —
+`APPROVER_GH_TOKEN` (approver-bot merge gate) and `CORTEX_DEV_GH_TOKEN` (dev
+agent's scoped forge token).
+
+## Storage backends
+
+| Platform | Native | Fallback |
+|---|---|---|
+| macOS | Keychain via the `security` CLI. Service key `ai.meta-factory.cortex.<agent>.<NAME>`, account-scoped to the principal's username. | chmod-600 file |
+| Linux | systemd `LoadCredential` resolves the file at daemon-start (no install-time backend) | chmod-600 file |
+| any | — | `~/.config/metafactory/secrets/<agent>/<NAME>`, one secret per file, chmod 600 enforced on every write **and** read (cortex#87) |
+
+`resolveSecretBackend()` picks the native backend when available, else the
+universal chmod-600 `FileBackend`.
+
+## Injection
+
+- **Postinstall env** — `arc install` injects the agent's stored secrets into
+  the postinstall child's environment only. The env is a fresh object scoped to
+  that child invocation; arc's own process env is never mutated, so the secrets
+  are gone the moment postinstall exits.
+- **Plist / systemd render** — the service template references the stored secret
+  by name; the resolver reads it from the backend at render / daemon-start time.
+
+## Lifecycle verbs
+
+```
+arc secrets list   <agent>            # stored secret NAMES (never values)
+arc secrets check  <agent>            # declared vs stored; exit 1 if any missing
+arc secrets set    <agent> <secret>   # prompt securely, or --from-env
+arc secrets rotate <agent> <secret>   # no in-place overwrite (delete then add)
+arc secrets remove <agent> [<secret>] # one secret, or all declared when omitted
+```
+
+## Never-log invariant (issue §E)
+
+A secret **value** never reaches stdout, stderr, an argv arc logs, or an audit
+line. Every verb and warning prints NAMES only. The only ingress is the prompt /
+env read; the only egress is the storage backend and the per-child env. The
+`redactSecret()` helper is the single string a diagnostic may print in a value's
+place: `(secret redacted)`.
+
+Other guardrails:
+
+- **chmod 600** enforced on the file fallback on every write and read.
+- **No in-place overwrite on rotate** — delete then add (two steps).
+- **One secret per file** — no mixing in the file backend.
+- **Keychain/file scope** — locked to the principal's user account; a
+  daemon-start retrieval failure is loud (with a hint to re-run `arc secrets
+  set`), never silent.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,15 @@ import { createArcPaths, ensureDirectories, getDefaultHost } from "./lib/paths.j
 import { openDatabase, getSkill } from "./lib/db.js";
 import { extractAllCliInfo, SymlinkConflictError } from "./lib/symlinks.js";
 import { install, parseNameVersion } from "./commands/install.js";
+import {
+  secretsList,
+  secretsCheck,
+  secretsSet,
+  secretsRotate,
+  secretsRemove,
+} from "./commands/secrets.js";
+import { readManifest } from "./lib/manifest.js";
+import { resolveSecretBackend, type SecretBackend } from "./lib/secrets.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
 import { info, formatInfo, formatInfoJson } from "./commands/info.js";
 import { audit, formatAudit } from "./commands/audit.js";
@@ -97,7 +106,7 @@ import {
   findInAllSources,
   updateAllSources,
 } from "./lib/remote-registry.js";
-import { homedir } from "os";
+import { homedir, userInfo } from "os";
 import { join } from "path";
 import { parseLibraryRef } from "./lib/artifact-installer.js";
 import { errorMessage } from "./lib/errors.js";
@@ -165,7 +174,9 @@ program
   .option("--pin <version>", "Pin to a specific version (git tag)")
   .option("--bin-dir <path>", "Directory for PATH-accessible command shims")
   .option("--strict-signing", "Refuse to install if Sigstore signature is missing on an official-tier package")
-  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; binDir?: string; strictSigning?: boolean }) => {
+  .option("--skip-secrets", "Install without provisioning declared secrets (daemon fails at first use with a clear message)")
+  .option("--from-env", "Resolve declared secrets from the current environment instead of prompting")
+  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; binDir?: string; strictSigning?: boolean; skipSecrets?: boolean; fromEnv?: boolean }) => {
     // Non-TTY guard: fail loud rather than silently half-installing
     if (!opts.yes && !process.stdin.isTTY) {
       console.error("Error: arc install requires an interactive terminal for capability confirmation.");
@@ -381,6 +392,8 @@ program
         preExtractedPath: extract.extractedPath,
         sourceName: resolved.source.name,
         sourceTier: resolved.source.tier,
+        skipSecrets: opts.skipSecrets,
+        fromEnv: opts.fromEnv,
       });
       if (result.success) {
         // arc#160: don't claim "(verified)" on the final line when only the
@@ -397,7 +410,7 @@ program
       }
     } else if (isUrl) {
       // Direct git install
-      const result = await install({ arc: paths, host, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion });
+      const result = await install({ arc: paths, host, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion, skipSecrets: opts.skipSecrets, fromEnv: opts.fromEnv });
       if (result.success) {
         if (result.artifacts?.length) {
           console.log(`\n✅ Installed ${result.artifacts.filter(a => a.success).length} artifact(s) from ${result.name}`);
@@ -434,6 +447,8 @@ program
         artifactName,
         libraryName,
         pinnedVersion,
+        skipSecrets: opts.skipSecrets,
+        fromEnv: opts.fromEnv,
       });
       if (result.success) {
         if (result.artifacts?.length) {
@@ -1518,6 +1533,97 @@ nats
       return;
     }
     await setupOperator(account, botNames, { force: opts.force });
+  });
+
+// ── F-6e (arc#229) secret provisioning commands ───────────────────
+//
+// `arc secrets <verb> <agent> [<secret>]` manages the per-agent secrets a
+// `type: agent` package declares in `capabilities.secrets`. Storage is the
+// platform backend (Keychain on macOS, chmod-600 file fallback). The verbs
+// print NAMES only — a secret value never reaches stdout/stderr (issue §E).
+
+/**
+ * Resolve an installed agent's manifest from the package DB, plus a storage
+ * backend scoped to that agent. Exits the process with a clear message when
+ * the agent isn't installed (no value is ever involved here).
+ */
+async function resolveAgentSecretContext(
+  agent: string,
+): Promise<{ manifest: ArcManifest; backend: SecretBackend }> {
+  const paths = createArcPaths();
+  const db = openDatabase(paths.dbPath);
+  const skill = getSkill(db, agent);
+  db.close();
+  if (!skill) {
+    console.error(`No installed package named '${agent}'. Run \`arc list\` to see installed agents.`);
+    process.exit(1);
+  }
+  const manifest = await readManifest(skill.install_path);
+  if (!manifest) {
+    console.error(`Could not read the manifest for '${agent}' at ${skill.install_path}.`);
+    process.exit(1);
+  }
+  const backend = resolveSecretBackend(agent, {
+    platform: process.platform,
+    secretsRoot: paths.secretsDir,
+    username: secretUsername(),
+  });
+  return { manifest, backend };
+}
+
+/** Best-effort current username for the Keychain account scope. */
+function secretUsername(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return homedir().split("/").filter(Boolean).pop() ?? "user";
+  }
+}
+
+const secrets = program
+  .command("secrets")
+  .description("Provision and manage per-agent secrets (capabilities.secrets)");
+
+secrets
+  .command("list <agent>")
+  .description("List the secret names stored for an agent (never values)")
+  .action(async (agent: string) => {
+    const { backend } = await resolveAgentSecretContext(agent);
+    process.exit(await secretsList({ agent, backend }));
+  });
+
+secrets
+  .command("check <agent>")
+  .description("Verify every declared secret is stored; exit 1 if any missing")
+  .action(async (agent: string) => {
+    const { manifest, backend } = await resolveAgentSecretContext(agent);
+    process.exit(await secretsCheck(manifest, { agent, backend }));
+  });
+
+secrets
+  .command("set <agent> <secret>")
+  .description("Store a secret (prompts securely, or use --from-env)")
+  .option("--from-env", "Take the value from the env var of the same name")
+  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean }) => {
+    const { backend } = await resolveAgentSecretContext(agent);
+    process.exit(await secretsSet(secret, { agent, backend, fromEnv: opts.fromEnv }));
+  });
+
+secrets
+  .command("rotate <agent> <secret>")
+  .description("Replace a secret with no in-place overwrite (delete then add)")
+  .option("--from-env", "Take the new value from the env var of the same name")
+  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean }) => {
+    const { backend } = await resolveAgentSecretContext(agent);
+    process.exit(await secretsRotate(secret, { agent, backend, fromEnv: opts.fromEnv }));
+  });
+
+secrets
+  .command("remove <agent> [secret]")
+  .description("Remove one secret, or all declared secrets when none is named")
+  .action(async (agent: string, secret: string | undefined) => {
+    const { manifest, backend } = await resolveAgentSecretContext(agent);
+    process.exit(await secretsRemove({ agent, backend, name: secret, manifest }));
   });
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {
   secretsRemove,
 } from "./commands/secrets.js";
 import { readManifest } from "./lib/manifest.js";
-import { resolveSecretBackend, type SecretBackend } from "./lib/secrets.js";
+import { resolveSecretBackend, type SecretBackend, type SecretBackendChoice } from "./lib/secrets.js";
 import { list, formatList, formatListJson } from "./commands/list.js";
 import { info, formatInfo, formatInfoJson } from "./commands/info.js";
 import { audit, formatAudit } from "./commands/audit.js";
@@ -176,13 +176,19 @@ program
   .option("--strict-signing", "Refuse to install if Sigstore signature is missing on an official-tier package")
   .option("--skip-secrets", "Install without provisioning declared secrets (daemon fails at first use with a clear message)")
   .option("--from-env", "Resolve declared secrets from the current environment instead of prompting")
-  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; binDir?: string; strictSigning?: boolean; skipSecrets?: boolean; fromEnv?: boolean }) => {
+  .option("--secret-backend <choice>", "Secret storage backend: auto (default) | keychain | file. 'auto' uses the chmod-600 file backend on shared/CI hosts to avoid the macOS Keychain argv-exposure window")
+  .action(async (nameOrUrl: string, opts: { yes?: boolean; pin?: string; binDir?: string; strictSigning?: boolean; skipSecrets?: boolean; fromEnv?: boolean; secretBackend?: string }) => {
     // Non-TTY guard: fail loud rather than silently half-installing
     if (!opts.yes && !process.stdin.isTTY) {
       console.error("Error: arc install requires an interactive terminal for capability confirmation.");
       console.error("Pass --yes (-y) to approve non-interactively.");
       process.exit(1);
     }
+
+    // Validate --secret-backend (F-6e). `auto` applies the shared-host
+    // heuristic; `keychain` forces the macOS Keychain (accepting its argv
+    // exposure); `file` forces the chmod-600 file backend.
+    const secretBackend = parseSecretBackendChoice(opts.secretBackend);
 
     const paths = createInstallPaths(opts);
     const host = getDefaultHost();
@@ -394,6 +400,7 @@ program
         sourceTier: resolved.source.tier,
         skipSecrets: opts.skipSecrets,
         fromEnv: opts.fromEnv,
+        secretBackend,
       });
       if (result.success) {
         // arc#160: don't claim "(verified)" on the final line when only the
@@ -410,7 +417,7 @@ program
       }
     } else if (isUrl) {
       // Direct git install
-      const result = await install({ arc: paths, host, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion, skipSecrets: opts.skipSecrets, fromEnv: opts.fromEnv });
+      const result = await install({ arc: paths, host, db, repoUrl: nameOrUrl, yes: opts.yes, artifactName, pinnedVersion, skipSecrets: opts.skipSecrets, fromEnv: opts.fromEnv, secretBackend });
       if (result.success) {
         if (result.artifacts?.length) {
           console.log(`\n✅ Installed ${result.artifacts.filter(a => a.success).length} artifact(s) from ${result.name}`);
@@ -449,6 +456,7 @@ program
         pinnedVersion,
         skipSecrets: opts.skipSecrets,
         fromEnv: opts.fromEnv,
+        secretBackend,
       });
       if (result.success) {
         if (result.artifacts?.length) {
@@ -1549,6 +1557,7 @@ nats
  */
 async function resolveAgentSecretContext(
   agent: string,
+  backendChoice?: SecretBackendChoice,
 ): Promise<{ manifest: ArcManifest; backend: SecretBackend }> {
   const paths = createArcPaths();
   const db = openDatabase(paths.dbPath);
@@ -1567,8 +1576,20 @@ async function resolveAgentSecretContext(
     platform: process.platform,
     secretsRoot: paths.secretsDir,
     username: secretUsername(),
+    backendChoice,
   });
   return { manifest, backend };
+}
+
+/**
+ * Validate a `--secret-backend` flag value into a {@link SecretBackendChoice}.
+ * Exits with a clear message on an unknown value. `undefined` → `auto`.
+ */
+function parseSecretBackendChoice(value: string | undefined): SecretBackendChoice {
+  if (value === undefined) return "auto";
+  if (value === "auto" || value === "keychain" || value === "file") return value;
+  console.error(`Invalid --secret-backend "${value}". Expected: auto | keychain | file.`);
+  process.exit(1);
 }
 
 /** Best-effort current username for the Keychain account scope. */
@@ -1584,19 +1605,34 @@ const secrets = program
   .command("secrets")
   .description("Provision and manage per-agent secrets (capabilities.secrets)");
 
+// All five verbs accept `--secret-backend` so an operator who provisioned with
+// a forced backend (e.g. `file` on a shared host) reads/rotates/removes against
+// that same backend. Omitted → `auto`.
+const SECRET_BACKEND_OPT = "--secret-backend <choice>";
+const SECRET_BACKEND_DESC =
+  "Secret storage backend: auto (default) | keychain | file";
+
 secrets
   .command("list <agent>")
   .description("List the secret names stored for an agent (never values)")
-  .action(async (agent: string) => {
-    const { backend } = await resolveAgentSecretContext(agent);
+  .option(SECRET_BACKEND_OPT, SECRET_BACKEND_DESC)
+  .action(async (agent: string, opts: { secretBackend?: string }) => {
+    const { backend } = await resolveAgentSecretContext(
+      agent,
+      parseSecretBackendChoice(opts.secretBackend),
+    );
     process.exit(await secretsList({ agent, backend }));
   });
 
 secrets
   .command("check <agent>")
   .description("Verify every declared secret is stored; exit 1 if any missing")
-  .action(async (agent: string) => {
-    const { manifest, backend } = await resolveAgentSecretContext(agent);
+  .option(SECRET_BACKEND_OPT, SECRET_BACKEND_DESC)
+  .action(async (agent: string, opts: { secretBackend?: string }) => {
+    const { manifest, backend } = await resolveAgentSecretContext(
+      agent,
+      parseSecretBackendChoice(opts.secretBackend),
+    );
     process.exit(await secretsCheck(manifest, { agent, backend }));
   });
 
@@ -1604,8 +1640,12 @@ secrets
   .command("set <agent> <secret>")
   .description("Store a secret (prompts securely, or use --from-env)")
   .option("--from-env", "Take the value from the env var of the same name")
-  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean }) => {
-    const { backend } = await resolveAgentSecretContext(agent);
+  .option(SECRET_BACKEND_OPT, SECRET_BACKEND_DESC)
+  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean; secretBackend?: string }) => {
+    const { backend } = await resolveAgentSecretContext(
+      agent,
+      parseSecretBackendChoice(opts.secretBackend),
+    );
     process.exit(await secretsSet(secret, { agent, backend, fromEnv: opts.fromEnv }));
   });
 
@@ -1613,16 +1653,24 @@ secrets
   .command("rotate <agent> <secret>")
   .description("Replace a secret with no in-place overwrite (delete then add)")
   .option("--from-env", "Take the new value from the env var of the same name")
-  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean }) => {
-    const { backend } = await resolveAgentSecretContext(agent);
+  .option(SECRET_BACKEND_OPT, SECRET_BACKEND_DESC)
+  .action(async (agent: string, secret: string, opts: { fromEnv?: boolean; secretBackend?: string }) => {
+    const { backend } = await resolveAgentSecretContext(
+      agent,
+      parseSecretBackendChoice(opts.secretBackend),
+    );
     process.exit(await secretsRotate(secret, { agent, backend, fromEnv: opts.fromEnv }));
   });
 
 secrets
   .command("remove <agent> [secret]")
   .description("Remove one secret, or all declared secrets when none is named")
-  .action(async (agent: string, secret: string | undefined) => {
-    const { manifest, backend } = await resolveAgentSecretContext(agent);
+  .option(SECRET_BACKEND_OPT, SECRET_BACKEND_DESC)
+  .action(async (agent: string, secret: string | undefined, opts: { secretBackend?: string }) => {
+    const { manifest, backend } = await resolveAgentSecretContext(
+      agent,
+      parseSecretBackendChoice(opts.secretBackend),
+    );
     process.exit(await secretsRemove({ agent, backend, name: secret, manifest }));
   });
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -53,6 +53,7 @@ import {
   installTimeProvisionSecrets,
   buildSecretEnvForInstall,
 } from "../lib/secret-provision-install.js";
+import type { SecretBackendChoice } from "../lib/secrets.js";
 
 export interface InstallOptions {
   /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
@@ -96,9 +97,14 @@ export interface InstallOptions {
    * left unstored and the daemon fails at first use with a clear message.
    * `--from-env`: resolve each declared secret from the current environment
    * instead of prompting (CI / scripted installs).
+   * `secretBackend`: `--secret-backend keychain|file|auto` override. `auto`
+   * (default) prefers Keychain on a single-user macOS dev box but the
+   * chmod-600 file backend on a shared/CI host (where the macOS `security`
+   * argv-exposure window is at risk — arc#234 review).
    */
   skipSecrets?: boolean;
   fromEnv?: boolean;
+  secretBackend?: SecretBackendChoice;
 }
 
 export interface InstallResult {
@@ -366,6 +372,7 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     skipSecrets: opts.skipSecrets,
     fromEnv: opts.fromEnv,
     quiet: opts.yes,
+    backendChoice: opts.secretBackend,
   });
   if (!secretStep.success) {
     Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
@@ -505,7 +512,10 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // a fresh object scoped to this child invocation; arc's own process env is
   // never mutated, so the secrets are gone the moment postinstall exits
   // (issue §E "unset after postinstall").
-  const postinstallEnv = await buildSecretEnvForInstall(manifest, { arc });
+  const postinstallEnv = await buildSecretEnvForInstall(manifest, {
+    arc,
+    backendChoice: opts.secretBackend,
+  });
   const postinstallResult = runPostinstallPhase(
     installPath,
     manifest,
@@ -700,6 +710,7 @@ export async function installSingleArtifact(
     skipSecrets: opts.skipSecrets,
     fromEnv: opts.fromEnv,
     quiet: opts.yes,
+    backendChoice: opts.secretBackend,
   });
   if (!secretStep.success) {
     return { success: false, error: secretStep.error };
@@ -794,7 +805,10 @@ export async function installSingleArtifact(
 
   // Run postinstall script(s). F-6e: inject the artifact's stored secrets into
   // the postinstall env only (per-agent env, never the brief).
-  const artifactPostinstallEnv = await buildSecretEnvForInstall(manifest, { arc });
+  const artifactPostinstallEnv = await buildSecretEnvForInstall(manifest, {
+    arc,
+    backendChoice: opts.secretBackend,
+  });
   const postinstallResult = runPostinstallPhase(
     artifactDir,
     manifest,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -44,6 +44,15 @@ import {
   beginInstallTransaction,
   type InstallTransactionEvidence,
 } from "../lib/install-transaction.js";
+// F-6e (arc#229): SECRETS provisioning. Lives in its own module
+// (secret-provision.ts / secrets.ts); wired in below as a SINGLE clearly
+// commented hook at the SECRETS step — non-adjacent to F-6b's identity hook
+// (near the return) and F-6c's library-ordering (install-transaction.ts), per
+// the batch-merge coordination note on arc#229. Concern: SECRETS only.
+import {
+  installTimeProvisionSecrets,
+  buildSecretEnvForInstall,
+} from "../lib/secret-provision-install.js";
 
 export interface InstallOptions {
   /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
@@ -80,6 +89,16 @@ export interface InstallOptions {
    * to sandboxed temp dirs. Production calls leave this absent.
    */
   hostOverrides?: HostOverrides;
+  /**
+   * F-6e (arc#229) — secret provisioning controls.
+   *
+   * `--skip-secrets`: install proceeds without prompting; declared secrets are
+   * left unstored and the daemon fails at first use with a clear message.
+   * `--from-env`: resolve each declared secret from the current environment
+   * instead of prompting (CI / scripted installs).
+   */
+  skipSecrets?: boolean;
+  fromEnv?: boolean;
 }
 
 export interface InstallResult {
@@ -332,6 +351,27 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     }
   }
 
+  // ── F-6e (arc#229) SECRETS STEP ──────────────────────────────────────────
+  // Provision the package's declared `capabilities.secrets` (prompt / --from-env
+  // / --skip-secrets) and store them via the platform backend (Keychain on
+  // macOS, chmod-600 file fallback elsewhere) BEFORE preinstall — so a
+  // preinstall/postinstall script that bootstraps a token can read it from the
+  // injected env. Best-effort + fail-closed-loud: a store failure aborts the
+  // install (clean — no symlinks placed yet); a skipped secret just WARNs.
+  // Values never touch stdout/argv-we-log (issue §E). IDENTITY (F-6b) owns a
+  // separate hook near the return; LIBRARY ORDERING (F-6c) lives in
+  // install-transaction.ts. Concern here: SECRETS only.
+  const secretStep = await installTimeProvisionSecrets(manifest, {
+    arc,
+    skipSecrets: opts.skipSecrets,
+    fromEnv: opts.fromEnv,
+    quiet: opts.yes,
+  });
+  if (!secretStep.success) {
+    Bun.spawnSync(["rm", "-rf", installPath], { stdout: "pipe", stderr: "pipe" });
+    return { success: false, error: secretStep.error };
+  }
+
   // 3b. Run preinstall script(s) if declared
   const preinstallResult = runPreinstallPhase(installPath, manifest, opts.yes);
   if (!preinstallResult.success) {
@@ -459,8 +499,19 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // 6. Run bun install if package.json exists
   installNodeDependencies(installPath);
 
-  // 6b. Run postinstall script(s) if declared
-  const postinstallResult = runPostinstallPhase(installPath, manifest, opts.yes);
+  // 6b. Run postinstall script(s) if declared.
+  // F-6e (arc#229): inject the agent's stored secrets into the postinstall env
+  // ONLY (per design §6.2 step 5 — per-agent env, never the brief). The env is
+  // a fresh object scoped to this child invocation; arc's own process env is
+  // never mutated, so the secrets are gone the moment postinstall exits
+  // (issue §E "unset after postinstall").
+  const postinstallEnv = await buildSecretEnvForInstall(manifest, { arc });
+  const postinstallResult = runPostinstallPhase(
+    installPath,
+    manifest,
+    opts.yes,
+    postinstallEnv,
+  );
   if (!postinstallResult.success) {
     // #97: postinstall failure leaves the same partial-state shape as the
     // hook-validation gate (#89) plus registered hooks pointing at a package
@@ -640,6 +691,20 @@ export async function installSingleArtifact(
     }
   }
 
+  // F-6e (arc#229) SECRETS STEP — library-artifact path. dev-loop ships its
+  // agents as library artifacts (design §6.1), so per-artifact install also
+  // provisions declared secrets. Same fail-closed-loud hook + env injection as
+  // the standalone path. Concern: SECRETS only.
+  const secretStep = await installTimeProvisionSecrets(manifest, {
+    arc,
+    skipSecrets: opts.skipSecrets,
+    fromEnv: opts.fromEnv,
+    quiet: opts.yes,
+  });
+  if (!secretStep.success) {
+    return { success: false, error: secretStep.error };
+  }
+
   // Run preinstall script(s)
   const preinstallResult = runPreinstallPhase(artifactDir, manifest, opts.yes);
   if (!preinstallResult.success) {
@@ -727,8 +792,15 @@ export async function installSingleArtifact(
   // Run bun install if package.json exists in artifact dir
   installNodeDependencies(artifactDir);
 
-  // Run postinstall script(s)
-  const postinstallResult = runPostinstallPhase(artifactDir, manifest, opts.yes);
+  // Run postinstall script(s). F-6e: inject the artifact's stored secrets into
+  // the postinstall env only (per-agent env, never the brief).
+  const artifactPostinstallEnv = await buildSecretEnvForInstall(manifest, { arc });
+  const postinstallResult = runPostinstallPhase(
+    artifactDir,
+    manifest,
+    opts.yes,
+    artifactPostinstallEnv,
+  );
   if (!postinstallResult.success) {
     // #97: postinstall failure leaves the same partial-state shape as the
     // hook-validation gate (#89) plus registered hooks pointing at a package
@@ -968,6 +1040,12 @@ function runPostinstallPhase(
   installPath: string,
   manifest: ArcManifest,
   quiet?: boolean,
+  /**
+   * F-6e (arc#229): extra env injected into the postinstall child only —
+   * carries the agent's stored secrets. Scoped to the child invocation; arc's
+   * own process env is untouched.
+   */
+  env?: Record<string, string>,
 ): InstallResult {
   if (manifest.scripts?.postinstall) {
     const result = runScript({
@@ -975,6 +1053,7 @@ function runPostinstallPhase(
       scriptPath: manifest.scripts.postinstall,
       hookName: "postinstall",
       quiet,
+      env,
     });
     if (!result.success && !result.skipped) {
       return {
@@ -991,6 +1070,7 @@ function runPostinstallPhase(
       scriptPaths: lifecycle,
       phase: "postinstall",
       quiet,
+      env,
     });
     if (!result.success) {
       return {

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1,0 +1,201 @@
+/**
+ * F-6e (arc#229) — `arc secrets` lifecycle verbs.
+ *
+ *   arc secrets list   <agent>            — stored secret names (never values)
+ *   arc secrets check  <agent>            — declared vs stored; exit 1 if missing
+ *   arc secrets set    <agent> <secret>   — prompt / --from-env store
+ *   arc secrets rotate <agent> <secret>   — no-overwrite replace (delete+add)
+ *   arc secrets remove <agent> [<secret>] — one or all declared secrets
+ *
+ * The verb implementations below are pure functions over an injected
+ * SecretBackend + (where needed) the agent's manifest, so they unit-test
+ * without a DB or keychain. The commander wrapper in cli.ts resolves the real
+ * backend (`resolveSecretBackend`) and manifest (`readManifest` off the
+ * installed package's `install_path`).
+ *
+ * NEVER-LOG (issue §E): every verb prints NAMES only. No code path emits a
+ * value to stdout/stderr.
+ */
+
+import type { ArcManifest } from "../types.js";
+import type { SecretBackend } from "../lib/secrets.js";
+import {
+  provisionSecrets,
+  validateSecretPresence,
+  type SecretPrompt,
+} from "../lib/secret-provision.js";
+import { errorMessage } from "../lib/errors.js";
+
+interface BaseCtx {
+  agent: string;
+  backend: SecretBackend;
+}
+
+/** `arc secrets list <agent>` — stored secret NAMES only. */
+export async function secretsList(ctx: BaseCtx): Promise<number> {
+  const names = await ctx.backend.list();
+  if (names.length === 0) {
+    console.log(`No secrets stored for agent '${ctx.agent}'.`);
+    return 0;
+  }
+  console.log(`Secrets stored for '${ctx.agent}':`);
+  for (const name of names.sort()) {
+    console.log(`  ${name}`);
+  }
+  return 0;
+}
+
+/**
+ * `arc secrets check <agent>` — verify every declared secret is present.
+ * Exit 1 (loud, not silent — issue §E) when any declared secret is missing.
+ */
+export async function secretsCheck(
+  manifest: ArcManifest,
+  ctx: BaseCtx,
+): Promise<number> {
+  const report = await validateSecretPresence(manifest, ctx);
+  const declared = manifest.capabilities?.secrets ?? [];
+  if (declared.length === 0) {
+    console.log(`Agent '${ctx.agent}' declares no secrets.`);
+    return 0;
+  }
+
+  console.log(`Secret status for '${ctx.agent}':`);
+  for (const name of report.present) {
+    console.log(`  ✓ ${name}`);
+  }
+  for (const name of report.missing) {
+    console.log(`  ✗ ${name} (missing)`);
+  }
+
+  if (!report.ok) {
+    console.error(
+      `Missing ${report.missing.length} secret(s). ` +
+        `Run \`arc secrets set ${ctx.agent} <secret>\` to provision.`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+/** Options for {@link secretsSet}. */
+export interface SecretsSetOpts extends BaseCtx {
+  /** `--from-env`: take the value from `env[secret]` rather than prompting. */
+  fromEnv?: boolean;
+  /** Env source for `--from-env` (defaults to `process.env`). */
+  env?: Record<string, string | undefined>;
+  /** Interactive prompt (defaults to the no-echo terminal read). */
+  prompt?: SecretPrompt;
+}
+
+/** `arc secrets set <agent> <secret>` — store via prompt or --from-env. */
+export async function secretsSet(
+  secret: string,
+  opts: SecretsSetOpts,
+): Promise<number> {
+  // Reuse the install-time flow over a single-secret synthetic manifest so the
+  // prompt / from-env / store path stays one implementation.
+  const synthetic: ArcManifest = {
+    name: opts.agent,
+    version: "0",
+    type: "agent",
+    capabilities: { secrets: [secret] },
+  };
+  try {
+    const result = await provisionSecrets(synthetic, {
+      agent: opts.agent,
+      backend: opts.backend,
+      fromEnv: opts.fromEnv,
+      env: opts.env,
+      prompt: opts.prompt,
+    });
+    if (result.stored.length === 0) {
+      console.error(
+        opts.fromEnv
+          ? `Env var ${secret} is not set; nothing stored.`
+          : `No value entered for ${secret}; nothing stored.`,
+      );
+      return 1;
+    }
+    console.log(`✓ Stored ${secret} for '${opts.agent}'.`);
+    return 0;
+  } catch (err) {
+    // errorMessage is name-scoped; the value is never in the message.
+    console.error(`Failed to set ${secret}: ${errorMessage(err)}`);
+    return 1;
+  }
+}
+
+/**
+ * `arc secrets rotate <agent> <secret>` — replace the value with NO in-place
+ * overwrite (issue §E): the backend deletes the old entry then adds the new.
+ * Aborts (exit 1, old value intact) on empty input.
+ */
+export async function secretsRotate(
+  secret: string,
+  opts: SecretsSetOpts,
+): Promise<number> {
+  const env = opts.env ?? process.env;
+  let value: string | undefined;
+
+  if (opts.fromEnv) {
+    value = env[secret];
+    if (value === undefined || value === "") {
+      console.error(`Env var ${secret} is not set; rotation aborted (old value intact).`);
+      return 1;
+    }
+  } else {
+    const prompt = opts.prompt;
+    const entered = prompt ? await prompt(secret) : "";
+    if (entered === "") {
+      console.error(`No value entered; rotation aborted (old value intact).`);
+      return 1;
+    }
+    value = entered;
+  }
+
+  try {
+    await opts.backend.rotate(secret, value);
+    console.log(`✓ Rotated ${secret} for '${opts.agent}'.`);
+    return 0;
+  } catch (err) {
+    console.error(`Failed to rotate ${secret}: ${errorMessage(err)}`);
+    return 1;
+  }
+}
+
+/** Options for {@link secretsRemove}. */
+export interface SecretsRemoveOpts extends BaseCtx {
+  /** A single secret name to remove. When absent, all declared are removed. */
+  name?: string;
+  /** Manifest — required to enumerate declared secrets for the remove-all path. */
+  manifest?: ArcManifest;
+}
+
+/**
+ * `arc secrets remove <agent> [<secret>]` — remove one named secret, or all of
+ * the agent's declared secrets when no name is given.
+ */
+export async function secretsRemove(opts: SecretsRemoveOpts): Promise<number> {
+  try {
+    if (opts.name) {
+      await opts.backend.remove(opts.name);
+      console.log(`✓ Removed ${opts.name} for '${opts.agent}'.`);
+      return 0;
+    }
+
+    const declared = opts.manifest?.capabilities?.secrets ?? [];
+    if (declared.length === 0) {
+      console.log(`Agent '${opts.agent}' declares no secrets; nothing to remove.`);
+      return 0;
+    }
+    for (const name of declared) {
+      await opts.backend.remove(name);
+      console.log(`✓ Removed ${name} for '${opts.agent}'.`);
+    }
+    return 0;
+  } catch (err) {
+    console.error(`Failed to remove secret(s): ${errorMessage(err)}`);
+    return 1;
+  }
+}

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -18,7 +18,7 @@
  */
 
 import type { ArcManifest } from "../types.js";
-import type { SecretBackend } from "../lib/secrets.js";
+import { type SecretBackend, SecretListUnsupportedError } from "../lib/secrets.js";
 import {
   provisionSecrets,
   validateSecretPresence,
@@ -33,7 +33,19 @@ interface BaseCtx {
 
 /** `arc secrets list <agent>` — stored secret NAMES only. */
 export async function secretsList(ctx: BaseCtx): Promise<number> {
-  const names = await ctx.backend.list();
+  let names: string[];
+  try {
+    names = await ctx.backend.list();
+  } catch (err) {
+    if (err instanceof SecretListUnsupportedError) {
+      // Honest report instead of a silently-empty list (arc#234 review nit 2):
+      // the Keychain backend can't enumerate. Point at the backend-agnostic
+      // `check` verb. Exit 2 (distinct from 0 "none" and 1 "error").
+      console.error(err.message);
+      return 2;
+    }
+    throw err;
+  }
   if (names.length === 0) {
     console.log(`No secrets stored for agent '${ctx.agent}'.`);
     return 0;

--- a/src/lib/secret-provision-install.ts
+++ b/src/lib/secret-provision-install.ts
@@ -1,0 +1,169 @@
+/**
+ * F-6e (arc#229) — install-time secret bridge.
+ *
+ * Thin glue between `commands/install.ts` and the storage + flow modules
+ * (`secrets.ts`, `secret-provision.ts`). Keeps install.ts to two clearly
+ * commented hook calls (provision + env-build) at the SECRETS step.
+ *
+ * Backend selection: Keychain on macOS when the `security` CLI is available,
+ * else the chmod-600 FileBackend under `arc.secretsDir/<agent>/`. The agent
+ * scope is the manifest name (an installed `type: agent` package's name is its
+ * agent id; dev-loop's agents install as named library artifacts).
+ *
+ * NEVER-LOG (issue §E): nothing here logs a value. Skip warnings list NAMES.
+ */
+
+import { homedir, userInfo } from "os";
+import type { ArcManifest, ArcPaths } from "../types.js";
+import {
+  resolveSecretBackend,
+  type SecretBackend,
+} from "./secrets.js";
+import {
+  provisionSecrets,
+  injectSecretsIntoEnv,
+} from "./secret-provision.js";
+
+/** Resolve the storage backend for a manifest's agent scope. */
+export function backendForManifest(
+  manifest: ArcManifest,
+  arc: ArcPaths,
+  overrides?: {
+    platform?: string;
+    username?: string;
+    backend?: SecretBackend;
+  },
+): SecretBackend {
+  if (overrides?.backend) return overrides.backend;
+  return resolveSecretBackend(manifest.name, {
+    platform: overrides?.platform ?? process.platform,
+    secretsRoot: arc.secretsDir,
+    username: overrides?.username ?? safeUsername(),
+  });
+}
+
+/** Best-effort current username for Keychain account scoping. */
+function safeUsername(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    // userInfo throws on some sandboxes with no passwd entry — fall back to a
+    // stable, non-secret value (the home dir basename). Never throws.
+    return homedir().split("/").filter(Boolean).pop() ?? "user";
+  }
+}
+
+/** Outcome of the install-time SECRETS step. */
+export interface SecretStepResult {
+  success: boolean;
+  error?: string;
+  /** Stored secret NAMES (never values). */
+  stored: string[];
+  /** Declared-but-unstored NAMES (skip / from-env-absent / empty input). */
+  skipped: string[];
+}
+
+/** Options for {@link installTimeProvisionSecrets}. */
+export interface InstallSecretStepOpts {
+  arc: ArcPaths;
+  skipSecrets?: boolean;
+  fromEnv?: boolean;
+  quiet?: boolean;
+  /** Test seams — injected platform / username / backend / env / prompt. */
+  platform?: string;
+  username?: string;
+  backend?: SecretBackend;
+  env?: Record<string, string | undefined>;
+  prompt?: (name: string) => Promise<string>;
+}
+
+/**
+ * The install.ts SECRETS hook: provision the manifest's declared secrets and
+ * surface a skip warning. Fail-closed-loud: a storage failure returns
+ * `success: false` so the install aborts cleanly; a skip just WARNs (the
+ * daemon will fail at first use with a clear message — issue §A.4).
+ */
+export async function installTimeProvisionSecrets(
+  manifest: ArcManifest,
+  opts: InstallSecretStepOpts,
+): Promise<SecretStepResult> {
+  const declared = manifest.capabilities?.secrets ?? [];
+  if (declared.length === 0) {
+    return { success: true, stored: [], skipped: [] };
+  }
+
+  const backend = backendForManifest(manifest, opts.arc, {
+    platform: opts.platform,
+    username: opts.username,
+    backend: opts.backend,
+  });
+
+  try {
+    const result = await provisionSecrets(manifest, {
+      agent: manifest.name,
+      backend,
+      skipSecrets: opts.skipSecrets,
+      fromEnv: opts.fromEnv,
+      env: opts.env,
+      prompt: opts.prompt,
+      quiet: opts.quiet,
+    });
+
+    if (!opts.quiet && result.skipped.length > 0) {
+      // NAMES only. Loud, not silent — the operator must know the daemon will
+      // fail at first use until these are provisioned.
+      console.warn(
+        `  ⚠ Secrets not provisioned for '${manifest.name}': ${result.skipped.join(", ")}. ` +
+          `The agent will fail at first use until you run ` +
+          `\`arc secrets set ${manifest.name} <secret>\`.`,
+      );
+    }
+
+    return { success: true, stored: result.stored, skipped: result.skipped };
+  } catch (err) {
+    // errorMessage is name-scoped (the storage layer never embeds a value).
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      error: `Secret provisioning failed: ${message}`,
+      stored: [],
+      skipped: declared,
+    };
+  }
+}
+
+/**
+ * Build the postinstall env for a manifest: arc's process env plus the agent's
+ * stored secrets. A fresh object scoped to the child invocation; arc's own
+ * process env is never mutated, so the secrets are gone when postinstall exits
+ * (issue §E "unset after postinstall").
+ */
+export async function buildSecretEnvForInstall(
+  manifest: ArcManifest,
+  opts: {
+    arc: ArcPaths;
+    platform?: string;
+    username?: string;
+    backend?: SecretBackend;
+    baseEnv?: Record<string, string>;
+  },
+): Promise<Record<string, string>> {
+  const declared = manifest.capabilities?.secrets ?? [];
+  // The runScript runner already spreads `process.env` first, then `opts.env`.
+  // We pass ONLY the secrets here so we never re-materialize the whole
+  // environment into a logged object — runScript merges it in.
+  const baseEnv = opts.baseEnv ?? {};
+  if (declared.length === 0) return baseEnv;
+
+  const backend = backendForManifest(manifest, opts.arc, {
+    platform: opts.platform,
+    username: opts.username,
+    backend: opts.backend,
+  });
+
+  return injectSecretsIntoEnv(manifest, {
+    agent: manifest.name,
+    backend,
+    baseEnv,
+  });
+}

--- a/src/lib/secret-provision-install.ts
+++ b/src/lib/secret-provision-install.ts
@@ -18,6 +18,7 @@ import type { ArcManifest, ArcPaths } from "../types.js";
 import {
   resolveSecretBackend,
   type SecretBackend,
+  type SecretBackendChoice,
 } from "./secrets.js";
 import {
   provisionSecrets,
@@ -32,6 +33,7 @@ export function backendForManifest(
     platform?: string;
     username?: string;
     backend?: SecretBackend;
+    backendChoice?: SecretBackendChoice;
   },
 ): SecretBackend {
   if (overrides?.backend) return overrides.backend;
@@ -39,6 +41,7 @@ export function backendForManifest(
     platform: overrides?.platform ?? process.platform,
     secretsRoot: arc.secretsDir,
     username: overrides?.username ?? safeUsername(),
+    backendChoice: overrides?.backendChoice,
   });
 }
 
@@ -75,6 +78,12 @@ export interface InstallSecretStepOpts {
   backend?: SecretBackend;
   env?: Record<string, string | undefined>;
   prompt?: (name: string) => Promise<string>;
+  /**
+   * `--secret-backend` override. MUST match the choice used by
+   * {@link buildSecretEnvForInstall} for the same install, or a secret stored
+   * to one backend won't be retrieved from the other.
+   */
+  backendChoice?: SecretBackendChoice;
 }
 
 /**
@@ -96,6 +105,7 @@ export async function installTimeProvisionSecrets(
     platform: opts.platform,
     username: opts.username,
     backend: opts.backend,
+    backendChoice: opts.backendChoice,
   });
 
   try {
@@ -146,6 +156,7 @@ export async function buildSecretEnvForInstall(
     username?: string;
     backend?: SecretBackend;
     baseEnv?: Record<string, string>;
+    backendChoice?: SecretBackendChoice;
   },
 ): Promise<Record<string, string>> {
   const declared = manifest.capabilities?.secrets ?? [];
@@ -159,6 +170,7 @@ export async function buildSecretEnvForInstall(
     platform: opts.platform,
     username: opts.username,
     backend: opts.backend,
+    backendChoice: opts.backendChoice,
   });
 
   return injectSecretsIntoEnv(manifest, {

--- a/src/lib/secret-provision.ts
+++ b/src/lib/secret-provision.ts
@@ -1,0 +1,251 @@
+/**
+ * F-6e (arc#229) — install-time secret provisioning flow.
+ *
+ * Wires the storage backends (`secrets.ts`) into the install lifecycle:
+ *
+ *   - {@link provisionSecrets}    — for each `capabilities.secrets` entry, resolve
+ *     a value via interactive prompt / `--from-env` / `--skip-secrets`, and store
+ *     it through the backend.
+ *   - {@link validateSecretPresence} — which declared secrets are stored vs missing
+ *     (backs `arc secrets check`).
+ *   - {@link injectSecretsIntoEnv}  — retrieve stored secrets and merge them into a
+ *     child-process env (plist render env / postinstall env). Per design §6.2
+ *     step 5 + §3.5b: secrets reach *per-agent env*, never the brief.
+ *
+ * NEVER-LOG (issue §E): the value flows prompt → backend.store and
+ * backend.retrieve → env only. No function here logs a value, and the result
+ * structs carry NAMES only — `provisionSecrets` never returns a value.
+ */
+
+import type { ArcManifest } from "../types.js";
+import type { SecretBackend } from "./secrets.js";
+import { errorMessage } from "./errors.js";
+
+/**
+ * Prompt the principal for a single secret value. Returns the entered string
+ * (empty string ⇒ the principal chose to skip this secret). The default
+ * implementation is a no-echo terminal read; tests inject their own.
+ */
+export type SecretPrompt = (name: string) => Promise<string>;
+
+/** Shared per-agent context for the provisioning functions. */
+interface SecretContext {
+  /** Agent name (storage scope). */
+  agent: string;
+  /** Resolved storage backend for this agent. */
+  backend: SecretBackend;
+}
+
+/** Options controlling {@link provisionSecrets}. */
+export interface ProvisionOpts extends SecretContext {
+  /** `--skip-secrets`: store nothing; report all declared as skipped. */
+  skipSecrets?: boolean;
+  /** `--from-env`: read each declared secret from `env` (no prompt). */
+  fromEnv?: boolean;
+  /** Env source for `fromEnv` (defaults to `process.env`). */
+  env?: Record<string, string | undefined>;
+  /** Interactive prompt (defaults to a no-echo terminal read). */
+  prompt?: SecretPrompt;
+  /** Suppress progress logging (NAMES only — never values). */
+  quiet?: boolean;
+}
+
+/** Outcome of a provisioning pass — NAMES only, never values. */
+export interface ProvisionResult {
+  /** Secrets stored this pass. */
+  stored: string[];
+  /** Declared secrets left unstored (skipped / absent-from-env / empty input). */
+  skipped: string[];
+}
+
+/** Declared secrets for a manifest (empty when none). */
+function declaredSecrets(manifest: ArcManifest): string[] {
+  return manifest.capabilities?.secrets ?? [];
+}
+
+/**
+ * Resolve + store each declared secret per the active mode. Returns NAMES
+ * only. Idempotent in the sense that re-running re-prompts / re-reads; storage
+ * overwrites in place (rotate is the explicit no-overwrite path).
+ */
+export async function provisionSecrets(
+  manifest: ArcManifest,
+  opts: ProvisionOpts,
+): Promise<ProvisionResult> {
+  const names = declaredSecrets(manifest);
+  const stored: string[] = [];
+  const skipped: string[] = [];
+
+  if (names.length === 0) {
+    return { stored, skipped };
+  }
+
+  if (opts.skipSecrets) {
+    // Daemon starts; first use fails with a clear message (issue §A.4). Record
+    // the skip so the caller can surface a hint.
+    return { stored: [], skipped: [...names] };
+  }
+
+  const env = opts.env ?? process.env;
+
+  for (const name of names) {
+    let value: string | undefined;
+
+    if (opts.fromEnv) {
+      value = env[name];
+      if (value === undefined || value === "") {
+        skipped.push(name);
+        continue;
+      }
+    } else {
+      const prompt = opts.prompt ?? defaultSecretPrompt;
+      const entered = await prompt(name);
+      if (entered === "") {
+        // Return-to-skip.
+        skipped.push(name);
+        continue;
+      }
+      value = entered;
+    }
+
+    try {
+      await opts.backend.store(name, value);
+    } catch (err) {
+      // NEVER include the value in the error (issue §E). errorMessage()
+      // surfaces only the backend's own message, which is name-scoped. Chain
+      // the cause so the underlying backend error survives for debuggability
+      // (the cause's message is also name-scoped — never carries the value).
+      throw new Error(`failed to store secret ${name}: ${errorMessage(err)}`, {
+        cause: err,
+      });
+    }
+    stored.push(name);
+    if (!opts.quiet) {
+      // NAME only.
+      console.log(`  ✓ Secret stored: ${name}`);
+    }
+  }
+
+  return { stored, skipped };
+}
+
+/** Report for {@link validateSecretPresence} — NAMES only. */
+export interface PresenceReport {
+  present: string[];
+  missing: string[];
+  /** True iff every declared secret is stored (or none declared). */
+  ok: boolean;
+}
+
+/**
+ * Check which declared secrets are stored. Backs `arc secrets check <agent>`
+ * and the daemon-start "loud failure on missing" path (issue §E).
+ */
+export async function validateSecretPresence(
+  manifest: ArcManifest,
+  ctx: SecretContext,
+): Promise<PresenceReport> {
+  const names = declaredSecrets(manifest);
+  const present: string[] = [];
+  const missing: string[] = [];
+
+  for (const name of names) {
+    const value = await ctx.backend.retrieve(name);
+    if (value === null || value === "") {
+      missing.push(name);
+    } else {
+      present.push(name);
+    }
+  }
+
+  return { present, missing, ok: missing.length === 0 };
+}
+
+/** Options for {@link injectSecretsIntoEnv}. */
+export interface InjectOpts extends SecretContext {
+  /** Base env to merge into (e.g. `process.env` filtered, or {}). */
+  baseEnv: Record<string, string>;
+}
+
+/**
+ * Retrieve every declared+stored secret and merge it into a child-process env.
+ * A declared-but-unstored secret is OMITTED (never injected as `undefined`) so
+ * the daemon fails at first use with a clear message rather than seeing an
+ * empty value.
+ *
+ * The returned object is a fresh copy of `baseEnv` plus the secrets — callers
+ * pass it straight to `runLifecycleScripts({ env })` / the plist render env,
+ * and the SECRET keys are scoped to that single child invocation (issue §E
+ * "unset after postinstall": the parent never mutates its own env).
+ */
+export async function injectSecretsIntoEnv(
+  manifest: ArcManifest,
+  opts: InjectOpts,
+): Promise<Record<string, string>> {
+  const env: Record<string, string> = { ...opts.baseEnv };
+  const names = declaredSecrets(manifest);
+
+  for (const name of names) {
+    const value = await opts.backend.retrieve(name);
+    if (value !== null && value !== "") {
+      env[name] = value;
+    }
+  }
+
+  return env;
+}
+
+/**
+ * Default no-echo terminal prompt for a secret value.
+ *
+ * Disables echo via raw mode for the duration of the read so the typed value
+ * never appears on screen (issue §A.2 "[secure input, no echo]"). On a
+ * non-TTY stdin returns "" (skip) — a non-interactive install must use
+ * `--from-env` or `--skip-secrets`, never block on a prompt.
+ */
+export function defaultSecretPrompt(name: string): Promise<string> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) {
+    return Promise.resolve("");
+  }
+
+  process.stdout.write(`Enter ${name} (or press Return to skip): `);
+
+  return new Promise<string>((resolve) => {
+    let buffer = "";
+    const onData = (chunk: Buffer) => {
+      const s = chunk.toString("utf-8");
+      for (const ch of s) {
+        if (ch === "\n" || ch === "\r") {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(buffer);
+          return;
+        }
+        if (ch === "") {
+          // Ctrl-C — abort the whole process; never echo partial input.
+          cleanup();
+          process.stdout.write("\n");
+          process.exit(130);
+        }
+        if (ch === "" || ch === "\b") {
+          // Backspace — drop one char from the buffer (no echo to manage).
+          buffer = buffer.slice(0, -1);
+          continue;
+        }
+        buffer += ch;
+      }
+    };
+
+    const cleanup = () => {
+      stdin.removeListener("data", onData);
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.pause();
+    };
+
+    stdin.resume();
+    stdin.setEncoding("utf-8");
+    if (stdin.isTTY) stdin.setRawMode(true); // suppress echo
+    stdin.on("data", onData);
+  });
+}

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -1,0 +1,352 @@
+/**
+ * F-6e (arc#229) — secret storage backends.
+ *
+ * Manifests declare `capabilities.secrets: [GITHUB_TOKEN, APPROVER_GH_TOKEN, …]`.
+ * This module owns the *storage* half: where a provisioned secret lives, how it
+ * is retrieved at daemon-start / postinstall time, and how it is rotated and
+ * removed. The install-time *flow* (prompt / --from-env / --skip-secrets) lives
+ * in `secret-provision.ts`; the CLI verbs in `commands/secrets.ts`.
+ *
+ * Backends (issue §B):
+ *   - KeychainBackend — macOS, wraps the `security` CLI. Service-scoped to the
+ *     agent + secret name, account-scoped to the principal's username.
+ *   - FileBackend — universal fallback. One secret per file under
+ *     `<secretsRoot>/<agent>/<NAME>`, chmod 600 enforced on every write AND read
+ *     (cortex#87 `enforceChmod600` pattern).
+ *   - SystemdCredentialsBackend (Linux ≥256) is resolved at *daemon-start* by the
+ *     unit's `LoadCredential` directive, not by arc at install time — arc stores
+ *     to the FileBackend on Linux and the systemd unit's resolver reads it. A
+ *     dedicated read-only backend is deferred (issue "Future considerations").
+ *
+ * NEVER-LOG invariant (issue §E): a secret VALUE must never be written to
+ * stdout / stderr / argv-we-log / an audit line. Backends accept and return
+ * values but never log them. `redactSecret()` is the only string a diagnostic
+ * may print in a value's place. Service keys and file paths are built from the
+ * agent + secret NAME only — never the value.
+ */
+
+import { mkdir, readFile, writeFile, chmod, stat, unlink, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { errorMessage, isErrno } from "./errors.js";
+
+/** Fixed sentinel printed in place of a secret value in any diagnostic. */
+export const SECRET_REDACTION = "(secret redacted)";
+
+/**
+ * Return the redaction sentinel. Exists as a named function (rather than the
+ * bare constant) so call sites read as an explicit, greppable redaction — and
+ * so a value accidentally passed in is swallowed, never echoed.
+ */
+export function redactSecret(_value: string): string {
+  return SECRET_REDACTION;
+}
+
+/**
+ * Derive the platform-stable service key for a secret:
+ *   `ai.meta-factory.cortex.<agent>.<SECRET_NAME>`
+ *
+ * Built from NAMES only (issue §B) — the value is never part of the key, so
+ * the key is safe to log.
+ */
+export function secretServiceKey(agent: string, name: string): string {
+  return `ai.meta-factory.cortex.${agent}.${name}`;
+}
+
+// A secret/agent name is an env-var-shaped identifier; reject anything that
+// could escape the per-agent directory or smuggle a separator into a service
+// key. This is the storage-layer guard; the CLI/provision layer validates the
+// manifest declaration up front too.
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function assertSecretName(name: string): void {
+  if (!NAME_RE.test(name)) {
+    throw new Error(
+      `invalid secret name "${name}": expected an env-var-shaped identifier ([A-Za-z_][A-Za-z0-9_]*)`,
+    );
+  }
+}
+
+function assertAgentName(agent: string): void {
+  // The agent scope is the manifest package name. Ecosystem packages may lead
+  // with an underscore (e.g. `_JIRA`, `_CONFLUENCE`) and use hyphens
+  // (`dev-loop`). Allow `[A-Za-z0-9_]` to start, then `[A-Za-z0-9_-]` — but
+  // never a path separator or `..` (those would escape `<root>/<agent>/`).
+  if (!/^[A-Za-z0-9_][A-Za-z0-9_-]*$/.test(agent)) {
+    throw new Error(
+      `invalid agent name "${agent}": expected a package-name slug ([A-Za-z0-9_][A-Za-z0-9_-]*)`,
+    );
+  }
+}
+
+/**
+ * A single secret-storage backend. Names in / values in-and-out; the backend
+ * never logs the value.
+ */
+export interface SecretBackend {
+  /** Persist `value` under `name`. Overwrites unless the backend forbids it. */
+  store(name: string, value: string): Promise<void>;
+  /** Return the stored value, or `null` if not present. */
+  retrieve(name: string): Promise<string | null>;
+  /** Delete the secret. Idempotent — no throw if it was already absent. */
+  remove(name: string): Promise<void>;
+  /** Stored secret NAMES for this agent (never values). */
+  list(): Promise<string[]>;
+  /**
+   * Replace the value with no in-place overwrite (issue §E): delete the old
+   * entry, then add the new one. Default impl is remove-then-store; a backend
+   * may override if its native primitive differs.
+   */
+  rotate(name: string, value: string): Promise<void>;
+}
+
+/** Result of a `security` CLI invocation. Mirrors the subset we consume. */
+export interface SecurityResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Runs the macOS `security` CLI. Injectable so tests never touch the real
+ * login keychain. The default runner spawns `security` synchronously and
+ * captures stdout/stderr (never logged by this module).
+ */
+export type SecurityRunner = (args: string[]) => SecurityResult;
+
+const defaultSecurityRunner: SecurityRunner = (args) => {
+  const result = Bun.spawnSync(["security", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+};
+
+// `security` returns exit 44 (errSecItemNotFound) when an item is absent.
+const SEC_ITEM_NOT_FOUND = 44;
+
+/**
+ * macOS Keychain backend. Each secret is a generic password keyed by
+ * `secretServiceKey(agent, name)` and scoped to the principal's username.
+ *
+ * The VALUE is passed to `security` via `-w <value>` through the injected
+ * runner only; this class never logs argv (issue §E). Note: `security`'s own
+ * `-w` does place the value on the spawned process's argv — that is the OS
+ * keychain tool's contract and is the same path `gh auth login` uses. arc's
+ * obligation is to never *log* it, which it does not.
+ */
+export class KeychainBackend implements SecretBackend {
+  constructor(
+    private readonly agent: string,
+    private readonly account: string,
+    private readonly runner: SecurityRunner = defaultSecurityRunner,
+  ) {
+    assertAgentName(agent);
+  }
+
+  async store(name: string, value: string): Promise<void> {
+    assertSecretName(name);
+    const service = secretServiceKey(this.agent, name);
+    // -U updates in place if present; for rotate we delete-then-add explicitly.
+    const r = this.runner([
+      "add-generic-password",
+      "-s", service,
+      "-a", this.account,
+      "-U",
+      "-w", value,
+    ]);
+    if (r.exitCode !== 0) {
+      // No `cause`: this is a synthesized error from a CLI exit code, not a
+      // caught exception — there is no upstream Error to chain.
+      throw new Error(
+        `keychain store failed for ${service} (exit ${r.exitCode}): ${r.stderr.trim()}`,
+      );
+    }
+    // Async to satisfy the interface; the spawn is synchronous.
+    return Promise.resolve();
+  }
+
+  retrieve(name: string): Promise<string | null> {
+    assertSecretName(name);
+    const service = secretServiceKey(this.agent, name);
+    const r = this.runner([
+      "find-generic-password",
+      "-s", service,
+      "-a", this.account,
+      "-w",
+    ]);
+    if (r.exitCode === SEC_ITEM_NOT_FOUND) return Promise.resolve(null);
+    if (r.exitCode !== 0) {
+      // Loud, not silent (issue §E): retrieval failure other than not-found is
+      // an error the operator must see — but NEVER includes the value.
+      throw new Error(
+        `keychain retrieve failed for ${service} (exit ${r.exitCode}): ${r.stderr.trim()}. ` +
+          `Re-run \`arc secrets set <agent> ${name}\` to repair.`,
+      );
+    }
+    // `-w` prints the raw value plus a trailing newline.
+    return Promise.resolve(r.stdout.replace(/\n$/, ""));
+  }
+
+  remove(name: string): Promise<void> {
+    assertSecretName(name);
+    const service = secretServiceKey(this.agent, name);
+    const r = this.runner([
+      "delete-generic-password",
+      "-s", service,
+      "-a", this.account,
+    ]);
+    if (r.exitCode !== 0 && r.exitCode !== SEC_ITEM_NOT_FOUND) {
+      throw new Error(
+        `keychain remove failed for ${service} (exit ${r.exitCode}): ${r.stderr.trim()}`,
+      );
+    }
+    return Promise.resolve();
+  }
+
+  async rotate(name: string, value: string): Promise<void> {
+    // No in-place overwrite (issue §E): delete the old item, then add the new.
+    await this.remove(name);
+    await this.store(name, value);
+  }
+
+  list(): Promise<string[]> {
+    // `security` has no clean "list items for a service prefix" without
+    // dumping the whole keychain. The authoritative roster of an agent's
+    // secrets is the manifest's `capabilities.secrets`; `list`/`check` resolve
+    // presence per declared name via retrieve(). So the backend-level list is
+    // intentionally empty here, and SecretResolver-level enumeration is driven
+    // by the manifest (see secret-provision.ts validateSecretPresence).
+    return Promise.resolve([]);
+  }
+}
+
+/**
+ * Universal file backend. One secret per file at
+ * `<secretsRoot>/<agent>/<NAME>`, chmod 600 enforced on every write and read.
+ */
+export class FileBackend implements SecretBackend {
+  private readonly agentDir: string;
+
+  constructor(
+    private readonly secretsRoot: string,
+    private readonly agent: string,
+  ) {
+    assertAgentName(agent);
+    this.agentDir = join(secretsRoot, agent);
+  }
+
+  private pathFor(name: string): string {
+    assertSecretName(name);
+    return join(this.agentDir, name);
+  }
+
+  async store(name: string, value: string): Promise<void> {
+    const path = this.pathFor(name);
+    await mkdir(this.agentDir, { recursive: true });
+    // Write with mode 600 from the start, then re-chmod in case the file
+    // pre-existed with looser perms (write-with-mode only applies on create).
+    await writeFile(path, value, { mode: 0o600 });
+    await chmod(path, 0o600);
+  }
+
+  async retrieve(name: string): Promise<string | null> {
+    const path = this.pathFor(name);
+    if (!existsSync(path)) return null;
+    // cortex#87 pattern: re-enforce 600 on read — a file that drifted to a
+    // looser mode is tightened, loudly-correctable rather than silently used.
+    await enforceChmod600(path);
+    return readFile(path, "utf-8");
+  }
+
+  async remove(name: string): Promise<void> {
+    const path = this.pathFor(name);
+    try {
+      await unlink(path);
+    } catch (err) {
+      // Idempotent: already-gone is success. Surface any other errno.
+      if (isErrno(err) && err.code === "ENOENT") return;
+      throw new Error(`failed to remove secret file: ${errorMessage(err)}`, { cause: err });
+    }
+  }
+
+  async rotate(name: string, value: string): Promise<void> {
+    await this.remove(name);
+    await this.store(name, value);
+  }
+
+  async list(): Promise<string[]> {
+    if (!existsSync(this.agentDir)) return [];
+    const entries = await readdir(this.agentDir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && NAME_RE.test(e.name))
+      .map((e) => e.name);
+  }
+}
+
+/**
+ * Re-enforce chmod 600 on a secret file (cortex#87). Called on every read so a
+ * file that drifted to a too-open mode is tightened before its contents are
+ * handed out. Throws (loud, never silent) on a chmod failure other than a
+ * missing file.
+ */
+export async function enforceChmod600(path: string): Promise<void> {
+  try {
+    const mode = (await stat(path)).mode & 0o777;
+    if (mode !== 0o600) {
+      await chmod(path, 0o600);
+    }
+  } catch (err) {
+    if (isErrno(err) && err.code === "ENOENT") return;
+    throw new Error(`failed to enforce chmod 600 on secret file: ${errorMessage(err)}`, { cause: err });
+  }
+}
+
+/** Options for {@link resolveSecretBackend}. */
+export interface ResolveBackendOpts {
+  /** `process.platform` (or an override for tests). */
+  platform: string;
+  /** Root directory for the FileBackend fallback. */
+  secretsRoot: string;
+  /** Principal's username — the Keychain account scope. */
+  username: string;
+  /** Injected `security` runner (tests / non-darwin). */
+  securityRunner?: SecurityRunner;
+  /**
+   * Whether the native keychain is usable. Defaults to probing `security`
+   * existence on darwin. Pass explicitly in tests to avoid touching the host.
+   */
+  keychainAvailable?: boolean;
+}
+
+/**
+ * Select the storage backend for an agent: native (Keychain on macOS) when
+ * available, else the universal chmod-600 FileBackend.
+ *
+ * Linux uses the FileBackend at install time; the systemd unit's
+ * `LoadCredential` resolves the file at daemon-start. There is no install-time
+ * SystemdCredentialsBackend (the credential is read by systemd, not arc).
+ */
+export function resolveSecretBackend(
+  agent: string,
+  opts: ResolveBackendOpts,
+): SecretBackend {
+  if (opts.platform === "darwin") {
+    const available =
+      opts.keychainAvailable ?? isSecurityCliAvailable();
+    if (available) {
+      return new KeychainBackend(agent, opts.username, opts.securityRunner);
+    }
+  }
+  return new FileBackend(opts.secretsRoot, agent);
+}
+
+/** Probe whether the macOS `security` CLI is on PATH. */
+export function isSecurityCliAvailable(): boolean {
+  const r = Bun.spawnSync(["security", "help"], { stdout: "pipe", stderr: "pipe" });
+  return r.exitCode === 0 || r.exitCode === 1; // `security help` exits 1 but exists
+}

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -25,9 +25,10 @@
  * agent + secret NAME only — never the value.
  */
 
-import { mkdir, readFile, writeFile, chmod, stat, unlink, readdir } from "fs/promises";
+import { mkdir, readFile, writeFile, chmod, stat, unlink, readdir, rename } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
+import { randomBytes } from "crypto";
 import { errorMessage, isErrno } from "./errors.js";
 
 /** Fixed sentinel printed in place of a secret value in any diagnostic. */
@@ -133,11 +134,26 @@ const SEC_ITEM_NOT_FOUND = 44;
  * macOS Keychain backend. Each secret is a generic password keyed by
  * `secretServiceKey(agent, name)` and scoped to the principal's username.
  *
- * The VALUE is passed to `security` via `-w <value>` through the injected
- * runner only; this class never logs argv (issue §E). Note: `security`'s own
- * `-w` does place the value on the spawned process's argv — that is the OS
- * keychain tool's contract and is the same path `gh auth login` uses. arc's
- * obligation is to never *log* it, which it does not.
+ * ARGV EXPOSURE (security finding, arc#234 review): `security
+ * add-generic-password -w <value>` places the secret VALUE on the spawned
+ * process's argv. For the lifetime of the spawn it is readable by any process
+ * that can see this user's process table — via `ps auxww` or
+ * `/proc/<pid>/cmdline` — which on a SHARED multi-user macOS host (or a
+ * shared-PID-namespace container) is another user. This is a limitation of the
+ * macOS `security` CLI: its `-w` flag has no stdin channel, so a value passed
+ * non-interactively MUST go through argv. (Contrast: `gh auth login` reads its
+ * token from STDIN via `--with-token` — `security -w` has no equivalent. The
+ * earlier comment here claimed parity with gh; that was factually wrong.)
+ *
+ * Mitigation lives in {@link resolveSecretBackend}, NOT here: on a host that
+ * indicates a shared / CI context, arc selects the chmod-600 FileBackend
+ * instead, so the argv window is opt-in on single-user dev machines only.
+ * Residual risk on a dev machine: the value is on argv for the few-millisecond
+ * `spawnSync` duration; acceptable for a single-user box, mitigated everywhere
+ * else.
+ *
+ * This class never *logs* argv (issue §E) — that obligation is upheld
+ * regardless of the argv exposure above.
  */
 export class KeychainBackend implements SecretBackend {
   constructor(
@@ -188,8 +204,16 @@ export class KeychainBackend implements SecretBackend {
           `Re-run \`arc secrets set <agent> ${name}\` to repair.`,
       );
     }
-    // `-w` prints the raw value plus a trailing newline.
-    return Promise.resolve(r.stdout.replace(/\n$/, ""));
+    // `security -w` prints the raw value plus exactly ONE trailing newline it
+    // adds itself. Strip only that single appended "\n" — a regex like
+    // /\n$/ collapses to the same single strip, but `slice` makes the intent
+    // explicit and provably touches at most one char, so a value that
+    // legitimately ends in "\n" round-trips as `value + "\n"` → stored, then
+    // retrieved as `value + "\n\n"` from `security` → sliced back to
+    // `value + "\n"`. (FileBackend has no such transform; values round-trip
+    // byte-for-byte there.)
+    const out = r.stdout;
+    return Promise.resolve(out.endsWith("\n") ? out.slice(0, -1) : out);
   }
 
   remove(name: string): Promise<void> {
@@ -215,13 +239,30 @@ export class KeychainBackend implements SecretBackend {
   }
 
   list(): Promise<string[]> {
-    // `security` has no clean "list items for a service prefix" without
-    // dumping the whole keychain. The authoritative roster of an agent's
-    // secrets is the manifest's `capabilities.secrets`; `list`/`check` resolve
-    // presence per declared name via retrieve(). So the backend-level list is
-    // intentionally empty here, and SecretResolver-level enumeration is driven
-    // by the manifest (see secret-provision.ts validateSecretPresence).
-    return Promise.resolve([]);
+    // `security` has no clean "enumerate items for a service prefix" without
+    // dumping the whole login keychain (and parsing an unstable text format).
+    // Rather than silently return [] — which would make `arc secrets list`
+    // lie "no secrets" on macOS even when secrets exist (arc#234 review nit 2)
+    // — we signal unsupported. The command layer catches this and tells the
+    // operator to use `arc secrets check <agent>` instead, which resolves
+    // presence per manifest-declared name via retrieve() and works on every
+    // backend.
+    return Promise.reject(new SecretListUnsupportedError("keychain"));
+  }
+}
+
+/**
+ * Thrown by a backend whose storage primitive cannot enumerate stored secret
+ * names (e.g. the macOS Keychain). The command layer catches it and points the
+ * operator at `arc secrets check <agent>` (manifest-driven, backend-agnostic).
+ */
+export class SecretListUnsupportedError extends Error {
+  constructor(public readonly backend: string) {
+    super(
+      `Listing stored secrets is not supported on the ${backend} backend. ` +
+        `Use \`arc secrets check <agent>\` to see which declared secrets are present.`,
+    );
+    this.name = "SecretListUnsupportedError";
   }
 }
 
@@ -248,10 +289,29 @@ export class FileBackend implements SecretBackend {
   async store(name: string, value: string): Promise<void> {
     const path = this.pathFor(name);
     await mkdir(this.agentDir, { recursive: true });
-    // Write with mode 600 from the start, then re-chmod in case the file
-    // pre-existed with looser perms (write-with-mode only applies on create).
-    await writeFile(path, value, { mode: 0o600 });
-    await chmod(path, 0o600);
+    // Atomic write (arc#234 review nit 1): write the new value into a fresh
+    // 0600 temp file in the SAME directory, then rename it over the target.
+    // `rename(2)` within one filesystem is atomic, so a concurrent reader sees
+    // either the old complete file or the new one — never a truncated value,
+    // and never the old content sitting at a transiently-loose mode (the
+    // earlier `writeFile`-then-`chmod` left that TOCTOU window on overwrite).
+    // The temp name is unguessable so two concurrent stores don't collide.
+    const tmpPath = join(this.agentDir, `.${name}.${randomBytes(6).toString("hex")}.tmp`);
+    try {
+      await writeFile(tmpPath, value, { mode: 0o600 });
+      // writeFile's `mode` is honored only on create + subject to umask; force
+      // 0600 explicitly before the value is visible at the final path.
+      await chmod(tmpPath, 0o600);
+      await rename(tmpPath, path);
+    } catch (err) {
+      // Best-effort cleanup of the temp file so a failed store never leaves a
+      // secret-bearing orphan behind. Swallow ENOENT (rename already consumed
+      // it); never log the value.
+      await unlink(tmpPath).catch(() => {
+        /* temp file already gone or never created — nothing to clean up */
+      });
+      throw new Error(`failed to store secret file: ${errorMessage(err)}`, { cause: err });
+    }
   }
 
   async retrieve(name: string): Promise<string | null> {
@@ -306,6 +366,9 @@ export async function enforceChmod600(path: string): Promise<void> {
   }
 }
 
+/** Explicit backend selection override (`--secret-backend`). */
+export type SecretBackendChoice = "auto" | "keychain" | "file";
+
 /** Options for {@link resolveSecretBackend}. */
 export interface ResolveBackendOpts {
   /** `process.platform` (or an override for tests). */
@@ -321,28 +384,97 @@ export interface ResolveBackendOpts {
    * existence on darwin. Pass explicitly in tests to avoid touching the host.
    */
   keychainAvailable?: boolean;
+  /**
+   * Explicit operator choice (`--secret-backend`): `keychain` forces the
+   * Keychain even on a shared/CI host (accepting the argv exposure), `file`
+   * forces the chmod-600 file backend, `auto` (default) applies the
+   * shared-host heuristic below.
+   */
+  backendChoice?: SecretBackendChoice;
+  /**
+   * Whether the host is a shared / CI context where the Keychain argv-exposure
+   * window (see {@link KeychainBackend}) is unacceptable. Defaults to the
+   * {@link isSharedOrCiHost} env heuristic. When true under `auto`, arc selects
+   * the FileBackend even on darwin.
+   */
+  sharedHost?: boolean;
+  /** Env source for the shared-host heuristic (defaults to `process.env`). */
+  env?: Record<string, string | undefined>;
 }
 
 /**
- * Select the storage backend for an agent: native (Keychain on macOS) when
- * available, else the universal chmod-600 FileBackend.
+ * Select the storage backend for an agent.
  *
- * Linux uses the FileBackend at install time; the systemd unit's
- * `LoadCredential` resolves the file at daemon-start. There is no install-time
- * SystemdCredentialsBackend (the credential is read by systemd, not arc).
+ * Default (`auto`): native Keychain on macOS — UNLESS the host looks shared /
+ * CI, in which case the chmod-600 FileBackend is preferred so the macOS
+ * `security` argv-exposure window (see {@link KeychainBackend}) is opt-in on
+ * single-user dev machines only (arc#234 review MAJOR). `--secret-backend
+ * keychain|file` overrides the heuristic.
+ *
+ * Linux/Windows always use the FileBackend at install time; on Linux the
+ * systemd unit's `LoadCredential` resolves the file at daemon-start. There is
+ * no install-time SystemdCredentialsBackend (the credential is read by systemd,
+ * not arc).
  */
 export function resolveSecretBackend(
   agent: string,
   opts: ResolveBackendOpts,
 ): SecretBackend {
-  if (opts.platform === "darwin") {
-    const available =
-      opts.keychainAvailable ?? isSecurityCliAvailable();
-    if (available) {
-      return new KeychainBackend(agent, opts.username, opts.securityRunner);
-    }
+  const choice = opts.backendChoice ?? "auto";
+
+  if (choice === "file") {
+    return new FileBackend(opts.secretsRoot, agent);
   }
-  return new FileBackend(opts.secretsRoot, agent);
+
+  const fileBackend = () => new FileBackend(opts.secretsRoot, agent);
+  const keychainBackend = () =>
+    new KeychainBackend(agent, opts.username, opts.securityRunner);
+
+  if (choice === "keychain") {
+    // Operator explicitly opted in — honor it even on a shared host, but only
+    // where the Keychain actually exists.
+    if (opts.platform === "darwin") {
+      const available = opts.keychainAvailable ?? isSecurityCliAvailable();
+      if (available) return keychainBackend();
+    }
+    // Asked for keychain on a non-darwin host — fall back rather than fail.
+    return fileBackend();
+  }
+
+  // auto
+  if (opts.platform === "darwin") {
+    const shared = opts.sharedHost ?? isSharedOrCiHost(opts.env);
+    if (shared) {
+      // Prefer the file backend on a shared/CI macOS host: the argv exposure
+      // is the at-risk case there.
+      return fileBackend();
+    }
+    const available = opts.keychainAvailable ?? isSecurityCliAvailable();
+    if (available) return keychainBackend();
+  }
+  return fileBackend();
+}
+
+/**
+ * Heuristic for "this is a shared / CI host where another user could read the
+ * process table". Conservative: any common CI marker, or an explicit
+ * `ARC_SHARED_HOST=1`, flips it on. False on a typical single-user dev box.
+ */
+export function isSharedOrCiHost(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (truthyEnv(env.ARC_SHARED_HOST)) return true;
+  // Common CI providers set `CI`; GitHub Actions also sets `GITHUB_ACTIONS`.
+  if (truthyEnv(env.CI)) return true;
+  if (truthyEnv(env.GITHUB_ACTIONS)) return true;
+  if (truthyEnv(env.CONTINUOUS_INTEGRATION)) return true;
+  return false;
+}
+
+function truthyEnv(v: string | undefined): boolean {
+  if (v === undefined) return false;
+  const s = v.trim().toLowerCase();
+  return s !== "" && s !== "0" && s !== "false" && s !== "no";
 }
 
 /** Probe whether the macOS `security` CLI is on PATH. */

--- a/test/commands/secrets-command.test.ts
+++ b/test/commands/secrets-command.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for F-6e (arc#229) `arc secrets` CLI verbs.
+ *
+ * The verb implementations are pure functions over an injected SecretBackend +
+ * a manifest resolver, so the suite is hermetic (no DB, no keychain). The thin
+ * commander wrapper in cli.ts resolves the real backend + manifest.
+ *
+ * NEVER-LOG (issue §E): every verb prints NAMES only. The tests capture
+ * stdout and assert no stored value ever appears.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { FileBackend } from "../../src/lib/secrets.js";
+import {
+  secretsList,
+  secretsCheck,
+  secretsSet,
+  secretsRotate,
+  secretsRemove,
+} from "../../src/commands/secrets.js";
+import type { ArcManifest } from "../../src/types.js";
+
+let tempDir: string;
+let secretsRoot: string;
+let logged: string[];
+let origLog: typeof console.log;
+let origErr: typeof console.error;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-secrets-cmd-test-"));
+  secretsRoot = join(tempDir, "secrets");
+  await mkdir(secretsRoot, { recursive: true });
+  logged = [];
+  origLog = console.log;
+  origErr = console.error;
+  console.log = (...a: unknown[]) => logged.push(a.join(" "));
+  console.error = (...a: unknown[]) => logged.push(a.join(" "));
+});
+
+afterEach(async () => {
+  console.log = origLog;
+  console.error = origErr;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function manifest(secrets: string[]): ArcManifest {
+  return {
+    name: "dev",
+    version: "0.1.0",
+    type: "agent",
+    capabilities: { secrets },
+  };
+}
+
+function assertNoValueLeaked(...values: string[]) {
+  const all = logged.join("\n");
+  for (const v of values) {
+    expect(all).not.toContain(v);
+  }
+}
+
+describe("secretsList", () => {
+  test("lists stored secret names, never values", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("APPROVER_GH_TOKEN", "gh_pat_secret_value");
+    const code = await secretsList({ agent: "dev", backend });
+    expect(code).toBe(0);
+    expect(logged.join("\n")).toContain("APPROVER_GH_TOKEN");
+    assertNoValueLeaked("gh_pat_secret_value");
+  });
+});
+
+describe("secretsCheck", () => {
+  test("reports present + missing and exits 1 when any missing", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("HAVE", "v-have");
+    const code = await secretsCheck(manifest(["HAVE", "MISSING"]), {
+      agent: "dev",
+      backend,
+    });
+    expect(code).toBe(1);
+    const out = logged.join("\n");
+    expect(out).toContain("HAVE");
+    expect(out).toContain("MISSING");
+    assertNoValueLeaked("v-have");
+  });
+
+  test("exits 0 when all declared secrets present", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("HAVE", "v");
+    const code = await secretsCheck(manifest(["HAVE"]), { agent: "dev", backend });
+    expect(code).toBe(0);
+  });
+});
+
+describe("secretsSet", () => {
+  test("--from-env stores the value from the env var", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const code = await secretsSet("APPROVER_GH_TOKEN", {
+      agent: "dev",
+      backend,
+      fromEnv: true,
+      env: { APPROVER_GH_TOKEN: "from-env-value" },
+    });
+    expect(code).toBe(0);
+    expect(await backend.retrieve("APPROVER_GH_TOKEN")).toBe("from-env-value");
+    assertNoValueLeaked("from-env-value");
+  });
+
+  test("--from-env with the env var absent fails with exit 1 (no value logged)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const code = await secretsSet("APPROVER_GH_TOKEN", {
+      agent: "dev",
+      backend,
+      fromEnv: true,
+      env: {},
+    });
+    expect(code).toBe(1);
+    expect(await backend.retrieve("APPROVER_GH_TOKEN")).toBeNull();
+  });
+
+  test("interactive prompt stores the typed value", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const code = await secretsSet("GITHUB_TOKEN", {
+      agent: "dev",
+      backend,
+      prompt: async () => "typed-secret",
+    });
+    expect(code).toBe(0);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("typed-secret");
+    assertNoValueLeaked("typed-secret");
+  });
+});
+
+describe("secretsRotate", () => {
+  test("replaces the stored value (delete-then-add semantics)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "old-value");
+    const code = await secretsRotate("GITHUB_TOKEN", {
+      agent: "dev",
+      backend,
+      prompt: async () => "new-value",
+    });
+    expect(code).toBe(0);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("new-value");
+    assertNoValueLeaked("old-value", "new-value");
+  });
+
+  test("rotate aborts (exit 1) on empty input, leaving the old value intact", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "old-value");
+    const code = await secretsRotate("GITHUB_TOKEN", {
+      agent: "dev",
+      backend,
+      prompt: async () => "",
+    });
+    expect(code).toBe(1);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("old-value");
+  });
+});
+
+describe("secretsRemove", () => {
+  test("removes one named secret", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "v");
+    const code = await secretsRemove({ agent: "dev", backend, name: "GITHUB_TOKEN" });
+    expect(code).toBe(0);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBeNull();
+  });
+
+  test("removes all declared secrets when no name is given", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("A", "1");
+    await backend.store("B", "2");
+    const code = await secretsRemove({
+      agent: "dev",
+      backend,
+      manifest: manifest(["A", "B"]),
+    });
+    expect(code).toBe(0);
+    expect(await backend.retrieve("A")).toBeNull();
+    expect(await backend.retrieve("B")).toBeNull();
+  });
+});

--- a/test/unit/secret-provision-install.test.ts
+++ b/test/unit/secret-provision-install.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for F-6e (arc#229) install-time secret bridge
+ * (`secret-provision-install.ts`) — the glue install.ts calls at the SECRETS
+ * step. Hermetic via an injected FileBackend.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { FileBackend } from "../../src/lib/secrets.js";
+import {
+  installTimeProvisionSecrets,
+  buildSecretEnvForInstall,
+} from "../../src/lib/secret-provision-install.js";
+import type { ArcManifest, ArcPaths } from "../../src/types.js";
+
+let tempDir: string;
+let secretsRoot: string;
+let arc: ArcPaths;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-secret-install-test-"));
+  secretsRoot = join(tempDir, "secrets");
+  await mkdir(secretsRoot, { recursive: true });
+  // Only secretsDir is read by the bridge; stub the rest minimally.
+  arc = { secretsDir: secretsRoot } as unknown as ArcPaths;
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function manifest(secrets?: string[]): ArcManifest {
+  return {
+    name: "dev",
+    version: "0.1.0",
+    type: "agent",
+    capabilities: secrets ? { secrets } : undefined,
+  };
+}
+
+describe("installTimeProvisionSecrets", () => {
+  test("no-op success when no secrets declared", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const r = await installTimeProvisionSecrets(manifest(), { arc, backend, quiet: true });
+    expect(r.success).toBe(true);
+    expect(r.stored).toEqual([]);
+  });
+
+  test("fromEnv stores declared secrets and reports names only", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const r = await installTimeProvisionSecrets(manifest(["APPROVER_GH_TOKEN"]), {
+      arc,
+      backend,
+      fromEnv: true,
+      env: { APPROVER_GH_TOKEN: "gh_pat_value" },
+      quiet: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.stored).toEqual(["APPROVER_GH_TOKEN"]);
+    expect(await backend.retrieve("APPROVER_GH_TOKEN")).toBe("gh_pat_value");
+    expect(JSON.stringify(r)).not.toContain("gh_pat_value");
+  });
+
+  test("skipSecrets stores nothing and reports the declared as skipped", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const r = await installTimeProvisionSecrets(manifest(["GITHUB_TOKEN"]), {
+      arc,
+      backend,
+      skipSecrets: true,
+      quiet: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.skipped).toEqual(["GITHUB_TOKEN"]);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBeNull();
+  });
+
+  test("a backend store failure aborts the step (fail-closed)", async () => {
+    const failing = new FileBackend(secretsRoot, "dev");
+    failing.store = () => Promise.reject(new Error("boom"));
+    const r = await installTimeProvisionSecrets(manifest(["GITHUB_TOKEN"]), {
+      arc,
+      backend: failing,
+      fromEnv: true,
+      env: { GITHUB_TOKEN: "v" },
+      quiet: true,
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("Secret provisioning failed");
+  });
+});
+
+describe("buildSecretEnvForInstall", () => {
+  test("merges stored secrets into the (empty) base env", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("APPROVER_GH_TOKEN", "gh_pat_inject");
+    const env = await buildSecretEnvForInstall(manifest(["APPROVER_GH_TOKEN"]), {
+      arc,
+      backend,
+    });
+    expect(env.APPROVER_GH_TOKEN).toBe("gh_pat_inject");
+  });
+
+  test("returns the base env unchanged when nothing declared", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const env = await buildSecretEnvForInstall(manifest(), {
+      arc,
+      backend,
+      baseEnv: { FOO: "bar" },
+    });
+    expect(env).toEqual({ FOO: "bar" });
+  });
+
+  test("omits a declared-but-unstored secret", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const env = await buildSecretEnvForInstall(manifest(["MISSING"]), {
+      arc,
+      backend,
+    });
+    expect("MISSING" in env).toBe(false);
+  });
+});

--- a/test/unit/secret-provision.test.ts
+++ b/test/unit/secret-provision.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for F-6e (arc#229) install-time secret provisioning flow.
+ *
+ * provisionSecrets — prompt / --from-env / --skip-secrets resolution.
+ * validateSecretPresence — which declared secrets are stored vs missing.
+ * injectSecretsIntoEnv — retrieve from storage, merge into a child-process env.
+ *
+ * All exercised with an injected backend + injected prompt so the suite is
+ * hermetic. NEVER-LOG: a value must never reach stdout — the prompt is the
+ * only ingress and injection the only egress.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { FileBackend } from "../../src/lib/secrets.js";
+import {
+  provisionSecrets,
+  validateSecretPresence,
+  injectSecretsIntoEnv,
+} from "../../src/lib/secret-provision.js";
+import type { ArcManifest } from "../../src/types.js";
+
+let tempDir: string;
+let secretsRoot: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-secret-provision-test-"));
+  secretsRoot = join(tempDir, "secrets");
+  await mkdir(secretsRoot, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function manifest(secrets?: string[]): ArcManifest {
+  return {
+    name: "dev",
+    version: "0.1.0",
+    type: "agent",
+    capabilities: secrets ? { secrets } : undefined,
+  };
+}
+
+describe("provisionSecrets", () => {
+  test("no-op when the manifest declares no secrets", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(), {
+      agent: "dev",
+      backend,
+    });
+    expect(result.stored).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  test("skipSecrets stores nothing and reports all declared as skipped", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["APPROVER_GH_TOKEN"]), {
+      agent: "dev",
+      backend,
+      skipSecrets: true,
+    });
+    expect(result.stored).toEqual([]);
+    expect(result.skipped).toEqual(["APPROVER_GH_TOKEN"]);
+    expect(await backend.retrieve("APPROVER_GH_TOKEN")).toBeNull();
+  });
+
+  test("fromEnv reads existing env vars without prompting", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["APPROVER_GH_TOKEN"]), {
+      agent: "dev",
+      backend,
+      fromEnv: true,
+      env: { APPROVER_GH_TOKEN: "gh_pat_from_env" },
+    });
+    expect(result.stored).toEqual(["APPROVER_GH_TOKEN"]);
+    expect(await backend.retrieve("APPROVER_GH_TOKEN")).toBe("gh_pat_from_env");
+  });
+
+  test("fromEnv skips a secret absent from the env (reported as skipped)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["CORTEX_DEV_GH_TOKEN"]), {
+      agent: "dev",
+      backend,
+      fromEnv: true,
+      env: {},
+    });
+    expect(result.stored).toEqual([]);
+    expect(result.skipped).toEqual(["CORTEX_DEV_GH_TOKEN"]);
+  });
+
+  test("interactive prompt stores the entered value", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["GITHUB_TOKEN"]), {
+      agent: "dev",
+      backend,
+      prompt: async (name) => {
+        expect(name).toBe("GITHUB_TOKEN");
+        return "typed-value";
+      },
+    });
+    expect(result.stored).toEqual(["GITHUB_TOKEN"]);
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("typed-value");
+  });
+
+  test("interactive prompt returning empty string skips that secret", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["GITHUB_TOKEN"]), {
+      agent: "dev",
+      backend,
+      prompt: async () => "", // user pressed Return to skip
+    });
+    expect(result.stored).toEqual([]);
+    expect(result.skipped).toEqual(["GITHUB_TOKEN"]);
+  });
+
+  test("never echoes a secret value through the result struct keys", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const result = await provisionSecrets(manifest(["GITHUB_TOKEN"]), {
+      agent: "dev",
+      backend,
+      prompt: async () => "super-secret-value",
+    });
+    // The result reports NAMES only — never the value.
+    expect(JSON.stringify(result)).not.toContain("super-secret-value");
+  });
+});
+
+describe("validateSecretPresence", () => {
+  test("reports present and missing declared secrets", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("HAVE_TOKEN", "v");
+    const report = await validateSecretPresence(
+      manifest(["HAVE_TOKEN", "MISSING_TOKEN"]),
+      { agent: "dev", backend },
+    );
+    expect(report.present).toEqual(["HAVE_TOKEN"]);
+    expect(report.missing).toEqual(["MISSING_TOKEN"]);
+    expect(report.ok).toBe(false);
+  });
+
+  test("ok=true when every declared secret is stored", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("HAVE_TOKEN", "v");
+    const report = await validateSecretPresence(manifest(["HAVE_TOKEN"]), {
+      agent: "dev",
+      backend,
+    });
+    expect(report.ok).toBe(true);
+    expect(report.missing).toEqual([]);
+  });
+
+  test("ok=true and empty lists when nothing is declared", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const report = await validateSecretPresence(manifest(), {
+      agent: "dev",
+      backend,
+    });
+    expect(report.ok).toBe(true);
+    expect(report.present).toEqual([]);
+    expect(report.missing).toEqual([]);
+  });
+});
+
+describe("injectSecretsIntoEnv", () => {
+  test("merges stored secrets into a base env", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("APPROVER_GH_TOKEN", "gh_pat_inject");
+    const env = await injectSecretsIntoEnv(manifest(["APPROVER_GH_TOKEN"]), {
+      agent: "dev",
+      backend,
+      baseEnv: { PATH: "/usr/bin" },
+    });
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.APPROVER_GH_TOKEN).toBe("gh_pat_inject");
+  });
+
+  test("omits a declared-but-unstored secret (does not inject undefined)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const env = await injectSecretsIntoEnv(manifest(["MISSING"]), {
+      agent: "dev",
+      backend,
+      baseEnv: {},
+    });
+    expect("MISSING" in env).toBe(false);
+  });
+
+  test("returns the base env unchanged when nothing is declared", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const env = await injectSecretsIntoEnv(manifest(), {
+      agent: "dev",
+      backend,
+      baseEnv: { FOO: "bar" },
+    });
+    expect(env).toEqual({ FOO: "bar" });
+  });
+});

--- a/test/unit/secrets.test.ts
+++ b/test/unit/secrets.test.ts
@@ -21,9 +21,12 @@ import {
   resolveSecretBackend,
   secretServiceKey,
   redactSecret,
+  isSharedOrCiHost,
+  SecretListUnsupportedError,
   type SecurityRunner,
   type SecurityResult,
 } from "../../src/lib/secrets.js";
+import { readdir } from "fs/promises";
 
 let tempDir: string;
 let secretsRoot: string;
@@ -128,6 +131,36 @@ describe("FileBackend", () => {
   test("rejects path-traversal in the agent name", () => {
     expect(() => new FileBackend(secretsRoot, "../etc")).toThrow(/invalid agent name/i);
   });
+
+  // arc#234 review nit 1: atomic write.
+  test("overwrite preserves 0600 and leaves no temp orphan (atomic write)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "first");
+    await backend.store("GITHUB_TOKEN", "second");
+    const path = join(secretsRoot, "dev", "GITHUB_TOKEN");
+    expect(await readFile(path, "utf-8")).toBe("second");
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    // No leftover `.NAME.<rand>.tmp` files in the agent dir.
+    const entries = await readdir(join(secretsRoot, "dev"));
+    expect(entries.some((e) => e.includes(".tmp"))).toBe(false);
+    expect(entries).toEqual(["GITHUB_TOKEN"]);
+  });
+
+  test("list ignores temp + dotfiles (only env-var-shaped names)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("REAL_TOKEN", "v");
+    // Drop a stray dotfile/temp that an interrupted write could leave.
+    await mkdir(join(secretsRoot, "dev"), { recursive: true });
+    await writeFile(join(secretsRoot, "dev", ".REAL_TOKEN.abc123.tmp"), "junk");
+    const names = await backend.list();
+    expect(names).toEqual(["REAL_TOKEN"]);
+  });
+
+  test("round-trips a value byte-for-byte, including a trailing newline", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("MULTILINE", "line1\nline2\n");
+    expect(await backend.retrieve("MULTILINE")).toBe("line1\nline2\n");
+  });
 });
 
 describe("KeychainBackend", () => {
@@ -218,6 +251,33 @@ describe("KeychainBackend", () => {
     expect(await backend.retrieve("GITHUB_TOKEN")).toBeNull();
     await expect(backend.remove("GITHUB_TOKEN")).resolves.toBeUndefined();
   });
+
+  // arc#234 review nit 2: list() must NOT silently return [] (would lie
+  // "no secrets" on macOS). It rejects with a typed unsupported error.
+  test("list rejects with SecretListUnsupportedError (never a silent empty list)", async () => {
+    const { runner } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await expect(backend.list()).rejects.toBeInstanceOf(SecretListUnsupportedError);
+  });
+
+  // arc#234 review nit 4: strip ONLY the single newline `security -w` appends;
+  // a value that itself ends in "\n" must round-trip correctly.
+  test("retrieve strips exactly one trailing newline that security adds", async () => {
+    const { runner, store } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    // Simulate a stored value that genuinely ends in "\n"; on store we wrote it
+    // verbatim, and `security -w` prints it back with ITS extra "\n" appended.
+    store.set("ai.meta-factory.cortex.dev.NL_TOKEN", "value-with-nl\n");
+    const got = await backend.retrieve("NL_TOKEN");
+    expect(got).toBe("value-with-nl\n");
+  });
+
+  test("retrieve of a no-newline value is unchanged", async () => {
+    const { runner } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("PLAIN", "no-newline-here");
+    expect(await backend.retrieve("PLAIN")).toBe("no-newline-here");
+  });
 });
 
 describe("resolveSecretBackend", () => {
@@ -230,13 +290,14 @@ describe("resolveSecretBackend", () => {
     expect(backend).toBeInstanceOf(FileBackend);
   });
 
-  test("selects KeychainBackend on darwin when security CLI is available", () => {
+  test("selects KeychainBackend on a NON-shared darwin host when security CLI is available", () => {
     const backend = resolveSecretBackend("dev", {
       platform: "darwin",
       secretsRoot,
       username: "alice",
       securityRunner: () => ({ exitCode: 0, stdout: "", stderr: "" }),
       keychainAvailable: true,
+      sharedHost: false,
     });
     expect(backend).toBeInstanceOf(KeychainBackend);
   });
@@ -247,7 +308,81 @@ describe("resolveSecretBackend", () => {
       secretsRoot,
       username: "alice",
       keychainAvailable: false,
+      sharedHost: false,
     });
     expect(backend).toBeInstanceOf(FileBackend);
+  });
+
+  // arc#234 review MAJOR: on a shared/CI macOS host, prefer the file backend so
+  // the Keychain `security -w` argv-exposure window is opt-in on dev boxes only.
+  test("auto prefers FileBackend on a SHARED darwin host even when keychain is available", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      keychainAvailable: true,
+      sharedHost: true,
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+
+  test("auto detects a CI host via the CI env var and prefers FileBackend", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      keychainAvailable: true,
+      env: { CI: "true" },
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+
+  test("--secret-backend keychain forces Keychain even on a shared darwin host", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      keychainAvailable: true,
+      sharedHost: true,
+      backendChoice: "keychain",
+    });
+    expect(backend).toBeInstanceOf(KeychainBackend);
+  });
+
+  test("--secret-backend keychain on a non-darwin host falls back to FileBackend", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "linux",
+      secretsRoot,
+      username: "alice",
+      backendChoice: "keychain",
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+
+  test("--secret-backend file forces FileBackend on a non-shared darwin host", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      keychainAvailable: true,
+      sharedHost: false,
+      backendChoice: "file",
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+});
+
+describe("isSharedOrCiHost", () => {
+  test("true under common CI markers", () => {
+    expect(isSharedOrCiHost({ CI: "true" })).toBe(true);
+    expect(isSharedOrCiHost({ GITHUB_ACTIONS: "true" })).toBe(true);
+    expect(isSharedOrCiHost({ ARC_SHARED_HOST: "1" })).toBe(true);
+  });
+
+  test("false on a clean single-user env", () => {
+    expect(isSharedOrCiHost({})).toBe(false);
+    expect(isSharedOrCiHost({ CI: "" })).toBe(false);
+    expect(isSharedOrCiHost({ CI: "0" })).toBe(false);
+    expect(isSharedOrCiHost({ CI: "false" })).toBe(false);
   });
 });

--- a/test/unit/secrets.test.ts
+++ b/test/unit/secrets.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for F-6e (arc#229) secret storage backends.
+ *
+ * Covers the FileBackend (universal chmod-600 fallback) and KeychainBackend
+ * (macOS `security` CLI, exercised through an injected runner so the suite is
+ * hermetic and never touches the real login keychain).
+ *
+ * NEVER-LOG invariant (issue §E): a secret value must never be emitted to
+ * stdout/stderr. These tests assert backends return values but the redaction
+ * helpers and service-key derivation never embed a value.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir, readFile, stat, writeFile, chmod } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  FileBackend,
+  KeychainBackend,
+  resolveSecretBackend,
+  secretServiceKey,
+  redactSecret,
+  type SecurityRunner,
+  type SecurityResult,
+} from "../../src/lib/secrets.js";
+
+let tempDir: string;
+let secretsRoot: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "arc-secrets-test-"));
+  secretsRoot = join(tempDir, "secrets");
+  await mkdir(secretsRoot, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("secretServiceKey", () => {
+  test("derives ai.meta-factory.cortex.<agent>.<NAME>", () => {
+    expect(secretServiceKey("dev", "APPROVER_GH_TOKEN")).toBe(
+      "ai.meta-factory.cortex.dev.APPROVER_GH_TOKEN",
+    );
+  });
+
+  test("never embeds the secret value (key is built from names only)", () => {
+    const key = secretServiceKey("approver", "CORTEX_DEV_GH_TOKEN");
+    expect(key).not.toContain("gh_pat");
+    expect(key).toBe("ai.meta-factory.cortex.approver.CORTEX_DEV_GH_TOKEN");
+  });
+});
+
+describe("redactSecret", () => {
+  test("returns the fixed redaction sentinel, never the value", () => {
+    expect(redactSecret("gh_pat_supersecret")).toBe("(secret redacted)");
+    expect(redactSecret("")).toBe("(secret redacted)");
+  });
+});
+
+describe("FileBackend", () => {
+  test("store writes one secret per file under <root>/<agent>/<NAME>", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "gh_pat_value");
+    const path = join(secretsRoot, "dev", "GITHUB_TOKEN");
+    expect(existsSync(path)).toBe(true);
+    expect((await readFile(path, "utf-8"))).toBe("gh_pat_value");
+  });
+
+  test("store enforces chmod 600 on the file", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "v");
+    const path = join(secretsRoot, "dev", "GITHUB_TOKEN");
+    const mode = (await stat(path)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("retrieve returns the stored value", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "round-trip");
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("round-trip");
+  });
+
+  test("retrieve returns null for a missing secret", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    expect(await backend.retrieve("NOPE")).toBeNull();
+  });
+
+  test("retrieve re-enforces chmod 600 on read (cortex#87 pattern)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    const path = join(secretsRoot, "dev", "LOOSE");
+    await mkdir(join(secretsRoot, "dev"), { recursive: true });
+    await writeFile(path, "v");
+    await chmod(path, 0o644); // simulate a too-open file
+    const val = await backend.retrieve("LOOSE");
+    expect(val).toBe("v");
+    const mode = (await stat(path)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("remove deletes the secret file", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("GITHUB_TOKEN", "v");
+    await backend.remove("GITHUB_TOKEN");
+    expect(existsSync(join(secretsRoot, "dev", "GITHUB_TOKEN"))).toBe(false);
+  });
+
+  test("remove is idempotent (no throw on missing)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await expect(backend.remove("GHOST")).resolves.toBeUndefined();
+  });
+
+  test("list returns stored secret names only (never values)", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await backend.store("A_TOKEN", "secret-a");
+    await backend.store("B_TOKEN", "secret-b");
+    const names = await backend.list();
+    expect(names.sort()).toEqual(["A_TOKEN", "B_TOKEN"]);
+    expect(names.join(",")).not.toContain("secret-");
+  });
+
+  test("rejects path-traversal in the secret name", async () => {
+    const backend = new FileBackend(secretsRoot, "dev");
+    await expect(backend.store("../escape", "v")).rejects.toThrow(/invalid secret name/i);
+  });
+
+  test("rejects path-traversal in the agent name", () => {
+    expect(() => new FileBackend(secretsRoot, "../etc")).toThrow(/invalid agent name/i);
+  });
+});
+
+describe("KeychainBackend", () => {
+  function makeRunner(): {
+    runner: SecurityRunner;
+    calls: string[][];
+    store: Map<string, string>;
+  } {
+    const store = new Map<string, string>();
+    const calls: string[][] = [];
+    const runner: SecurityRunner = (args): SecurityResult => {
+      calls.push(args);
+      const verb = args[0];
+      // crude arg parse mirroring the `security` CLI surface we use
+      const sIdx = args.indexOf("-s");
+      const service = sIdx >= 0 ? args[sIdx + 1] : "";
+      if (verb === "add-generic-password") {
+        const wIdx = args.indexOf("-w");
+        store.set(service, args[wIdx + 1]);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (verb === "find-generic-password") {
+        const stored = store.get(service);
+        if (stored === undefined) {
+          return { exitCode: 44, stdout: "", stderr: "could not be found" };
+        }
+        return { exitCode: 0, stdout: `${stored}\n`, stderr: "" };
+      }
+      if (verb === "delete-generic-password") {
+        const existed = store.delete(service);
+        return existed
+          ? { exitCode: 0, stdout: "", stderr: "" }
+          : { exitCode: 44, stdout: "", stderr: "could not be found" };
+      }
+      return { exitCode: 1, stdout: "", stderr: "unknown verb" };
+    };
+    return { runner, calls, store };
+  }
+
+  test("store calls security add-generic-password with the derived service key", async () => {
+    const { runner, store } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("GITHUB_TOKEN", "gh_pat_x");
+    expect(store.get("ai.meta-factory.cortex.dev.GITHUB_TOKEN")).toBe("gh_pat_x");
+  });
+
+  test("retrieve returns the value via find-generic-password -w", async () => {
+    const { runner } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("GITHUB_TOKEN", "gh_pat_x");
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBe("gh_pat_x");
+  });
+
+  test("retrieve returns null when keychain reports not-found (exit 44)", async () => {
+    const { runner } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    expect(await backend.retrieve("MISSING")).toBeNull();
+  });
+
+  test("store passes the value via argv-free -w (value never on the command line we log)", async () => {
+    const { runner, calls } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("GITHUB_TOKEN", "gh_pat_secret");
+    // The runner is the ONLY place a value is handed to `security`; the
+    // backend must not log argv. We assert the account scoping is present.
+    const addCall = calls.find((c) => c[0] === "add-generic-password");
+    expect(addCall).toBeDefined();
+    expect(addCall).toContain("-a");
+    expect(addCall![addCall!.indexOf("-a") + 1]).toBe("alice");
+  });
+
+  test("rotate deletes then adds (no in-place overwrite — issue §E)", async () => {
+    const { runner, calls, store } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("GITHUB_TOKEN", "old");
+    calls.length = 0;
+    await backend.rotate("GITHUB_TOKEN", "new");
+    const verbs = calls.map((c) => c[0]);
+    expect(verbs).toEqual(["delete-generic-password", "add-generic-password"]);
+    expect(store.get("ai.meta-factory.cortex.dev.GITHUB_TOKEN")).toBe("new");
+  });
+
+  test("remove calls delete-generic-password and is idempotent", async () => {
+    const { runner } = makeRunner();
+    const backend = new KeychainBackend("dev", "alice", runner);
+    await backend.store("GITHUB_TOKEN", "v");
+    await backend.remove("GITHUB_TOKEN");
+    expect(await backend.retrieve("GITHUB_TOKEN")).toBeNull();
+    await expect(backend.remove("GITHUB_TOKEN")).resolves.toBeUndefined();
+  });
+});
+
+describe("resolveSecretBackend", () => {
+  test("selects FileBackend when forced (cross-platform fallback)", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "linux",
+      secretsRoot,
+      username: "alice",
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+
+  test("selects KeychainBackend on darwin when security CLI is available", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      securityRunner: () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      keychainAvailable: true,
+    });
+    expect(backend).toBeInstanceOf(KeychainBackend);
+  });
+
+  test("falls back to FileBackend on darwin when keychain is unavailable", () => {
+    const backend = resolveSecretBackend("dev", {
+      platform: "darwin",
+      secretsRoot,
+      username: "alice",
+      keychainAvailable: false,
+    });
+    expect(backend).toBeInstanceOf(FileBackend);
+  });
+});


### PR DESCRIPTION
Closes #229
Refs cortex#835 (dev-loop epic) → phase cortex#869; design §6.4 row F-6e.

## What

Provision a `type: agent` package's declared `capabilities.secrets` at install
time and inject them into the **per-agent environment** — never a brief or a log
(cortex `docs/design-agentic-dev-pipeline.md` §6.2 step 5, §3.5b authority
model). The dev-loop's own `APPROVER_GH_TOKEN` / `CORTEX_DEV_GH_TOKEN` are the
motivating examples.

## Secret flow

`arc install <pkg>` detects `capabilities.secrets` and, per declared name:

- **interactive (default):** secure no-echo prompt; Return skips a secret.
- **`--from-env`:** read each declared secret from the current environment.
- **`--skip-secrets`:** store nothing; the daemon starts and fails at first use
  with a clear message.

A storage failure aborts the install cleanly (no symlinks placed yet); a skip
only WARNs, listing the missing NAMES + the `arc secrets set …` command.

## Storage

- **macOS:** Keychain via the `security` CLI. Service key
  `ai.meta-factory.cortex.<agent>.<NAME>`, account-scoped to the principal's
  username.
- **Linux:** systemd `LoadCredential` resolves the file at daemon-start.
- **Universal fallback:** `~/.config/metafactory/secrets/<agent>/<NAME>`, one
  secret per file, **chmod 600 enforced on every write AND read** (cortex#87
  `enforceChmod600` pattern).

`resolveSecretBackend()` selects native-when-available, else the chmod-600 file
backend.

## Injection

`arc install` injects the agent's stored secrets into the **postinstall child's
env only** — a fresh object scoped to that invocation; arc's own process env is
never mutated, so the secrets are gone when postinstall exits (issue §E "unset
after postinstall"). The plist/systemd render resolves a secret by name at
render / daemon-start time.

## Lifecycle verbs

`arc secrets {list,check,set,rotate,remove} <agent> [<secret>]` — `rotate` is
delete-then-add (no in-place overwrite); `set`/`rotate` support `--from-env`.

## Never-log handling (issue §E)

A secret **value** never reaches stdout / stderr / an argv arc logs / an audit
line. Every verb, warning, and error prints NAMES only; the only ingress is the
prompt / env read, the only egress the storage backend and the per-child env.
`redactSecret()` is the single string a diagnostic may print in a value's place
(`(secret redacted)`). Error rethrows are name-scoped and chain `{ cause }`
(whose message is also name-scoped). `rotate` never overwrites in place;
chmod 600 is re-enforced on read.

## Merge coordination

All logic lives in NEW dedicated modules (`src/lib/secrets.ts`,
`src/lib/secret-provision.ts`, `src/lib/secret-provision-install.ts`,
`src/commands/secrets.ts`). The install.ts wiring is a SINGLE clearly-commented
SECRETS hook in `install()` and `installSingleArtifact()`, placed **non-adjacent**
to the F-6b identity hook (near the return, #233) and the F-6c library-ordering
work (`install-transaction.ts`, #231). Concern: SECRETS only.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint:errors` — clean
- `bun test` — **1081 pass / 0 fail / 3 skip** (52 new tests across 4 files:
  storage backends, flow, install bridge, CLI verbs)

Note: I did NOT see the predicted ~139 e2e git-commit failures in this sandbox —
the full suite ran green. The one e2e failure I hit during development
(`_JIRA` agent-name validation) was mine and is fixed; CI remains the source of
truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)