### PR TITLE
feat(install): cortex bot-pack drop — agent.yaml/persona.md install flow (cortex#1021 W-4)

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1042,16 +1042,25 @@ async function installPerTarget(opts: {
       };
     }
 
-    // registry hosts (cortex, claude-code) take the existing symlink path
-    const r = await createArtifactSymlinks({
-      type: opts.manifest.type,
-      manifest: opts.manifest,
-      arc: opts.arc,
-      host: targetHost,
-      installDir: opts.installPath,
-      consumerDir: opts.consumerDir,
-      quiet: opts.quiet,
-    });
+    // registry hosts (cortex, claude-code) take the existing symlink path.
+    // A THROW from the artifact drop (e.g. a bot pack refusing an unsafe
+    // fragment id) must roll back the targets already installed and surface
+    // as a normal install error, not an uncaught exception.
+    let r: Awaited<ReturnType<typeof createArtifactSymlinks>>;
+    try {
+      r = await createArtifactSymlinks({
+        type: opts.manifest.type,
+        manifest: opts.manifest,
+        arc: opts.arc,
+        host: targetHost,
+        installDir: opts.installPath,
+        consumerDir: opts.consumerDir,
+        quiet: opts.quiet,
+      });
+    } catch (err) {
+      await rollbackAll();
+      return { error: `[${targetId}] ${errorMessage(err)}` };
+    }
     if (r.filesMissingSource.length) {
       const detail = r.filesMissingSource
         .map((f) => `  - ${f.source} -> ${f.target}`)

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -494,11 +494,13 @@ export function toposortArtifacts(artifacts: ArtifactEntry[]): ArtifactEntry[] {
  * not a string, or the YAML is unreadable (cortex's own loader still
  * validates the fragment content after the drop).
  *
- * The §8.1 post-install side effects — `cortex agents reload`, then
- * `cortex creds issue <id>` for daemon brains — are the PACK's
- * `lifecycle.postinstall` scripts, which install() runs after this drop.
- * Drop → reload → creds: the ordering invariant holds without arc
- * hardcoding cortex CLI calls.
+ * Post-install side effects: arc guarantees ONLY that the artifact drop
+ * happens before `lifecycle.postinstall` scripts run, and that those
+ * scripts run in their declared order. The §8.1 sequence (drop fragment →
+ * `cortex agents reload` → `cortex creds issue <id>`) therefore holds IFF
+ * the pack ships those scripts in that order (as yarrow does) — it is a
+ * pack-authored convention arc sequences, not an arc-enforced cortex
+ * side effect. arc itself never invokes cortex CLI calls.
  */
 async function linkCortexBotPackSymlinks(opts: {
   fragmentPath: string;

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -217,7 +217,16 @@ export async function createArtifactSymlinks(opts: {
         // drop. Drop → reload → creds: the ordering invariant holds without
         // arc hardcoding cortex CLI calls.
         const cortexPaths = host.paths as CortexHostPaths;
-        const agentId = readAgentFragmentId(botPackFragment) ?? manifest.name.toLowerCase();
+        const agentId =
+          readAgentFragmentId(botPackFragment) ??
+          sanitizeAgentId(manifest.name.toLowerCase());
+        if (agentId === undefined) {
+          throw new Error(
+            `agent pack "${manifest.name}": neither the agent.yaml id nor the ` +
+              `manifest name is a safe filename stem (lowercase alphanumerics ` +
+              `plus . _ -, no path separators) — refusing to drop the fragment`,
+          );
+        }
         await linkTracked(botPackFragment, join(cortexPaths.agentsDir, `${agentId}.yaml`));
         const personaPath = join(installDir, "persona.md");
         if (existsSync(personaPath)) {
@@ -503,7 +512,7 @@ export function readAgentFragmentId(fragmentPath: string): string | undefined {
     const raw = YAML.parse(readFileSync(fragmentPath, "utf-8")) as unknown;
     if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
     const id = (raw as Record<string, unknown>).id;
-    return typeof id === "string" && id.trim().length > 0 ? id.trim() : undefined;
+    return typeof id === "string" ? sanitizeAgentId(id.trim()) : undefined;
   } catch (err) {
     // Fall back to the manifest-name stem; the fragment will still fail
     // loudly in cortex's own loader if it is genuinely malformed.
@@ -512,4 +521,20 @@ export function readAgentFragmentId(fragmentPath: string): string | undefined {
     );
     return undefined;
   }
+}
+
+/**
+ * An agent id is used as a FILENAME STEM under agents.d/ and personas/ — it
+ * must not be able to escape those directories (sage arc#238 round 1
+ * blocker: an id containing `/` or `..` would symlink outside agents.d).
+ * Accepts cortex-conventional ids only: lowercase-insensitive alphanumerics
+ * plus `.`, `_`, `-`, starting alphanumeric, and no `..` sequence anywhere.
+ * Returns `undefined` for anything else so the caller can fall back or
+ * refuse loudly.
+ */
+export function sanitizeAgentId(id: string): string | undefined {
+  if (id.length === 0 || id.length > 128) return undefined;
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(id)) return undefined;
+  if (id.includes("..")) return undefined;
+  return id;
 }

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -197,41 +197,20 @@ export async function createArtifactSymlinks(opts: {
 
     case "agent": {
       const botPackFragment = join(installDir, "agent.yaml");
+      // Bot-pack branch needs BOTH conditions: a cortex host target AND the
+      // agent.yaml shape at the pack root. On a non-cortex host the same
+      // pack falls through to the legacy .md path (cortex is today the only
+      // host with a fragment/persona contract); a cortex target WITHOUT
+      // agent.yaml is the legacy standalone-bot shape (fragment via
+      // provides.files) and is untouched.
       if (host.id === "cortex" && existsSync(botPackFragment)) {
-        // Bot pack (cortex docs/design-bot-packs.md §4 +
-        // design-arc-agent-bots.md §6.2): the pack root carries
-        // `agent.yaml` (identity fragment) and `persona.md`. They land as
-        //   agent.yaml  → {agentsDir}/<id>.yaml   (~/.config/cortex/agents.d/)
-        //   persona.md  → {personasDir}/<id>.md   (~/.config/cortex/personas/)
-        // <id> is the fragment's own `id:` field — cortex warns when the
-        // fragment filename stem disagrees with the id, so the file is named
-        // after the id, not the (display-cased) manifest name.
-        //
-        // Shape-gated on `agent.yaml` presence: pre-bot-pack agent repos
-        // (standalone bots whose fragment travels via provides.files, e.g.
-        // the sage shape) keep the legacy path below unchanged.
-        //
-        // The §8.1 post-install side effects — `cortex agents reload`, then
-        // `cortex creds issue <id>` for daemon brains — are the PACK's
-        // `lifecycle.postinstall` scripts, which install() runs after this
-        // drop. Drop → reload → creds: the ordering invariant holds without
-        // arc hardcoding cortex CLI calls.
-        const cortexPaths = host.paths as CortexHostPaths;
-        const agentId =
-          readAgentFragmentId(botPackFragment) ??
-          sanitizeAgentId(manifest.name.toLowerCase());
-        if (agentId === undefined) {
-          throw new Error(
-            `agent pack "${manifest.name}": neither the agent.yaml id nor the ` +
-              `manifest name is a safe filename stem (lowercase alphanumerics ` +
-              `plus . _ -, no path separators) — refusing to drop the fragment`,
-          );
-        }
-        await linkTracked(botPackFragment, join(cortexPaths.agentsDir, `${agentId}.yaml`));
-        const personaPath = join(installDir, "persona.md");
-        if (existsSync(personaPath)) {
-          await linkTracked(personaPath, join(cortexPaths.personasDir, `${agentId}.md`));
-        }
+        await linkCortexBotPackSymlinks({
+          fragmentPath: botPackFragment,
+          installDir,
+          manifestName: manifest.name,
+          cortexPaths: host.paths as CortexHostPaths,
+          linkTracked,
+        });
         break;
       }
 
@@ -501,21 +480,81 @@ export function toposortArtifacts(artifacts: ArtifactEntry[]): ArtifactEntry[] {
 }
 
 /**
- * Read the `id:` field from a cortex agent identity fragment (`agent.yaml`).
- * Returns `undefined` when the file is unreadable, not a YAML map, or has no
- * string `id` — the caller falls back to the lowercased manifest name. The
- * fragment is the authority on its id because cortex warns when the
- * `agents.d/` filename stem disagrees with the fragment's `id:`.
+ * Cortex bot-pack drop (cortex docs/design-bot-packs.md §4 +
+ * design-arc-agent-bots.md §6.2):
+ *
+ *   agent.yaml  → {agentsDir}/<id>.yaml   (~/.config/cortex/agents.d/)
+ *   persona.md  → {personasDir}/<id>.md   (~/.config/cortex/personas/)
+ *
+ * <id> comes from the fragment's own `id:` field (cortex warns when the
+ * filename stem disagrees with the id). A PRESENT-but-unsafe id is an
+ * install ERROR (sage arc#238 round 2) — silently renaming the file under a
+ * fallback stem would install a fragment whose id contradicts its filename
+ * authority. The manifest-name fallback applies only when the id is absent,
+ * not a string, or the YAML is unreadable (cortex's own loader still
+ * validates the fragment content after the drop).
+ *
+ * The §8.1 post-install side effects — `cortex agents reload`, then
+ * `cortex creds issue <id>` for daemon brains — are the PACK's
+ * `lifecycle.postinstall` scripts, which install() runs after this drop.
+ * Drop → reload → creds: the ordering invariant holds without arc
+ * hardcoding cortex CLI calls.
  */
-export function readAgentFragmentId(fragmentPath: string): string | undefined {
+async function linkCortexBotPackSymlinks(opts: {
+  fragmentPath: string;
+  installDir: string;
+  manifestName: string;
+  cortexPaths: CortexHostPaths;
+  linkTracked: (source: string, target: string) => Promise<void>;
+}): Promise<void> {
+  const rawId = readRawAgentFragmentId(opts.fragmentPath);
+  let agentId: string | undefined;
+  if (rawId !== undefined) {
+    agentId = sanitizeAgentId(rawId);
+    if (agentId === undefined) {
+      throw new Error(
+        `agent pack "${opts.manifestName}": agent.yaml declares an unsafe id ` +
+          `"${rawId}" — an id is a filename stem under agents.d/ (alphanumeric ` +
+          `start, [a-z0-9._-], no "..", ≤128 chars). Refusing to install.`,
+      );
+    }
+  } else {
+    agentId = sanitizeAgentId(opts.manifestName.toLowerCase());
+    if (agentId === undefined) {
+      throw new Error(
+        `agent pack "${opts.manifestName}": agent.yaml has no usable id and ` +
+          `the manifest name is not a safe filename stem — refusing to install.`,
+      );
+    }
+  }
+  await opts.linkTracked(
+    opts.fragmentPath,
+    join(opts.cortexPaths.agentsDir, `${agentId}.yaml`),
+  );
+  const personaPath = join(opts.installDir, "persona.md");
+  if (existsSync(personaPath)) {
+    await opts.linkTracked(
+      personaPath,
+      join(opts.cortexPaths.personasDir, `${agentId}.md`),
+    );
+  }
+}
+
+/**
+ * Read the RAW `id:` string from a cortex agent identity fragment. Returns
+ * `undefined` when the file is unreadable, not a YAML map, or `id` is absent
+ * or not a string — those cases fall back to the manifest name (the caller
+ * validates safety either way; cortex's loader validates the fragment after
+ * the drop). NO safety filtering here: a present-but-unsafe id must surface
+ * as an error upstream, never silently degrade to the fallback.
+ */
+function readRawAgentFragmentId(fragmentPath: string): string | undefined {
   try {
     const raw = YAML.parse(readFileSync(fragmentPath, "utf-8")) as unknown;
     if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
     const id = (raw as Record<string, unknown>).id;
-    return typeof id === "string" ? sanitizeAgentId(id.trim()) : undefined;
+    return typeof id === "string" && id.trim().length > 0 ? id.trim() : undefined;
   } catch (err) {
-    // Fall back to the manifest-name stem; the fragment will still fail
-    // loudly in cortex's own loader if it is genuinely malformed.
     console.warn(
       `arc: could not read agent fragment id from ${fragmentPath}: ${errorMessage(err)}`,
     );
@@ -527,10 +566,9 @@ export function readAgentFragmentId(fragmentPath: string): string | undefined {
  * An agent id is used as a FILENAME STEM under agents.d/ and personas/ — it
  * must not be able to escape those directories (sage arc#238 round 1
  * blocker: an id containing `/` or `..` would symlink outside agents.d).
- * Accepts cortex-conventional ids only: lowercase-insensitive alphanumerics
+ * Accepts cortex-conventional ids only: case-insensitive alphanumerics
  * plus `.`, `_`, `-`, starting alphanumeric, and no `..` sequence anywhere.
- * Returns `undefined` for anything else so the caller can fall back or
- * refuse loudly.
+ * Returns `undefined` for anything else.
  */
 export function sanitizeAgentId(id: string): string | undefined {
   if (id.length === 0 || id.length > 128) return undefined;

--- a/src/lib/artifact-installer.ts
+++ b/src/lib/artifact-installer.ts
@@ -2,10 +2,13 @@ import { join, dirname } from "path";
 import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
+import { readFileSync } from "fs";
+import YAML from "yaml";
 import type {
   ArtifactType,
   ArcManifest,
   ArcPaths,
+  CortexHostPaths,
   HostAdapter,
   LibraryArtifactEntry,
 } from "../types.js";
@@ -193,7 +196,38 @@ export async function createArtifactSymlinks(opts: {
     }
 
     case "agent": {
-      // Agents: symlink the .md file directly into agentsDir for auto-discovery.
+      const botPackFragment = join(installDir, "agent.yaml");
+      if (host.id === "cortex" && existsSync(botPackFragment)) {
+        // Bot pack (cortex docs/design-bot-packs.md §4 +
+        // design-arc-agent-bots.md §6.2): the pack root carries
+        // `agent.yaml` (identity fragment) and `persona.md`. They land as
+        //   agent.yaml  → {agentsDir}/<id>.yaml   (~/.config/cortex/agents.d/)
+        //   persona.md  → {personasDir}/<id>.md   (~/.config/cortex/personas/)
+        // <id> is the fragment's own `id:` field — cortex warns when the
+        // fragment filename stem disagrees with the id, so the file is named
+        // after the id, not the (display-cased) manifest name.
+        //
+        // Shape-gated on `agent.yaml` presence: pre-bot-pack agent repos
+        // (standalone bots whose fragment travels via provides.files, e.g.
+        // the sage shape) keep the legacy path below unchanged.
+        //
+        // The §8.1 post-install side effects — `cortex agents reload`, then
+        // `cortex creds issue <id>` for daemon brains — are the PACK's
+        // `lifecycle.postinstall` scripts, which install() runs after this
+        // drop. Drop → reload → creds: the ordering invariant holds without
+        // arc hardcoding cortex CLI calls.
+        const cortexPaths = host.paths as CortexHostPaths;
+        const agentId = readAgentFragmentId(botPackFragment) ?? manifest.name.toLowerCase();
+        await linkTracked(botPackFragment, join(cortexPaths.agentsDir, `${agentId}.yaml`));
+        const personaPath = join(installDir, "persona.md");
+        if (existsSync(personaPath)) {
+          await linkTracked(personaPath, join(cortexPaths.personasDir, `${agentId}.md`));
+        }
+        break;
+      }
+
+      // Other hosts (claude-code) and legacy agent repos: symlink the .md
+      // file directly into agentsDir for auto-discovery.
       const agentsDir = requireHostDir(host, "agent");
       const agentSourceDir = join(installDir, "agent");
       const sourceDir = existsSync(agentSourceDir) ? agentSourceDir : installDir;
@@ -455,4 +489,27 @@ export function toposortArtifacts(artifacts: ArtifactEntry[]): ArtifactEntry[] {
   }
 
   return ordered;
+}
+
+/**
+ * Read the `id:` field from a cortex agent identity fragment (`agent.yaml`).
+ * Returns `undefined` when the file is unreadable, not a YAML map, or has no
+ * string `id` — the caller falls back to the lowercased manifest name. The
+ * fragment is the authority on its id because cortex warns when the
+ * `agents.d/` filename stem disagrees with the fragment's `id:`.
+ */
+export function readAgentFragmentId(fragmentPath: string): string | undefined {
+  try {
+    const raw = YAML.parse(readFileSync(fragmentPath, "utf-8")) as unknown;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+    const id = (raw as Record<string, unknown>).id;
+    return typeof id === "string" && id.trim().length > 0 ? id.trim() : undefined;
+  } catch (err) {
+    // Fall back to the manifest-name stem; the fragment will still fail
+    // loudly in cortex's own loader if it is genuinely malformed.
+    console.warn(
+      `arc: could not read agent fragment id from ${fragmentPath}: ${errorMessage(err)}`,
+    );
+    return undefined;
+  }
 }

--- a/src/lib/hosts/cortex.ts
+++ b/src/lib/hosts/cortex.ts
@@ -26,9 +26,12 @@ import type {
  * without `cortex.yaml` yet can run `cortex init` to materialize the file.
  *
  * See cortex `docs/design-arc-agent-bots.md` §6.2 for the full design
- * rationale and the post-install side effects (`cortex agents reload`,
- * `cortex creds issue`) that land in a follow-up once arc exposes per-adapter
- * install hooks.
+ * rationale. Bot packs (an `agent.yaml` at the pack root) are dropped by
+ * `artifact-installer.ts` as `agents.d/<id>.yaml` + `personas/<id>.md`; the
+ * §8.1 post-install side effects (`cortex agents reload`, then
+ * `cortex creds issue <id>`) ride the PACK's `lifecycle.postinstall` scripts,
+ * which install() runs after the drop — arc never hardcodes cortex CLI calls
+ * (cortex#1021 W-4).
  */
 
 export interface CortexHostOptions {

--- a/test/commands/install-cortex-botpack.test.ts
+++ b/test/commands/install-cortex-botpack.test.ts
@@ -43,6 +43,14 @@ afterEach(async () => {
   await env.cleanup();
 });
 
+function commitAll(repoDir: string, message: string): void {
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", message],
+    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+  );
+}
+
 /** A yarrow-shaped bot pack: agent.yaml + persona.md + lifecycle scripts. */
 async function createBotPackRepo(opts: {
   parent: string;
@@ -98,11 +106,7 @@ lifecycle:
 `,
   );
   Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
-  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
-  Bun.spawnSync(
-    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
-    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
-  );
+  commitAll(repoDir, "init");
   return { url: repoDir, dir: repoDir };
 }
 
@@ -175,7 +179,7 @@ describe("install: cortex bot pack (agent.yaml shape)", () => {
     expect(existsSync(join(cortexRoot, "personas", "sparse.md"))).toBe(false);
   });
 
-  test("path-traversal id is rejected — falls back to the manifest name, fragment stays inside agents.d", async () => {
+  test("path-traversal id is an install ERROR — nothing lands anywhere", async () => {
     const logPath = join(env.root, "postinstall4.log");
     const repo = await createBotPackRepo({
       parent: env.root,
@@ -183,29 +187,27 @@ describe("install: cortex bot pack (agent.yaml shape)", () => {
       fragmentId: "ignored",
       logPath,
     });
-    // An id that would escape agents.d/ must never be used as a stem.
+    // A PRESENT-but-unsafe id is an install ERROR — silently renaming the
+    // fragment under a fallback stem would install an identity whose id
+    // contradicts its filename (sage round 2). Nothing may land anywhere.
     await writeFile(
       join(repo.dir, "agent.yaml"),
       `id: "../../outside/evil"\ndisplayName: "Escape"\n`,
     );
-    Bun.spawnSync(["git", "add", "."], { cwd: repo.dir, stdout: "pipe", stderr: "pipe" });
-    Bun.spawnSync(
-      ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "evil id"],
-      { cwd: repo.dir, stdout: "pipe", stderr: "pipe" },
-    );
+    commitAll(repo.dir, "evil id");
 
     const result = await install({
       arc: env.arc, host: env.host, db: env.db,
       repoUrl: repo.url, yes: true,
       hostOverrides: cortexOverrides(),
     });
-    expect(result.success).toBe(true);
-    expect(existsSync(join(cortexRoot, "agents.d", "evil.yaml"))).toBe(true);
+    expect(result.success).toBe(false);
+    expect(existsSync(join(cortexRoot, "agents.d", "evil.yaml"))).toBe(false);
     expect(existsSync(join(env.root, ".config", "outside"))).toBe(false);
     expect(existsSync(join(cortexRoot, "outside"))).toBe(false);
   });
 
-  test("malformed agent.yaml id falls back to the lowercased manifest name", async () => {
+  test("ABSENT agent.yaml id falls back to the lowercased manifest name", async () => {
     const logPath = join(env.root, "postinstall3.log");
     const repo = await createBotPackRepo({
       parent: env.root,
@@ -213,13 +215,10 @@ describe("install: cortex bot pack (agent.yaml shape)", () => {
       fragmentId: "ignored",
       logPath,
     });
-    // Overwrite with a fragment that has no usable id.
+    // Overwrite with a fragment that has no usable id (ABSENT id — the only
+    // case where the manifest-name fallback applies).
     await writeFile(join(repo.dir, "agent.yaml"), `displayName: "No Id Here"\n`);
-    Bun.spawnSync(["git", "add", "."], { cwd: repo.dir, stdout: "pipe", stderr: "pipe" });
-    Bun.spawnSync(
-      ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "no id"],
-      { cwd: repo.dir, stdout: "pipe", stderr: "pipe" },
-    );
+    commitAll(repo.dir, "no id");
 
     const result = await install({
       arc: env.arc, host: env.host, db: env.db,

--- a/test/commands/install-cortex-botpack.test.ts
+++ b/test/commands/install-cortex-botpack.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Cortex bot-pack install (cortex#1021 W-4; design-bot-packs.md §4 +
+ * design-arc-agent-bots.md §6.2/§8.1).
+ *
+ * A `type: agent, targets: [cortex]` pack whose root carries `agent.yaml` +
+ * `persona.md` (the yarrow shape) must land:
+ *
+ *   agent.yaml → {configRoot}/agents.d/<id>.yaml   (id from the fragment)
+ *   persona.md → {configRoot}/personas/<id>.md
+ *
+ * and run the pack's `lifecycle.postinstall` scripts AFTER the drop (the
+ * §8.1 ordering: drop fragment → signal reload → issue creds — the scripts
+ * stand in for `cortex agents reload` / `cortex creds issue` here).
+ *
+ * The legacy standalone-bot shape (no agent.yaml; fragment via
+ * provides.files) is covered by install-multitarget-i140.test.ts and must
+ * stay on the old path — pinned below.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, lstatSync } from "fs";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { join } from "path";
+import {
+  createTestEnv,
+  type TestEnv,
+} from "../helpers/test-env.js";
+import { install } from "../../src/commands/install.js";
+import { getSkill } from "../../src/lib/db.js";
+
+let env: TestEnv;
+let cortexRoot: string;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+  cortexRoot = join(env.root, ".config", "cortex");
+  await mkdir(join(cortexRoot, "agents.d"), { recursive: true });
+  await mkdir(join(cortexRoot, "personas"), { recursive: true });
+  await writeFile(join(cortexRoot, "cortex.yaml"), "# fake cortex.yaml\n");
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+/** A yarrow-shaped bot pack: agent.yaml + persona.md + lifecycle scripts. */
+async function createBotPackRepo(opts: {
+  parent: string;
+  name: string;
+  fragmentId: string;
+  logPath: string;
+  omitPersona?: boolean;
+}): Promise<{ url: string; dir: string }> {
+  const repoDir = join(opts.parent, `mock-${opts.name}`);
+  await mkdir(join(repoDir, "scripts"), { recursive: true });
+  await mkdir(join(repoDir, "brain"), { recursive: true });
+  await writeFile(
+    join(repoDir, "agent.yaml"),
+    `id: ${opts.fragmentId}
+displayName: "${opts.name} — Composer"
+persona: "../personas/${opts.fragmentId}.md"
+trust: []
+presence: {}
+runtime:
+  mode: in-process
+  capabilities:
+    - soc.compose.flow
+  brain:
+    kind: exec
+    run: "bun {pack}/brain/main.ts"
+    lifecycle: daemon
+`,
+  );
+  if (opts.omitPersona !== true) {
+    await writeFile(join(repoDir, "persona.md"), `# ${opts.name} persona\n`);
+  }
+  await writeFile(join(repoDir, "brain", "main.ts"), `process.exit(0);\n`);
+  await writeFile(
+    join(repoDir, "scripts", "signal-cortex-reload.sh"),
+    `#!/bin/bash\necho "reload" >> "${opts.logPath}"\n`,
+  );
+  await writeFile(
+    join(repoDir, "scripts", "issue-nats-creds.sh"),
+    `#!/bin/bash\necho "creds" >> "${opts.logPath}"\n`,
+  );
+  await writeFile(
+    join(repoDir, "arc-manifest.yaml"),
+    `name: ${opts.name}
+version: 0.1.0
+type: agent
+tier: custom
+description: bot pack fixture
+targets: [cortex]
+lifecycle:
+  postinstall:
+    - scripts/signal-cortex-reload.sh
+    - scripts/issue-nats-creds.sh
+`,
+  );
+  Bun.spawnSync(["git", "init"], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir, stdout: "pipe", stderr: "pipe" });
+  Bun.spawnSync(
+    ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
+    { cwd: repoDir, stdout: "pipe", stderr: "pipe" },
+  );
+  return { url: repoDir, dir: repoDir };
+}
+
+function cortexOverrides(): { cortex: { configRoot: string; credsRoot: string } } {
+  return {
+    cortex: {
+      configRoot: cortexRoot,
+      credsRoot: join(env.root, ".config", "nats", "creds"),
+    },
+  };
+}
+
+describe("install: cortex bot pack (agent.yaml shape)", () => {
+  test("fragment + persona land under the fragment's id; postinstall runs after the drop", async () => {
+    const logPath = join(env.root, "postinstall.log");
+    const repo = await createBotPackRepo({
+      parent: env.root,
+      name: "Yarrow",
+      fragmentId: "yarrow",
+      logPath,
+    });
+
+    const result = await install({
+      arc: env.arc,
+      host: env.host,
+      db: env.db,
+      repoUrl: repo.url,
+      yes: true,
+      hostOverrides: cortexOverrides(),
+    });
+    expect(result.success).toBe(true);
+
+    // Fragment named after the fragment's id (NOT the display-cased manifest
+    // name) in agents.d/, as a symlink into the install dir.
+    const fragmentLink = join(cortexRoot, "agents.d", "yarrow.yaml");
+    expect(existsSync(fragmentLink)).toBe(true);
+    expect(lstatSync(fragmentLink).isSymbolicLink()).toBe(true);
+    expect(await readFile(fragmentLink, "utf-8")).toContain("id: yarrow");
+
+    // Persona beside it, so the fragment's relative `../personas/yarrow.md`
+    // resolves from agents.d/.
+    const personaLink = join(cortexRoot, "personas", "yarrow.md");
+    expect(existsSync(personaLink)).toBe(true);
+    expect(await readFile(personaLink, "utf-8")).toContain("persona");
+
+    // §8.1 ordering — both postinstall scripts ran, reload before creds.
+    expect(await readFile(logPath, "utf-8")).toBe("reload\ncreds\n");
+
+    // One DB row under the manifest name.
+    expect(getSkill(env.db, "Yarrow")).toBeTruthy();
+  });
+
+  test("persona.md is optional — fragment alone installs", async () => {
+    const logPath = join(env.root, "postinstall2.log");
+    const repo = await createBotPackRepo({
+      parent: env.root,
+      name: "Sparse",
+      fragmentId: "sparse",
+      logPath,
+      omitPersona: true,
+    });
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+      hostOverrides: cortexOverrides(),
+    });
+    expect(result.success).toBe(true);
+    expect(existsSync(join(cortexRoot, "agents.d", "sparse.yaml"))).toBe(true);
+    expect(existsSync(join(cortexRoot, "personas", "sparse.md"))).toBe(false);
+  });
+
+  test("malformed agent.yaml id falls back to the lowercased manifest name", async () => {
+    const logPath = join(env.root, "postinstall3.log");
+    const repo = await createBotPackRepo({
+      parent: env.root,
+      name: "Fallback",
+      fragmentId: "ignored",
+      logPath,
+    });
+    // Overwrite with a fragment that has no usable id.
+    await writeFile(join(repo.dir, "agent.yaml"), `displayName: "No Id Here"\n`);
+    Bun.spawnSync(["git", "add", "."], { cwd: repo.dir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "no id"],
+      { cwd: repo.dir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+      hostOverrides: cortexOverrides(),
+    });
+    expect(result.success).toBe(true);
+    expect(existsSync(join(cortexRoot, "agents.d", "fallback.yaml"))).toBe(true);
+  });
+});

--- a/test/commands/install-cortex-botpack.test.ts
+++ b/test/commands/install-cortex-botpack.test.ts
@@ -175,6 +175,36 @@ describe("install: cortex bot pack (agent.yaml shape)", () => {
     expect(existsSync(join(cortexRoot, "personas", "sparse.md"))).toBe(false);
   });
 
+  test("path-traversal id is rejected — falls back to the manifest name, fragment stays inside agents.d", async () => {
+    const logPath = join(env.root, "postinstall4.log");
+    const repo = await createBotPackRepo({
+      parent: env.root,
+      name: "Evil",
+      fragmentId: "ignored",
+      logPath,
+    });
+    // An id that would escape agents.d/ must never be used as a stem.
+    await writeFile(
+      join(repo.dir, "agent.yaml"),
+      `id: "../../outside/evil"\ndisplayName: "Escape"\n`,
+    );
+    Bun.spawnSync(["git", "add", "."], { cwd: repo.dir, stdout: "pipe", stderr: "pipe" });
+    Bun.spawnSync(
+      ["git", "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "evil id"],
+      { cwd: repo.dir, stdout: "pipe", stderr: "pipe" },
+    );
+
+    const result = await install({
+      arc: env.arc, host: env.host, db: env.db,
+      repoUrl: repo.url, yes: true,
+      hostOverrides: cortexOverrides(),
+    });
+    expect(result.success).toBe(true);
+    expect(existsSync(join(cortexRoot, "agents.d", "evil.yaml"))).toBe(true);
+    expect(existsSync(join(env.root, ".config", "outside"))).toBe(false);
+    expect(existsSync(join(cortexRoot, "outside"))).toBe(false);
+  });
+
   test("malformed agent.yaml id falls back to the lowercased manifest name", async () => {
     const logPath = join(env.root, "postinstall3.log");
     const repo = await createBotPackRepo({


### PR DESCRIPTION
## What

W-4 of cortex `docs/plan-bot-packs-completion.md` (tracking cortex#1021; design: cortex `docs/design-bot-packs.md` §4, `docs/design-arc-agent-bots.md` §6.2/§8.1).

A `type: agent` pack installed on a **cortex target** whose root carries `agent.yaml` (the **bot-pack shape** — yarrow is the first) now installs as:

| Pack file | Lands at |
|---|---|
| `agent.yaml` | `{configRoot}/agents.d/<id>.yaml` — `<id>` from the fragment's own `id:`, validated as a safe filename stem; a present-but-unsafe id is an install ERROR (with rollback); absent id falls back to the sanitized manifest name |
| `persona.md` | `{configRoot}/personas/<id>.md` (optional) |

**Branch condition is cortex-host AND agent.yaml shape.** Legacy standalone-bot repos (fragment via `provides.files`, sage shape) keep the existing path — pinned by the untouched `install-multitarget-i140` tests. Non-cortex hosts keep the legacy `.md` agent drop.

**Post-install side effects without hardcoding cortex:** the §8.1 ordering (drop fragment → `cortex agents reload` → `cortex creds issue <id>`) rides the pack's `lifecycle.postinstall` scripts, which `install()` already runs after the artifact drop. Test pins reload-before-creds ordering.

**Hardening that fell out of review:** `installPerTarget` now catches a throw from the per-target artifact drop, rolls back already-installed targets, and surfaces a normal install error (previously an uncaught escape with no rollback).

## Tests
`test/commands/install-cortex-botpack.test.ts`: fragment+persona under the fragment id; lifecycle ordering; persona-optional; absent-id fallback; path-traversal id → install error, nothing lands. Full suite: 1212 tests green (one env-contention flake, 6/6 in isolation).

## Follow-up
`arc install yarrow` e2e against the real pack (github.com/the-metafactory/yarrow) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)