### PR TITLE
feat(arc): F-6a — invoke cortex config merge on install (cortex_config manifest field)

### DIFF
--- a/docs/cortex-config-composition.md
+++ b/docs/cortex-config-composition.md
@@ -1,0 +1,110 @@
+# Cortex config composition at install (F-6a / cortex#858)
+
+When `arc install` lands a package whose manifest declares a `cortex_config`
+fragment AND the install target host is a cortex stack, arc merges the package's
+declared capabilities/policy into the stack's config automatically — no manual
+editing of `stacks/<id>.yaml`. This closes the F-6a gap in the dev-loop
+blueprint (cortex `docs/design-agentic-dev-pipeline.md` §6.2 install lifecycle
+step 3 / "step 6c", §6.4).
+
+Implementation: [`src/lib/cortex-config-provision.ts`](../src/lib/cortex-config-provision.ts),
+wired into [`src/commands/install.ts`](../src/commands/install.ts) as a single
+hook call (`maybeMergeCortexConfig`) at the cortex-config step of both the
+standalone and library-artifact install paths — AFTER the post-landing
+transaction (so postinstall has run), non-adjacent to the F-6b identity hook and
+the F-6e secrets hook.
+
+## The `cortex_config` manifest field
+
+Optional. The package's CORTEX capability/policy declaration — distinct from
+`capabilities`, which is arc's OWN host-side enforcement (what the package may
+read/write/network/shell locally). Two mutually-exclusive forms:
+
+```yaml
+# Inline form — capabilities and/or policy, NOTHING else.
+cortex_config:
+  capabilities:
+    - id: dev.implement
+      description: "Dev agent implementation"
+      provided_by: [dev-agent]
+  policy:
+    principals:
+      - id: dev-agent
+        role: [develop]
+    roles:
+      - id: develop
+        capabilities: [dev.implement]
+```
+
+```yaml
+# Path-pointer form — a relative path to a YAML fragment shipped in the package.
+cortex_config:
+  path: cortex-config.yaml
+```
+
+A fragment may carry ONLY `capabilities` and/or `policy`. arc rejects any other
+top-level key (`agents`, `principal`, `nats`, …) at manifest-read time so a
+package can't smuggle a transport/identity change in through the merge path —
+that config is the stack's, not the package's. The path form is guarded to a
+relative path with no `..` traversal.
+
+## What runs
+
+arc does NOT reimplement the merge (Anti-Abstraction Gate). It invokes the
+cortex CLI verb, which owns the deep semantics:
+
+```
+cortex config merge --config <stack-config-dir> --fragment <file> [--stack <id>]
+```
+
+| cortex-side behavior | Consequence for arc |
+|---|---|
+| id-keyed deep merge (capabilities/principals/roles), fragment-wins | The package's declarations land in `stacks/<id>.yaml`. |
+| **idempotent** — same fragment twice is a no-op | A retry after a partial failure is safe. |
+| `CortexConfigSchema.parse()` of the composed whole before write | A fragment that would break the stack is rejected; install fails closed. |
+| timestamped 0o600 backup + post-write re-compose, restore-on-failure | A failed merge never leaves the stack unloadable. |
+
+arc's job is to (1) decide the step applies, (2) marshal the fragment to a file,
+and (3) map the verb's exit code to a fail-closed result.
+
+## When the step fires
+
+| Condition | Behavior |
+|---|---|
+| No `cortex_config` in the manifest | No-op (success). |
+| `cortex_config` present, target host NOT a (detected) cortex stack | No-op (success) — the fragment applies only when the package is installed onto a cortex stack. |
+| `cortex_config` present + target host IS cortex | Invoke `cortex config merge`. |
+
+Host-is-cortex reuses the existing host adapter (`host.id === "cortex"` AND
+`host.detect()` — a materialized `cortex.yaml`). The stack config dir is the
+cortex host's `paths.root`. The target stack id is passed through
+`InstallOptions.cortexStackId` → `--stack` (cortex needs it only when the config
+dir holds more than one `stacks/*.yaml`).
+
+## cortex CLI resolution
+
+`ARC_CORTEX_BIN` / `MF_CORTEX_BIN` env (an explicit path; a `.ts` target is run
+with `bun`) → `cortex` on PATH. If neither resolves and the package needs a
+merge, the install **fails closed** with guidance to put `cortex` on PATH (or
+set `ARC_CORTEX_BIN`) and retry — the merge is idempotent, so a retry is safe.
+
+## Fail-closed + rollback
+
+A non-zero exit from the verb fails the install. The landed state is unwound:
+the install transaction rolls back symlinks/hooks/extensions/launchd, and
+because the DB row was committed as the transaction's last step (BEFORE this
+step runs), the cortex-config step removes the row itself. Because the cortex
+verb is idempotent and writes a backup, an arc retry after fixing the cause
+re-runs cleanly.
+
+## Composition with the other F-6 slices
+
+| Slice | Concern | Module | Insertion point |
+|---|---|---|---|
+| F-6c (arc#231) | ordered library installs + atomic rollback | `install-transaction.ts` | per-artifact transaction |
+| F-6b (arc#233) | agent identity provisioning | `identity-provision.ts` | identity step |
+| F-6e (arc#234) | secret provisioning | `secret-provision-install.ts` | secrets step (before preinstall) |
+| **F-6a (cortex#858)** | **cortex config composition** | **`cortex-config-provision.ts`** | **cortex-config step (after the transaction)** |
+
+Each slice is a single, clearly-commented, non-adjacent hook so the lanes
+compose without stepping on each other.

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -58,6 +58,12 @@ import {
   maybeProvisionAgentIdentity,
   reportProvisioningResult,
 } from "../lib/identity-provision.js";
+// F-6a (cortex#858): cortex config composition. Lives in its own module
+// (cortex-config-provision.ts); wired in below as a SINGLE clearly-commented
+// hook at the cortex-config step ("step 6c") — AFTER the post-landing
+// transaction (which runs postinstall), non-adjacent to F-6b's identity hook
+// and F-6e's secrets hook. Concern: cortex config merge only.
+import { maybeMergeCortexConfig } from "../lib/cortex-config-provision.js";
 
 export interface InstallOptions {
   /** arc's own state paths (configRoot, dbPath, reposDir, …). Host-independent. */
@@ -120,6 +126,14 @@ export interface InstallOptions {
   skipSecrets?: boolean;
   fromEnv?: boolean;
   secretBackend?: SecretBackendChoice;
+  /**
+   * F-6a (cortex#858) — target stack id (`{principal}/{stack}`) for the cortex
+   * config merge step. Forwarded to `cortex config merge --stack`. Optional:
+   * cortex requires it only when the target config dir holds more than one
+   * `stacks/*.yaml`. Ignored unless the manifest declares `cortex_config` AND
+   * the target host is a cortex stack.
+   */
+  cortexStackId?: string;
 }
 
 export interface InstallResult {
@@ -463,6 +477,10 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     arc,
     backendChoice: opts.secretBackend,
   });
+  // Capture the live transaction so the F-6a cortex-config step below can
+  // unwind the landed state (symlinks/hooks/launchd/DB row) if the merge fails
+  // — atomic, same as the library path's onTransaction capture.
+  let installTx: InstallTransaction | undefined;
   const transactionResult = await completeInstallTransaction({
     host,
     db,
@@ -477,6 +495,9 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
     sourceTier: opts.sourceTier ?? manifest.tier ?? "custom",
     libraryName: opts.libraryName ?? null,
     postinstallEnv,
+    onTransaction: (handle) => {
+      installTx = handle;
+    },
   });
   if (!transactionResult.success) return transactionResult;
 
@@ -490,6 +511,37 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
   // a non-interactive install never hides an unidentified-agent gap.
   const identityResult = await maybeProvisionAgentIdentity(manifest, { quiet: opts.yes });
   reportProvisioningResult(identityResult);
+
+  // ── F-6a (cortex#858) CORTEX-CONFIG STEP ("step 6c") ──────────────────────
+  // When the manifest declares `cortex_config` AND the target host is a cortex
+  // stack, merge the package's declared capabilities/policy into the stack's
+  // `stacks/<id>.yaml` via `cortex config merge`. Runs AFTER the post-landing
+  // transaction (so postinstall has run) and is fail-closed: a merge failure
+  // unwinds the landed state and aborts the install. The cortex verb is
+  // idempotent + writes a 0o600 backup, so a retry after fixing the cause is
+  // safe. No-op (success) for non-cortex hosts or a manifest without the field.
+  const cortexConfigResult = maybeMergeCortexConfig(manifest, {
+    host,
+    installPath,
+    stackId: opts.cortexStackId,
+    quiet: opts.yes,
+  });
+  if (!cortexConfigResult.success) {
+    // Fail-closed: unwind the landed state. The transaction's rollback unwinds
+    // symlinks/hooks/extensions/launchd; the DB row was committed by
+    // completeInstallTransaction as its LAST step (the existing rollback paths
+    // all fire BEFORE that commit), so this step — which runs AFTER it — must
+    // remove the row itself to leave nothing behind.
+    const evidence = installTx ? await installTx.rollback() : transactionResult.evidence;
+    removeSkill(db, manifest.name);
+    return {
+      success: false,
+      name: manifest.name,
+      version: manifest.version,
+      error: cortexConfigResult.error,
+      evidence,
+    };
+  }
 
   return transactionResult;
 }
@@ -820,6 +872,12 @@ export async function installSingleArtifact(
     arc,
     backendChoice: opts.secretBackend,
   });
+  // Wrap the caller's onTransaction so we ALSO capture the handle locally —
+  // the F-6a cortex-config step below must unwind THIS artifact's landed state
+  // if the merge fails (installSingleArtifact's contract: on a failure return,
+  // its own state is already rolled back, so the library caller does not record
+  // it as a rollback target).
+  let artifactTx: InstallTransaction | undefined;
   const artifactTransactionResult = await completeInstallTransaction({
     host,
     db,
@@ -833,7 +891,10 @@ export async function installSingleArtifact(
     sourceTier: opts.sourceTier ?? manifest.tier ?? "custom",
     libraryName,
     postinstallEnv: artifactPostinstallEnv,
-    onTransaction,
+    onTransaction: (handle) => {
+      artifactTx = handle;
+      onTransaction?.(handle);
+    },
   });
   if (!artifactTransactionResult.success) return artifactTransactionResult;
 
@@ -843,6 +904,33 @@ export async function installSingleArtifact(
   // standalone path above — and the same unconditional failure-visibility rule.
   const artifactIdentityResult = await maybeProvisionAgentIdentity(manifest, { quiet: opts.yes });
   reportProvisioningResult(artifactIdentityResult);
+
+  // F-6a (cortex#858) — CORTEX-CONFIG STEP (library-artifact path). dev-loop's
+  // agents are the primary carriers of `cortex_config` (design §6.1), so the
+  // per-artifact install merges it too. Same fail-closed semantics: on a merge
+  // failure roll THIS artifact's landed state back and return failure, so the
+  // library transaction's own unwind treats it as an already-rolled-back step.
+  const artifactCortexConfig = maybeMergeCortexConfig(manifest, {
+    host,
+    installPath: artifactDir,
+    stackId: opts.cortexStackId,
+    quiet: opts.yes,
+  });
+  if (!artifactCortexConfig.success) {
+    // Roll THIS artifact's landed state back (symlinks/hooks/launchd) AND remove
+    // its committed DB row — the transaction's own rollback stops short of the
+    // DB commit (its last step), and the library caller does not record a
+    // FAILED artifact as a rollback target. So installSingleArtifact owns the
+    // full unwind on a failure return, per its contract.
+    if (artifactTx) await artifactTx.rollback();
+    removeSkill(db, manifest.name);
+    return {
+      success: false,
+      name: manifest.name,
+      version: manifest.version,
+      error: artifactCortexConfig.error,
+    };
+  }
 
   return artifactTransactionResult;
 }

--- a/src/lib/cortex-config-provision.ts
+++ b/src/lib/cortex-config-provision.ts
@@ -1,0 +1,332 @@
+/**
+ * cortex-config-provision.ts — install-time cortex config composition
+ * (F-6a, cortex#858).
+ *
+ * When `arc install` lands a package whose manifest declares a `cortex_config`
+ * fragment AND the install target host is a cortex stack, this module merges the
+ * fragment's capabilities/policy into the stack's `stacks/<id>.yaml` by invoking
+ * the cortex CLI verb:
+ *
+ *     cortex config merge --config <stack-config-dir> --fragment <file> [--stack <id>]
+ *
+ * It is the SINGLE dedicated home for that logic — the same merge-coordination
+ * pattern the sibling F-6 slices established:
+ *   - IDENTITY (F-6b, arc#228) lives in `identity-provision.ts`;
+ *   - SECRETS  (F-6e, arc#229) lives in `secret-provision-install.ts`;
+ *   - LIBRARY ORDERING (F-6c, arc#227) lives in `install-transaction.ts`;
+ *   - CORTEX CONFIG (F-6a) lives HERE.
+ * install.ts wires it in as ONE clearly-commented hook call at the cortex-config
+ * step (the design's "step 6c"), so the concurrent install lanes touch
+ * non-adjacent insertion points.
+ *
+ * Division of labour (Anti-Abstraction Gate): arc does NOT reimplement the
+ * merge. cortex's `config merge` owns the deep semantics — id-keyed deep merge,
+ * idempotency (re-running the same fragment is a no-op), `CortexConfigSchema`
+ * validation of the composed whole, a timestamped backup before write, and a
+ * post-write re-compose + restore-on-failure. arc only:
+ *   1. decides the step applies (manifest declares it + host is cortex),
+ *   2. marshals the fragment to a file the verb can read, and
+ *   3. invokes the verb and maps its exit code to a fail-closed result.
+ *
+ * Fail-closed (issue acceptance criterion): a non-zero exit from the verb fails
+ * the install. Because the verb is idempotent and writes a 0o600 backup, an arc
+ * retry after fixing the cause is safe — a second run with the same fragment is
+ * a no-op, and a partial failure left the original restored from backup.
+ *
+ * Test seam: production calls go through `Bun.spawnSync` via `defaultRunner`;
+ * tests swap a runner through `__setRunnerForTests` (gated on `ARC_TEST_MODE=1`
+ * / `NODE_ENV=test`, mirroring `nats-broker.ts`) so the unit suite never shells
+ * out to a real cortex.
+ */
+
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join, isAbsolute, resolve, relative } from "node:path";
+import { tmpdir } from "node:os";
+import YAML from "yaml";
+import type { ArcManifest, CortexConfigFragment, HostAdapter } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Spawn seam (mirrors nats-broker.ts) — production spawns; tests inject.
+// ---------------------------------------------------------------------------
+
+export interface CortexSpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Runs an argv and returns its exit code + captured streams. */
+export type CortexRunner = (argv: string[]) => CortexSpawnResult;
+
+const defaultRunner: CortexRunner = (argv) => {
+  const result = Bun.spawnSync(argv, { stdout: "pipe", stderr: "pipe" });
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+};
+
+let runner: CortexRunner = defaultRunner;
+
+function assertTestMode(seam: string): void {
+  if (process.env.ARC_TEST_MODE !== "1" && process.env.NODE_ENV !== "test") {
+    throw new Error(`${seam} is a test-only seam. Set ARC_TEST_MODE=1 or NODE_ENV=test.`);
+  }
+}
+
+/** Test-only: swap the spawn runner so the suite never shells out to cortex. */
+export function __setRunnerForTests(r: CortexRunner): void {
+  assertTestMode("__setRunnerForTests");
+  runner = r;
+}
+
+/** Test-only: restore the production spawn runner. */
+export function __resetRunnerForTests(): void {
+  assertTestMode("__resetRunnerForTests");
+  runner = defaultRunner;
+}
+
+// ---------------------------------------------------------------------------
+// cortex CLI resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the argv prefix that invokes `cortex config merge`.
+ *
+ * Resolution order (first hit wins):
+ *   1. `ARC_CORTEX_BIN` / `MF_CORTEX_BIN` env — an explicit path to the cortex
+ *      CLI entry. A `.ts` target is run with `bun`; anything else is exec'd
+ *      directly. This is the test/CI/non-PATH escape hatch and the override an
+ *      operator sets when cortex isn't on PATH.
+ *   2. A `cortex` binary on PATH (`Bun.which`) → `["cortex", "config", "merge"]`.
+ *
+ * Returns null when neither is available — the caller treats that as a
+ * fail-closed "cannot run the merge" rather than silently skipping it.
+ */
+export function resolveCortexMergeArgv(
+  env: Record<string, string | undefined> = process.env,
+): string[] | null {
+  const explicit = env.ARC_CORTEX_BIN ?? env.MF_CORTEX_BIN;
+  if (explicit && explicit.length > 0) {
+    return explicit.endsWith(".ts")
+      ? ["bun", explicit, "config", "merge"]
+      : [explicit, "config", "merge"];
+  }
+
+  // Honor an injected PATH (tests pin it) so resolution is deterministic; in
+  // production `env` is process.env and Bun.which uses the same PATH it would
+  // by default.
+  const onPath = env.PATH ? Bun.which("cortex", { PATH: env.PATH }) : Bun.which("cortex");
+  if (onPath) return ["cortex", "config", "merge"];
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Host detection + config-dir resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the install target host is a cortex stack.
+ *
+ * Reuses the host-awareness the F-6b/c/e slices wired (we do NOT invent a new
+ * detection mechanism): a cortex install is the `cortex` HostAdapter, and its
+ * `detect()` confirms a materialised config on disk (`cortex.yaml` present at
+ * `paths.settingsPath` — see `src/lib/hosts/cortex.ts`). Both must hold: the id
+ * tells us this is the cortex backend, `detect()` tells us the stack is actually
+ * present (not a fresh box without `cortex init` run yet).
+ */
+export function isTargetHostCortex(host: HostAdapter): boolean {
+  return host.id === "cortex" && host.detect();
+}
+
+/**
+ * The config-split directory the cortex daemon points `--config` at — the
+ * cortex host's root (`~/.config/cortex` by default, or a test-overridden
+ * configRoot). cortex's `config merge --config` accepts this directory and
+ * resolves the target `stacks/<id>.yaml` itself (with `--stack` disambiguating
+ * when more than one stack file is present).
+ */
+export function stackConfigDirForHost(host: HostAdapter): string {
+  return host.paths.root;
+}
+
+// ---------------------------------------------------------------------------
+// Step result + the install.ts hook
+// ---------------------------------------------------------------------------
+
+export interface CortexConfigStepResult {
+  /** True iff the step ran and the merge succeeded, OR the step did not apply. */
+  success: boolean;
+  /** Set when `success: false` — a fail-closed, actionable message. */
+  error?: string;
+  /**
+   * Why the step did not perform a merge, when it didn't:
+   *   - "no-fragment"   — manifest declares no `cortex_config`.
+   *   - "host-not-cortex" — target host is not a (detected) cortex stack.
+   * Absent when a merge was actually invoked.
+   */
+  skippedReason?: "no-fragment" | "host-not-cortex";
+  /** True when the verb was actually invoked (a merge attempt happened). */
+  merged?: boolean;
+}
+
+export interface CortexConfigStepOpts {
+  /** Target host adapter (decides host-is-cortex + the config dir). */
+  host: HostAdapter;
+  /** Absolute path to the installed package dir (resolves a `path` fragment). */
+  installPath: string;
+  /**
+   * Target stack id (`{principal}/{stack}`). Forwarded as `--stack`. Optional:
+   * cortex requires it only when the config dir holds more than one stack file.
+   */
+  stackId?: string;
+  /** Suppress stdout progress lines (non-interactive / test use). */
+  quiet?: boolean;
+  /** Test seam — inject the env consulted for cortex-bin resolution. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * The install.ts CORTEX-CONFIG hook — the SINGLE entry point install calls at
+ * the cortex-config step. No-op (success) when the manifest declares no
+ * `cortex_config` or the target host is not a cortex stack. Otherwise marshals
+ * the fragment and invokes `cortex config merge`, returning a fail-closed
+ * result on any error.
+ *
+ * Never throws — every failure path returns `success: false` with a message so
+ * install.ts can fail the install cleanly (and roll back its landed state via
+ * the existing transaction path) rather than crash.
+ */
+export function maybeMergeCortexConfig(
+  manifest: ArcManifest,
+  opts: CortexConfigStepOpts,
+): CortexConfigStepResult {
+  const fragment = manifest.cortex_config;
+  if (!fragment) {
+    return { success: true, skippedReason: "no-fragment" };
+  }
+
+  if (!isTargetHostCortex(opts.host)) {
+    // Not an error: a package may carry a cortex_config AND be installed onto a
+    // non-cortex host (e.g. claude-code). The fragment simply doesn't apply
+    // here; the cortex stack picks it up when the package is installed there.
+    if (!opts.quiet) {
+      process.stdout.write(
+        `cortex-config: package declares cortex_config but target host is not a cortex stack — skipping merge\n`,
+      );
+    }
+    return { success: true, skippedReason: "host-not-cortex" };
+  }
+
+  const configDir = stackConfigDirForHost(opts.host);
+
+  // Marshal the fragment to a file the verb can read. An inline fragment is
+  // written to a temp file we clean up; a `path` pointer resolves to a file
+  // inside the package (validated relative at manifest-read time).
+  let fragmentFile: string;
+  let tmpDir: string | undefined;
+  try {
+    const marshalled = marshalFragment(fragment, opts.installPath);
+    fragmentFile = marshalled.fragmentFile;
+    tmpDir = marshalled.tmpDir;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      error: `cortex-config: cannot prepare fragment for merge: ${msg}`,
+    };
+  }
+
+  try {
+    const argvPrefix = resolveCortexMergeArgv(opts.env);
+    if (!argvPrefix) {
+      // Fail-closed: the package needs its cortex config merged but we can't
+      // find the cortex CLI. Don't silently skip — the install must fail so the
+      // operator wires `cortex` onto PATH (or sets ARC_CORTEX_BIN) and retries.
+      return {
+        success: false,
+        error:
+          `cortex-config: cortex_config declared but the cortex CLI was not found. ` +
+          `Put 'cortex' on PATH or set ARC_CORTEX_BIN to the cortex CLI, then re-run the install (the merge is idempotent).`,
+      };
+    }
+
+    const argv = [...argvPrefix, "--config", configDir, "--fragment", fragmentFile];
+    if (opts.stackId) argv.push("--stack", opts.stackId);
+
+    if (!opts.quiet) {
+      // Log the invocation WITHOUT the fragment file's contents (paths only).
+      process.stdout.write(`cortex-config: merging fragment into ${configDir}\n`);
+    }
+
+    const result = runner(argv);
+    if (result.exitCode !== 0) {
+      // Surface cortex's own diagnostic (it writes a per-entry merge report +
+      // the failing schema error to stderr). Fail-closed.
+      const detail = (result.stderr || result.stdout || "").trim();
+      return {
+        success: false,
+        error:
+          `cortex-config: \`cortex config merge\` failed (exit ${result.exitCode})` +
+          (detail ? `:\n${detail}` : `. Re-run after fixing the cause — the merge is idempotent.`),
+      };
+    }
+
+    if (!opts.quiet && result.stderr.trim()) {
+      // cortex reports the merge disposition (added/skipped/changed) on stderr.
+      process.stdout.write(`${result.stderr.trim()}\n`);
+    }
+
+    return { success: true, merged: true };
+  } finally {
+    // Clean up only the temp file we created for an inline fragment; a `path`
+    // pointer lives inside the package and is not ours to remove.
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Resolve the fragment to an on-disk YAML file for `--fragment`.
+ *
+ * - Path pointer (`{ path }`): resolve relative to the package install dir,
+ *   guard against escaping it (defense-in-depth — the path was already
+ *   validated relative/no-`..` at manifest-read time), and require it to exist.
+ * - Inline (`{ capabilities?, policy? }`): serialize to a temp file. The caller
+ *   removes `tmpDir` in a finally.
+ */
+export function marshalFragment(
+  fragment: CortexConfigFragment,
+  installPath: string,
+): { fragmentFile: string; tmpDir?: string } {
+  if (typeof fragment.path === "string" && fragment.path.length > 0) {
+    const abs = resolve(installPath, fragment.path);
+    // Containment guard: the resolved path must stay inside the package.
+    const rel = relative(installPath, abs);
+    if (rel.startsWith("..") || isAbsolute(rel)) {
+      throw new Error(
+        `cortex_config.path '${fragment.path}' escapes the package directory`,
+      );
+    }
+    if (!existsSync(abs)) {
+      throw new Error(
+        `cortex_config.path '${fragment.path}' does not exist in the package (resolved: ${abs})`,
+      );
+    }
+    return { fragmentFile: abs };
+  }
+
+  // Inline form — write only the capability/policy subset (the manifest
+  // validator already rejected any other key).
+  const body: Record<string, unknown> = {};
+  if (fragment.capabilities !== undefined) body.capabilities = fragment.capabilities;
+  if (fragment.policy !== undefined) body.policy = fragment.policy;
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "arc-cortex-fragment-"));
+  const fragmentFile = join(tmpDir, "fragment.yaml");
+  writeFileSync(fragmentFile, YAML.stringify(body, { indent: 2, lineWidth: 0 }), "utf-8");
+  return { fragmentFile, tmpDir };
+}

--- a/src/lib/cortex-config-provision.ts
+++ b/src/lib/cortex-config-provision.ts
@@ -325,6 +325,17 @@ export function marshalFragment(
   if (fragment.capabilities !== undefined) body.capabilities = fragment.capabilities;
   if (fragment.policy !== undefined) body.policy = fragment.policy;
 
+  // Defensive guard (self-review §1): the install path always runs through the
+  // manifest validator, which rejects an empty fragment — but this fn is also
+  // exported and callable directly. An empty inline body would otherwise write
+  // `{}`, which cortex rejects with an opaque exit 1. Fail with an arc-side
+  // message instead.
+  if (Object.keys(body).length === 0) {
+    throw new Error(
+      "cortex_config inline fragment is empty — declare 'capabilities' and/or 'policy', or use a 'path' pointer",
+    );
+  }
+
   const tmpDir = mkdtempSync(join(tmpdir(), "arc-cortex-fragment-"));
   const fragmentFile = join(tmpDir, "fragment.yaml");
   writeFileSync(fragmentFile, YAML.stringify(body, { indent: 2, lineWidth: 0 }), "utf-8");

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -73,6 +73,7 @@ async function readManifestFromDir(
       // Library-specific validation
       if (parsed.type === "library") {
         validateLibraryManifest(parsed, filename);
+        validateCortexConfig(parsed, filename);
         return parsed;
       }
 
@@ -83,6 +84,7 @@ async function readManifestFromDir(
         validateProcess(parsed, filename);
         validateTargets(parsed, filename);
         validateLifecycle(parsed, filename);
+        validateCortexConfig(parsed, filename);
         return parsed;
       }
 
@@ -123,6 +125,7 @@ async function readManifestFromDir(
       normalizeCapabilities(parsed, filename);
       validateTargets(parsed, filename);
       validateLifecycle(parsed, filename);
+      validateCortexConfig(parsed, filename);
 
       return parsed;
     } catch (err) {
@@ -302,6 +305,103 @@ export function validateLifecycle(manifest: ArcManifest, filename: string): void
         );
       }
     }
+  }
+}
+
+/** The only top-level keys a `cortex_config` fragment may carry inline (besides
+ *  the mutually-exclusive `path` pointer). Mirrors cortex's
+ *  `CapabilityMergeFragmentSchema.strict()` boundary so a package can't smuggle
+ *  a transport/identity change (`agents`, `principal`, `nats`, …) in through the
+ *  merge path. cortex re-validates authoritatively at merge time; this is the
+ *  structural pre-filter at arc's manifest edge. */
+const CORTEX_CONFIG_INLINE_KEYS = new Set(["capabilities", "policy"]);
+
+/**
+ * Validate `cortex_config:` on the manifest (F-6a / cortex#858).
+ *
+ * The field is OPTIONAL. When present it must be one of two mutually-exclusive
+ * forms:
+ *   - Path pointer: `{ path: "<relative-file>" }` — a relative path (no leading
+ *     `/`, no `..` segment, defense-in-depth against escaping the package root)
+ *     to a YAML fragment file shipped in the package.
+ *   - Inline fragment: at least one of `capabilities:` / `policy:`, and NO
+ *     other top-level key.
+ *
+ * arc does NOT parse the fragment's deep contents — cortex's
+ * `CapabilityMergeFragmentSchema` + `CortexConfigSchema` own that at merge time
+ * (Anti-Abstraction Gate: trust the downstream validator, don't reimplement it).
+ * arc's job here is to reject obviously-malformed manifests at read time so a
+ * typo surfaces on install rather than as an opaque cortex-side error, and to
+ * enforce the capability/policy-only boundary at the trust edge.
+ */
+export function validateCortexConfig(manifest: ArcManifest, filename: string): void {
+  const cc = manifest.cortex_config as unknown;
+  if (cc === undefined || cc === null) return;
+
+  if (!isRecord(cc)) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config' must be an object with a 'path' pointer or inline 'capabilities'/'policy' (got ${Array.isArray(cc) ? "array" : typeof cc})`,
+    );
+  }
+
+  const keys = Object.keys(cc);
+  if (keys.length === 0) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config' is empty — declare a 'path' to a fragment file, or inline 'capabilities'/'policy'. Omit the field entirely if there is nothing to merge.`,
+    );
+  }
+
+  const hasPath = "path" in cc;
+  const inlineKeys = keys.filter((k) => k !== "path");
+
+  // Path-pointer form: `path` + nothing else.
+  if (hasPath) {
+    if (inlineKeys.length > 0) {
+      throw new Error(
+        `Invalid ${filename}: 'cortex_config' is both a 'path' pointer and inline (${inlineKeys.join(", ")}) — choose one form, not both.`,
+      );
+    }
+    const p = cc.path;
+    if (typeof p !== "string" || p.length === 0) {
+      throw new Error(
+        `Invalid ${filename}: 'cortex_config.path' must be a non-empty relative path to a YAML fragment file.`,
+      );
+    }
+    if (p.startsWith("/")) {
+      throw new Error(
+        `Invalid ${filename}: 'cortex_config.path' '${p}' must be a relative path (no leading /).`,
+      );
+    }
+    if (p.split("/").includes("..")) {
+      throw new Error(
+        `Invalid ${filename}: 'cortex_config.path' '${p}' must not contain '..'.`,
+      );
+    }
+    return;
+  }
+
+  // Inline form: only capabilities/policy, at least one present.
+  const unknownKeys = inlineKeys.filter((k) => !CORTEX_CONFIG_INLINE_KEYS.has(k));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config' may only declare 'capabilities' and/or 'policy' (or a 'path' pointer); got unexpected key(s): ${unknownKeys.join(", ")}. ` +
+        `A package may not declare transport/identity config (agents, principal, nats, …) — that is the stack's, not the package's.`,
+    );
+  }
+  if (inlineKeys.length === 0) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config' inline form must declare at least one of 'capabilities:' or 'policy:'.`,
+    );
+  }
+  if ("capabilities" in cc && !Array.isArray(cc.capabilities)) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config.capabilities' must be an array of capability declarations.`,
+    );
+  }
+  if ("policy" in cc && !isRecord(cc.policy)) {
+    throw new Error(
+      `Invalid ${filename}: 'cortex_config.policy' must be an object with 'principals'/'roles' arrays.`,
+    );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,6 +495,55 @@ export interface ArcManifest {
    * one place.
    */
   category?: string;
+  /**
+   * Cortex-side config fragment to merge into the target stack at install
+   * time (F-6a, cortex#858). When present AND the install target host is a
+   * cortex stack, arc invokes `cortex config merge --fragment <…> --config
+   * <stack-config-dir>` after the post-landing transaction, so the package's
+   * declared capabilities/policy land in the stack's `stacks/<id>.yaml`
+   * without the operator hand-editing it.
+   *
+   * This is the package's CORTEX capability/policy declaration — distinct from
+   * `capabilities`, which is arc's OWN host-side capability enforcement (what
+   * the package may read/write/network/shell on the local machine). A fragment
+   * carries ONLY `capabilities` and/or `policy`; arc rejects any other
+   * top-level key (`agents`, `principal`, `nats`, …) at manifest-read time so a
+   * package can't smuggle a transport/identity change in through the merge
+   * path. cortex's `CapabilityMergeFragmentSchema` is the authoritative
+   * validator — arc's check is a structural pre-filter at the manifest edge.
+   *
+   * Either an inline fragment object, or a `{ path: <relative-file> }` pointer
+   * to a YAML fragment file shipped inside the package.
+   */
+  cortex_config?: CortexConfigFragment;
+}
+
+/**
+ * A cortex config fragment declared in arc-manifest.yaml (F-6a / cortex#858).
+ *
+ * Two forms:
+ *   - Inline: `{ capabilities?: [...], policy?: {...} }` — the fragment body
+ *     written verbatim to a temp file and passed to `cortex config merge
+ *     --fragment`.
+ *   - Path pointer: `{ path: "cortex-config.yaml" }` — a relative path (no
+ *     leading `/`, no `..`) to a YAML fragment file shipped in the package;
+ *     arc passes that file straight to `--fragment`.
+ *
+ * The two forms are mutually exclusive: a fragment is EITHER inline OR a path,
+ * never both. cortex owns the deep semantics (id-keyed merge, idempotency,
+ * CortexConfigSchema validation); arc only marshals the fragment to disk and
+ * invokes the verb.
+ */
+export interface CortexConfigFragment {
+  /**
+   * Relative path to a YAML fragment file inside the package. Mutually
+   * exclusive with the inline `capabilities`/`policy` keys.
+   */
+  path?: string;
+  /** Inline cortex capability declarations (id-keyed). */
+  capabilities?: unknown[];
+  /** Inline cortex policy (principals + roles). */
+  policy?: { principals?: unknown[]; roles?: unknown[] } & Record<string, unknown>;
 }
 
 /**

--- a/test/commands/install-cortex-config-f6a.test.ts
+++ b/test/commands/install-cortex-config-f6a.test.ts
@@ -1,0 +1,219 @@
+/**
+ * F-6a (cortex#858) end-to-end: cortex config composition through `install()`.
+ *
+ * Drives the install flow against a cortex host and asserts the cortex-config
+ * step fires exactly when (a) the manifest declares `cortex_config` AND (b) the
+ * target host is a detected cortex stack. The `cortex config merge` verb is
+ * never actually spawned — a runner is injected via `__setRunnerForTests` and
+ * cortex-bin resolution is pinned via ARC_CORTEX_BIN.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+import { Database } from "bun:sqlite";
+import { createTestEnv, type TestEnv } from "../helpers/test-env.js";
+import { install } from "../../src/commands/install.js";
+import { createCortexHost } from "../../src/lib/hosts/cortex.js";
+import {
+  __setRunnerForTests,
+  __resetRunnerForTests,
+  type CortexRunner,
+} from "../../src/lib/cortex-config-provision.js";
+import { getSkill } from "../../src/lib/db.js";
+
+process.env.ARC_TEST_MODE = "1";
+
+let env: TestEnv;
+let cortexRoot: string;
+let prevCortexBin: string | undefined;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  cortexRoot = join(env.root, "cortex");
+  await mkdir(cortexRoot, { recursive: true });
+  // Materialize cortex.yaml so the cortex host's detect() passes.
+  await writeFile(join(cortexRoot, "cortex.yaml"), "principal: {}\n", "utf-8");
+  prevCortexBin = process.env.ARC_CORTEX_BIN;
+  process.env.ARC_CORTEX_BIN = "/x/cortex"; // pin resolution; runner is mocked anyway
+});
+
+afterEach(async () => {
+  __resetRunnerForTests();
+  if (prevCortexBin === undefined) delete process.env.ARC_CORTEX_BIN;
+  else process.env.ARC_CORTEX_BIN = prevCortexBin;
+  await env.cleanup();
+});
+
+/** Build a git-backed agent repo whose manifest carries an optional cortex_config. */
+async function makeAgentRepo(
+  name: string,
+  cortex_config?: Record<string, unknown>,
+): Promise<string> {
+  const repoDir = join(env.root, `mock-${name}`);
+  await mkdir(join(repoDir, "agent"), { recursive: true });
+  await writeFile(
+    join(repoDir, "agent", `${name}.md`),
+    `---\nname: ${name}\ndescription: mock\nmodel: sonnet\n---\n# ${name}\n`,
+    "utf-8",
+  );
+  const manifest: Record<string, unknown> = {
+    name,
+    version: "1.0.0",
+    type: "agent",
+    tier: "custom",
+    author: { name: "t", github: "t" },
+    ...(cortex_config ? { cortex_config } : {}),
+  };
+  await writeFile(join(repoDir, "arc-manifest.yaml"), YAML.stringify(manifest), "utf-8");
+  Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=T", "-c", "user.email=t@t.com", "commit", "-m", "init"],
+    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+  );
+  return repoDir;
+}
+
+function cortexHost() {
+  return createCortexHost({ configRoot: cortexRoot });
+}
+
+function recorder(calls: string[][]): CortexRunner {
+  return (argv) => {
+    calls.push(argv);
+    return { exitCode: 0, stdout: "", stderr: "" };
+  };
+}
+
+describe("install() — F-6a cortex config composition", () => {
+  test("invokes the merge when cortex_config present + host is cortex", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const repo = await makeAgentRepo("dev-agent", { capabilities: [{ id: "dev.implement" }] });
+
+    const result = await install({
+      arc: env.arc,
+      host: cortexHost(),
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+      cortexStackId: "andreas/work",
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls.length).toBe(1);
+    expect(calls[0].slice(0, 3)).toEqual(["/x/cortex", "config", "merge"]);
+    expect(calls[0][calls[0].indexOf("--config") + 1]).toBe(cortexRoot);
+    expect(calls[0][calls[0].indexOf("--stack") + 1]).toBe("andreas/work");
+    // Package landed in the DB.
+    expect(getSkill(env.db, "dev-agent")?.status).toBe("active");
+  });
+
+  test("skips the merge when manifest has no cortex_config", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const repo = await makeAgentRepo("plain-agent");
+
+    const result = await install({
+      arc: env.arc,
+      host: cortexHost(),
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls.length).toBe(0);
+  });
+
+  test("skips the merge when the host is NOT cortex (claude-code)", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const repo = await makeAgentRepo("dev-agent", { capabilities: [{ id: "dev.implement" }] });
+
+    const result = await install({
+      arc: env.arc,
+      host: env.host, // default claude-code host
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls.length).toBe(0);
+    // Still installed onto the claude-code host (cortex doesn't host agents in
+    // this path, but the agent .md symlink lands via the default host).
+    expect(getSkill(env.db, "dev-agent")?.status).toBe("active");
+  });
+
+  test("fails CLOSED + rolls back the DB row when the merge fails", async () => {
+    const failing: CortexRunner = () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "config merge: composed config failed CortexConfigSchema",
+    });
+    __setRunnerForTests(failing);
+    const repo = await makeAgentRepo("dev-agent", { capabilities: [{ id: "dev.implement" }] });
+
+    const result = await install({
+      arc: env.arc,
+      host: cortexHost(),
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+      cortexStackId: "andreas/work",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cortex config merge");
+    // Fail-closed rollback: the DB row that the transaction committed is unwound.
+    const db = new Database(env.arc.dbPath, { readonly: true });
+    try {
+      const row = db.query("SELECT status FROM skills WHERE name = 'dev-agent'").get() as
+        | { status: string }
+        | null;
+      // Either no row, or not active — the install did not stick.
+      expect(row?.status === "active").toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("a retry after a transient merge failure succeeds (idempotent verb)", async () => {
+    // First attempt: merge fails → install fails closed, nothing sticks.
+    let attempt = 0;
+    const flaky: CortexRunner = () => {
+      attempt += 1;
+      return attempt === 1
+        ? { exitCode: 1, stdout: "", stderr: "transient broker error" }
+        : { exitCode: 0, stdout: "", stderr: "config merge: idempotent no-op — OK" };
+    };
+    __setRunnerForTests(flaky);
+    const repo = await makeAgentRepo("dev-agent", { capabilities: [{ id: "dev.implement" }] });
+
+    const first = await install({
+      arc: env.arc,
+      host: cortexHost(),
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+      cortexStackId: "andreas/work",
+    });
+    expect(first.success).toBe(false);
+
+    // Retry: same package, merge now succeeds.
+    const second = await install({
+      arc: env.arc,
+      host: cortexHost(),
+      db: env.db,
+      repoUrl: repo,
+      yes: true,
+      cortexStackId: "andreas/work",
+    });
+    expect(second.success).toBe(true);
+    expect(getSkill(env.db, "dev-agent")?.status).toBe("active");
+  });
+});

--- a/test/unit/cortex-config-provision.test.ts
+++ b/test/unit/cortex-config-provision.test.ts
@@ -141,6 +141,10 @@ describe("marshalFragment", () => {
   test("path pointer to a missing file throws", () => {
     expect(() => marshalFragment({ path: "nope.yaml" }, root)).toThrow(/does not exist/);
   });
+
+  test("an empty inline fragment throws (defensive — bypasses the manifest validator)", () => {
+    expect(() => marshalFragment({}, root)).toThrow(/is empty/);
+  });
 });
 
 describe("maybeMergeCortexConfig", () => {

--- a/test/unit/cortex-config-provision.test.ts
+++ b/test/unit/cortex-config-provision.test.ts
@@ -1,0 +1,257 @@
+/**
+ * F-6a (cortex#858) — unit tests for the install-time cortex-config bridge
+ * (`cortex-config-provision.ts`). Hermetic: the `cortex config merge` verb is
+ * never actually spawned — a runner is injected via `__setRunnerForTests`, and
+ * cortex-bin resolution reads an injected env.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "fs/promises";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+import {
+  maybeMergeCortexConfig,
+  marshalFragment,
+  isTargetHostCortex,
+  stackConfigDirForHost,
+  resolveCortexMergeArgv,
+  __setRunnerForTests,
+  __resetRunnerForTests,
+  type CortexRunner,
+  type CortexSpawnResult,
+} from "../../src/lib/cortex-config-provision.js";
+import { createCortexHost } from "../../src/lib/hosts/cortex.js";
+import { getDefaultHost } from "../../src/lib/paths.js";
+import type { ArcManifest, HostAdapter } from "../../src/types.js";
+
+// ARC_TEST_MODE gates the runner seam; bun sets NODE_ENV=test, but be explicit.
+process.env.ARC_TEST_MODE = "1";
+
+let root: string;
+let cortexConfigRoot: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "arc-cortex-config-unit-"));
+  cortexConfigRoot = join(root, "cortex");
+  await mkdir(cortexConfigRoot, { recursive: true });
+});
+
+afterEach(async () => {
+  __resetRunnerForTests();
+  await rm(root, { recursive: true, force: true });
+});
+
+/** A cortex host whose detect() passes (cortex.yaml materialized in the root). */
+async function cortexHostDetected(): Promise<HostAdapter> {
+  await writeFile(join(cortexConfigRoot, "cortex.yaml"), "principal: {}\n", "utf-8");
+  return createCortexHost({ configRoot: cortexConfigRoot });
+}
+
+/** A cortex host whose detect() fails (no cortex.yaml — separate empty root). */
+function cortexHostUndetected(): HostAdapter {
+  return createCortexHost({ configRoot: join(root, "cortex-empty") });
+}
+
+function agent(cortex_config?: ArcManifest["cortex_config"]): ArcManifest {
+  return { name: "dev-agent", version: "1.0.0", type: "agent", cortex_config };
+}
+
+/** A recording runner that always succeeds (exit 0). */
+function recorder(calls: string[][]): CortexRunner {
+  return (argv) => {
+    calls.push(argv);
+    return { exitCode: 0, stdout: "", stderr: "config merge: 1 capability added — OK" };
+  };
+}
+
+describe("isTargetHostCortex / stackConfigDirForHost", () => {
+  test("true only for a detected cortex host", async () => {
+    expect(isTargetHostCortex(await cortexHostDetected())).toBe(true);
+    expect(isTargetHostCortex(cortexHostUndetected())).toBe(false);
+    expect(isTargetHostCortex(getDefaultHost({ root: join(root, ".claude") }))).toBe(false);
+  });
+
+  test("config dir is the cortex host root", async () => {
+    expect(stackConfigDirForHost(await cortexHostDetected())).toBe(cortexConfigRoot);
+  });
+});
+
+describe("resolveCortexMergeArgv", () => {
+  test("ARC_CORTEX_BIN .ts → bun runner", () => {
+    expect(resolveCortexMergeArgv({ ARC_CORTEX_BIN: "/x/config-merge.ts" })).toEqual([
+      "bun",
+      "/x/config-merge.ts",
+      "config",
+      "merge",
+    ]);
+  });
+
+  test("ARC_CORTEX_BIN binary → direct exec", () => {
+    expect(resolveCortexMergeArgv({ ARC_CORTEX_BIN: "/usr/local/bin/cortex" })).toEqual([
+      "/usr/local/bin/cortex",
+      "config",
+      "merge",
+    ]);
+  });
+
+  test("MF_CORTEX_BIN is honored as a fallback name", () => {
+    expect(resolveCortexMergeArgv({ MF_CORTEX_BIN: "/x/cortex" })).toEqual([
+      "/x/cortex",
+      "config",
+      "merge",
+    ]);
+  });
+
+  test("null when nothing resolves (no env, no PATH cortex)", () => {
+    // We can't reliably guarantee `cortex` is absent from the real PATH, so only
+    // assert the env-empty branch falls through to the Bun.which probe; if the
+    // box happens to have cortex installed this returns the PATH form, which is
+    // still a non-null valid argv. Either way it must be null OR a 3+ token argv.
+    const r = resolveCortexMergeArgv({});
+    expect(r === null || (Array.isArray(r) && r.length >= 3)).toBe(true);
+  });
+});
+
+describe("marshalFragment", () => {
+  test("inline fragment → temp file with only capability/policy keys", () => {
+    const { fragmentFile, tmpDir } = marshalFragment(
+      { capabilities: [{ id: "dev.implement" }], policy: { principals: [], roles: [] } },
+      root,
+    );
+    expect(tmpDir).toBeDefined();
+    expect(existsSync(fragmentFile)).toBe(true);
+    const parsed = YAML.parse(readFileSync(fragmentFile, "utf-8"));
+    expect(Object.keys(parsed).sort()).toEqual(["capabilities", "policy"]);
+    rmSync(tmpDir!, { recursive: true, force: true });
+  });
+
+  test("path pointer → resolves inside the package", async () => {
+    await writeFile(join(root, "frag.yaml"), "capabilities: []\n", "utf-8");
+    const { fragmentFile, tmpDir } = marshalFragment({ path: "frag.yaml" }, root);
+    expect(tmpDir).toBeUndefined();
+    expect(fragmentFile).toBe(join(root, "frag.yaml"));
+  });
+
+  test("path pointer that escapes the package throws", () => {
+    expect(() => marshalFragment({ path: "../../etc/passwd" }, root)).toThrow(/escapes the package/);
+  });
+
+  test("path pointer to a missing file throws", () => {
+    expect(() => marshalFragment({ path: "nope.yaml" }, root)).toThrow(/does not exist/);
+  });
+});
+
+describe("maybeMergeCortexConfig", () => {
+  test("no-op success when manifest has no cortex_config", async () => {
+    const r = maybeMergeCortexConfig(agent(), {
+      host: await cortexHostDetected(),
+      installPath: root,
+      quiet: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.skippedReason).toBe("no-fragment");
+    expect(r.merged).toBeUndefined();
+  });
+
+  test("no-op success when host is not cortex", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const r = maybeMergeCortexConfig(agent({ capabilities: [{ id: "x" }] }), {
+      host: getDefaultHost({ root: join(root, ".claude") }),
+      installPath: root,
+      quiet: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.skippedReason).toBe("host-not-cortex");
+    expect(calls.length).toBe(0); // never invoked the verb
+  });
+
+  test("invokes `cortex config merge` with the right argv when present + host is cortex", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const host = await cortexHostDetected();
+    const r = maybeMergeCortexConfig(agent({ capabilities: [{ id: "dev.implement" }] }), {
+      host,
+      installPath: root,
+      stackId: "andreas/work",
+      quiet: true,
+      env: { ARC_CORTEX_BIN: "/x/cortex" },
+    });
+    expect(r.success).toBe(true);
+    expect(r.merged).toBe(true);
+    expect(calls.length).toBe(1);
+    const argv = calls[0];
+    expect(argv.slice(0, 3)).toEqual(["/x/cortex", "config", "merge"]);
+    expect(argv).toContain("--config");
+    expect(argv[argv.indexOf("--config") + 1]).toBe(cortexConfigRoot);
+    expect(argv).toContain("--fragment");
+    expect(argv).toContain("--stack");
+    expect(argv[argv.indexOf("--stack") + 1]).toBe("andreas/work");
+  });
+
+  test("omits --stack when no stackId given", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    maybeMergeCortexConfig(agent({ capabilities: [{ id: "x" }] }), {
+      host: await cortexHostDetected(),
+      installPath: root,
+      quiet: true,
+      env: { ARC_CORTEX_BIN: "/x/cortex" },
+    });
+    expect(calls[0]).not.toContain("--stack");
+  });
+
+  test("fail-closed when the verb exits non-zero", async () => {
+    const failing: CortexRunner = (): CortexSpawnResult => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "config merge: composed config failed CortexConfigSchema",
+    });
+    __setRunnerForTests(failing);
+    const r = maybeMergeCortexConfig(agent({ capabilities: [{ id: "x" }] }), {
+      host: await cortexHostDetected(),
+      installPath: root,
+      quiet: true,
+      env: { ARC_CORTEX_BIN: "/x/cortex" },
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("exit 1");
+    expect(r.error).toContain("CortexConfigSchema");
+  });
+
+  test("fail-closed when the cortex CLI cannot be found", async () => {
+    const calls: string[][] = [];
+    __setRunnerForTests(recorder(calls));
+    const r = maybeMergeCortexConfig(agent({ capabilities: [{ id: "x" }] }), {
+      host: await cortexHostDetected(),
+      installPath: root,
+      quiet: true,
+      // Force resolution to fail: empty env AND a name PATH won't have.
+      env: { PATH: "/nonexistent-bin-dir" },
+    });
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("cortex CLI was not found");
+    expect(calls.length).toBe(0);
+  });
+
+  test("cleans up the inline-fragment temp file after a successful merge", async () => {
+    let capturedFragmentPath = "";
+    const runner: CortexRunner = (argv) => {
+      capturedFragmentPath = argv[argv.indexOf("--fragment") + 1];
+      // Verify the file exists DURING the merge.
+      expect(existsSync(capturedFragmentPath)).toBe(true);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    __setRunnerForTests(runner);
+    maybeMergeCortexConfig(agent({ capabilities: [{ id: "x" }] }), {
+      host: await cortexHostDetected(),
+      installPath: root,
+      quiet: true,
+      env: { ARC_CORTEX_BIN: "/x/cortex" },
+    });
+    // …and gone AFTER (finally block removed the temp dir).
+    expect(existsSync(capturedFragmentPath)).toBe(false);
+  });
+});

--- a/test/unit/manifest-cortex-config.test.ts
+++ b/test/unit/manifest-cortex-config.test.ts
@@ -1,0 +1,215 @@
+/**
+ * F-6a (cortex#858) — `cortex_config` manifest field validation +
+ * round-trip. Covers the structural pre-filter arc applies at manifest-read
+ * time (capability/policy-only boundary; inline-vs-path mutual exclusivity;
+ * relative-path guard). cortex's `CapabilityMergeFragmentSchema` owns the deep
+ * semantics at merge time — these tests assert only arc's edge contract.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+import { readManifest, validateCortexConfig } from "../../src/lib/manifest.js";
+import type { ArcManifest } from "../../src/types.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "arc-cortex-config-manifest-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Write an arc-manifest.yaml from an object and read it back through the parser. */
+async function roundTrip(manifest: Record<string, unknown>): Promise<ArcManifest | null> {
+  await writeFile(join(dir, "arc-manifest.yaml"), YAML.stringify(manifest), "utf-8");
+  return readManifest(dir);
+}
+
+const baseAgent = {
+  name: "dev-agent",
+  version: "1.0.0",
+  type: "agent",
+};
+
+describe("validateCortexConfig — inline form", () => {
+  test("accepts capabilities-only", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { capabilities: [{ id: "dev.implement" }] } } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("accepts policy-only", () => {
+    expect(() =>
+      validateCortexConfig(
+        {
+          ...baseAgent,
+          cortex_config: { policy: { principals: [{ id: "dev-agent" }], roles: [] } },
+        } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("accepts both capabilities + policy", () => {
+    expect(() =>
+      validateCortexConfig(
+        {
+          ...baseAgent,
+          cortex_config: {
+            capabilities: [{ id: "dev.implement" }],
+            policy: { principals: [], roles: [{ id: "develop" }] },
+          },
+        } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects a smuggled transport/identity key (agents)", () => {
+    expect(() =>
+      validateCortexConfig(
+        {
+          ...baseAgent,
+          cortex_config: { capabilities: [], agents: [{ id: "x" }] },
+        } as unknown as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/may only declare 'capabilities' and\/or 'policy'/);
+  });
+
+  test("rejects an empty inline fragment (no capabilities, no policy)", () => {
+    // An object with only an unknown key is caught by the unknown-key guard;
+    // a truly empty object is caught by the empty guard.
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: {} } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/is empty/);
+  });
+
+  test("rejects capabilities that is not an array", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { capabilities: "nope" } } as unknown as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/capabilities' must be an array/);
+  });
+
+  test("rejects policy that is not an object", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { policy: [] } } as unknown as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/policy' must be an object/);
+  });
+});
+
+describe("validateCortexConfig — path-pointer form", () => {
+  test("accepts a relative path pointer", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { path: "cortex-config.yaml" } } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects an absolute path", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { path: "/etc/passwd" } } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/must be a relative path/);
+  });
+
+  test("rejects a path with .. traversal", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: { path: "../escape.yaml" } } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/must not contain '\.\.'/);
+  });
+
+  test("rejects path + inline keys together (mutual exclusivity)", () => {
+    expect(() =>
+      validateCortexConfig(
+        {
+          ...baseAgent,
+          cortex_config: { path: "f.yaml", capabilities: [] },
+        } as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/both a 'path' pointer and inline/);
+  });
+});
+
+describe("validateCortexConfig — non-object", () => {
+  test("rejects a string", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: "nope" } as unknown as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/must be an object/);
+  });
+
+  test("rejects an array", () => {
+    expect(() =>
+      validateCortexConfig(
+        { ...baseAgent, cortex_config: [] } as unknown as ArcManifest,
+        "arc-manifest.yaml",
+      ),
+    ).toThrow(/must be an object/);
+  });
+
+  test("no-op when absent", () => {
+    expect(() =>
+      validateCortexConfig(baseAgent as ArcManifest, "arc-manifest.yaml"),
+    ).not.toThrow();
+  });
+});
+
+describe("readManifest — cortex_config round-trips through the parser", () => {
+  test("a valid inline fragment survives parse + validation", async () => {
+    const fragment = {
+      capabilities: [
+        { id: "dev.implement", description: "Dev agent implementation", provided_by: ["dev-agent"] },
+      ],
+      policy: { principals: [{ id: "dev-agent", role: ["develop"] }], roles: [{ id: "develop", capabilities: ["dev.implement"] }] },
+    };
+    const m = await roundTrip({ ...baseAgent, cortex_config: fragment });
+    expect(m).not.toBeNull();
+    expect(m!.cortex_config).toEqual(fragment);
+  });
+
+  test("a path-pointer fragment survives parse", async () => {
+    const m = await roundTrip({ ...baseAgent, cortex_config: { path: "cortex-config.yaml" } });
+    expect(m!.cortex_config).toEqual({ path: "cortex-config.yaml" });
+  });
+
+  test("an invalid fragment makes readManifest throw", async () => {
+    await writeFile(
+      join(dir, "arc-manifest.yaml"),
+      YAML.stringify({ ...baseAgent, cortex_config: { nats: { subjects: [] } } }),
+      "utf-8",
+    );
+    await expect(readManifest(dir)).rejects.toThrow(/may only declare 'capabilities'/);
+  });
+
+  test("a manifest WITHOUT cortex_config parses unchanged", async () => {
+    const m = await roundTrip(baseAgent);
+    expect(m!.cortex_config).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Arc side of F-6a (cortex#858)

Automated, validated, idempotent merge of a package's declared **cortex** capabilities/policy into a cortex stack's config at install time. The cortex `config merge` verb already exists and is merged (`the-metafactory/cortex` `src/cli/cortex/commands/config-merge.ts`). This PR adds the **arc side**: arc now declares `cortex_config` in the manifest and invokes the verb on install.

> Arc side of cortex#858 (the umbrella issue lives in the cortex repo).

### What shipped

| Area | Change |
|---|---|
| `src/types.ts` | Optional `cortex_config` field on `ArcManifest` — inline (`capabilities`/`policy` only) **or** a `{ path }` pointer to a YAML fragment shipped in the package. |
| `src/lib/manifest.ts` | `validateCortexConfig` structural pre-filter at the manifest edge: capability/policy-only boundary (rejects smuggled `agents`/`principal`/`nats` keys), inline-vs-path mutual exclusivity, relative/no-`..` path guard. Wired into all three `readManifest` return paths (library/process/general). |
| `src/lib/cortex-config-provision.ts` | **New** dedicated module (sibling to `identity-provision.ts` / `secret-provision-install.ts`). Detects host-is-cortex (reuses the existing cortex `HostAdapter` `id` + `detect()`), resolves the stack config dir (`host.paths.root`), marshals the fragment to disk, and invokes `cortex config merge --config <dir> --fragment <file> [--stack <id>]` via a swappable spawn runner (test seam gated on `ARC_TEST_MODE`, mirroring `nats-broker.ts`). cortex resolution: `ARC_CORTEX_BIN`/`MF_CORTEX_BIN` → `cortex` on PATH. |
| `src/commands/install.ts` | Single hook at the cortex-config step ("step 6c") on **both** the standalone and library-artifact paths, **after** the post-landing transaction. Fail-closed. |
| `docs/cortex-config-composition.md` | Integration doc (matches the F-6b/F-6e sibling docs). |

### Fail-closed + rollback

A non-zero exit from `cortex config merge` fails the install. The landed state is unwound: the install transaction rolls back symlinks/hooks/extensions/launchd, and because the DB row is committed as the transaction's **last** step (BEFORE this step runs — every existing rollback path fires before the commit), the cortex-config step removes the row itself. The cortex verb is idempotent and writes a 0o600 backup, so an arc retry after fixing the cause re-runs cleanly.

### Composes with the merged F-6 slices

- **F-6c (#231)** ordered library installs + atomic rollback — `install-transaction.ts`
- **F-6b (#233)** agent identity provisioning — `identity-provision.ts`
- **F-6e (#234)** secret provisioning — `secret-provision-install.ts`

Each slice is a single, clearly-commented, **non-adjacent** hook so the lanes compose without colliding. F-6a captures the live transaction via the same `onTransaction` callback F-6c uses, runs after the identity step, and adds the DB-row removal that the post-commit position requires.

### Tests (40 new, full suite green)

- **Manifest** (`test/unit/manifest-cortex-config.test.ts`): inline accept (caps/policy/both), reject smuggled key, reject empty, reject non-array caps / non-object policy; path accept + absolute/`..`/path+inline rejection; non-object rejection; round-trip through `readManifest`.
- **Provision module** (`test/unit/cortex-config-provision.test.ts`): host detection, cortex-bin resolution, fragment marshalling (inline temp file + path resolution + traversal/missing guards), argv shape, `--stack` presence/absence, fail-closed on non-zero exit, fail-closed on missing CLI, temp-file cleanup.
- **Install integration** (`test/commands/install-cortex-config-f6a.test.ts`): invokes merge when fragment present + host cortex; skips when absent; skips when host non-cortex; fails closed + rolls back the DB row on merge failure; retry succeeds via the idempotent verb.

Gates: `bunx tsc --noEmit` clean · `bun run lint` clean · `bun test` 1205 pass / 0 fail.

Closes arc side of cortex#858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)